### PR TITLE
item 2: examples and sector policy templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,11 @@ venv/
 
 # CTRLRun local state (SPEC-v0.1 §5, §6)
 .ctrlrun/
-ctrlrun.yaml
+# Anchored: this ignores the operator's own policy at the repo root, which `ctrlrun init`
+# writes. Unanchored it matched every `ctrlrun.yaml` at any depth, which silently kept the
+# examples' policy files out of a commit — they worked locally and were missing from every
+# clone. `test_T31_every_file_an_example_needs_is_tracked_by_git` is the guard.
+/ctrlrun.yaml
 
 # OS
 .DS_Store

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,12 @@ include VISION.md
 recursive-include docs *.md
 recursive-include tests *.py
 
+# `examples/` travels because T31 runs every script and loads every sector template out of
+# the source tree (SPEC-v0.2 §1.1). Without these the sdist would ship a test suite that
+# fails on a fresh checkout, which is the failure `prune internal` exists to avoid.
+recursive-include examples *.py
+recursive-include examples *.yaml
+
 # Local-only: working notes, and anything an operator's run left behind. Nothing here is
 # picked up by default — these are belt and braces, so a stray file cannot ride along.
 prune internal

--- a/examples/agent-race/ctrlrun.yaml
+++ b/examples/agent-race/ctrlrun.yaml
@@ -1,0 +1,11 @@
+# The policy this example runs under. Unknown actions are denied; there is no default-allow.
+schema: ctrlrun.policy/v1
+
+actions:
+  # Both agents are inside policy here. Policy is not what stops the second one — the
+  # effect key is. Amounts are integer minor units (cents), with both ends bound.
+  stripe.refund:
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }      # €0.00 to €500.00
+        decision: allow
+      - decision: deny

--- a/examples/agent-race/main.py
+++ b/examples/agent-race/main.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Two agents, one effect: the second one loses, and loses before the remote is touched.
+
+Both agents are doing the right thing. They resolve the same effect key, `refund:txn_123`,
+because it is the same real-world effect — and a reservation is the right to execute it
+once. Agent B arrives while A holds the key and is refused with `DuplicateEffect`.
+
+The race is made deterministic rather than raced for: agent B runs from inside A's remote
+call, which is exactly the window that matters and needs no sleeping to hit. Across
+processes the guarantee is the same one, enforced by `BEGIN IMMEDIATE` and a unique
+constraint on the effect key rather than by a lock in this interpreter.
+
+    python examples/agent-race/main.py
+
+No network, and a state directory of its own under `.ctrlrun/examples/`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ctrlrun import (
+    Control,
+    DuplicateEffect,
+    Policy,
+    SQLiteStateStore,
+    context,
+    protect,
+)
+
+HERE = Path(__file__).resolve().parent
+BLOCKED = "   ✗ BLOCKED — "
+AMOUNT = 50000  # €500.00, in integer minor units
+KEY = "refund:txn_123"
+
+
+class FakeStripe:
+    """A remote that lets a second agent arrive mid-call, which is what makes this a race."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.on_call: dict[str, Callable[[], None]] = {}
+
+    def refund(self, payment_id: str, amount: int) -> dict[str, Any]:
+        self.calls.append(payment_id)
+        arriving = self.on_call.pop(payment_id, None)
+        if arriving is not None:
+            arriving()
+        return {"id": f"re_{payment_id}", "amount": amount, "status": "succeeded"}
+
+
+def state_dir(root: Path) -> Path:
+    """A store of this example's own, emptied so the example repeats.
+
+    An example that reserved effect keys in a live store would block real work. Only the
+    files this script writes are removed, and only by name: never a directory.
+    """
+    evidence = root / ".ctrlrun" / "examples" / HERE.name
+    evidence.mkdir(parents=True, exist_ok=True)
+    for name in ("state.db", "state.db-wal", "state.db-shm", "receipts.jsonl", "events.jsonl"):
+        (evidence / name).unlink(missing_ok=True)
+    return evidence
+
+
+def main(root: Path) -> None:
+    store = SQLiteStateStore(state_dir(root) / "state.db")
+    remote = FakeStripe()
+    control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+    @protect("stripe.refund", effect="refund:{payment_id}", control=control)
+    def refund(payment_id: str, amount: int) -> dict[str, Any]:
+        return remote.refund(payment_id, amount)
+
+    refused: list[DuplicateEffect] = []
+
+    def agent_b() -> None:
+        with context(agent="refund-agent-b"):
+            try:
+                refund(payment_id="txn_123", amount=AMOUNT)
+            except DuplicateEffect as blocked:
+                refused.append(blocked)
+
+    print("Concurrent agents, same effect")
+    try:
+        remote.on_call["txn_123"] = agent_b
+        with context(agent="refund-agent-a"):
+            refund(payment_id="txn_123", amount=AMOUNT)
+
+        if not refused:
+            raise SystemExit("agent B was permitted; this example proved nothing")
+
+        print(f"   Agent A  reserve {KEY}  →  ACQUIRED  →  executes")
+        print(f"   Agent B  reserve {KEY}  →")
+        print(f"{BLOCKED}already reserved ({refused[0].state})")
+        print(f"   remote refund calls: {remote.calls.count('txn_123')}")
+        print("   one effect key, one execution — whichever agent asked first")
+    finally:
+        store.close()
+
+
+if __name__ == "__main__":
+    main(Path.cwd())

--- a/examples/approval-mutation/ctrlrun.yaml
+++ b/examples/approval-mutation/ctrlrun.yaml
@@ -1,0 +1,13 @@
+# The policy this example runs under. Unknown actions are denied; there is no default-allow.
+schema: ctrlrun.policy/v1
+
+actions:
+  # Amounts are integer minor units (cents). First matching rule wins, so the autonomous
+  # band has to come first, and both ends of every band are bound.
+  stripe.refund:
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }      # €0.00 to €500.00 — autonomous
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 1000000 }    # €0.00 to €10,000.00 — a human
+        decision: approve
+      - decision: deny

--- a/examples/approval-mutation/main.py
+++ b/examples/approval-mutation/main.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""An approval authorizes one exact action, not a category of action.
+
+A human sees "refund €2,000 on txn_2" and says yes. The agent then executes €5,000 with
+that same approval — the sort of thing a prompt injection asks for, and the sort of thing a
+loop does by accident after re-planning. The approval is bound to the action's hash, which
+covers the principal, the arguments, the resource and the environment, so the mutated call
+matches nothing and is refused before the remote is touched.
+
+    python examples/approval-mutation/main.py
+
+No network, and a state directory of its own under `.ctrlrun/examples/`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ctrlrun import (
+    ApprovalMismatch,
+    ApprovalRequired,
+    Control,
+    Policy,
+    SQLiteStateStore,
+    context,
+    protect,
+    with_approval,
+)
+
+HERE = Path(__file__).resolve().parent
+BLOCKED = "   ✗ BLOCKED — "
+PROPOSED = 200000  # €2,000.00 — what the human approves
+MUTATED = 500000  # €5,000.00 — what the agent tries to run instead
+
+
+class FakeStripe:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def refund(self, payment_id: str, amount: int) -> dict[str, Any]:
+        self.calls.append(payment_id)
+        return {"id": f"re_{payment_id}", "amount": amount, "status": "succeeded"}
+
+
+def state_dir(root: Path) -> Path:
+    """A store of this example's own, emptied so the example repeats.
+
+    An example that reserved effect keys in a live store would block real work. Only the
+    files this script writes are removed, and only by name: never a directory.
+    """
+    evidence = root / ".ctrlrun" / "examples" / HERE.name
+    evidence.mkdir(parents=True, exist_ok=True)
+    for name in ("state.db", "state.db-wal", "state.db-shm", "receipts.jsonl", "events.jsonl"):
+        (evidence / name).unlink(missing_ok=True)
+    return evidence
+
+
+def main(root: Path) -> None:
+    store = SQLiteStateStore(state_dir(root) / "state.db")
+    remote = FakeStripe()
+    control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+    @protect("stripe.refund", effect="refund:{payment_id}", control=control)
+    def refund(payment_id: str, amount: int) -> dict[str, Any]:
+        return remote.refund(payment_id, amount)
+
+    print("Approval mutation")
+    try:
+        with context(agent="refund-agent"):
+            # A refund this size needs a human, so the first call raises rather than running.
+            try:
+                refund(payment_id="txn_2", amount=PROPOSED)
+                raise SystemExit("the refund ran without a human; this example proved nothing")
+            except ApprovalRequired as pending:
+                request_id = pending.request_id
+
+            # What `ctrlrun approve <request_id>` does, in process.
+            store.grant_approval(request_id, "human:ops")
+            print(f"   agent proposes refund €2,000.00  →  human approves {request_id}")
+            print("   agent executes refund €5,000.00  →")
+
+            try:
+                with with_approval(request_id):
+                    refund(payment_id="txn_2", amount=MUTATED)
+            except ApprovalMismatch as blocked:
+                print(f"{BLOCKED}approved action ≠ requested action ({blocked.reason})")
+            else:
+                raise SystemExit("the mutation was permitted; this example proved nothing")
+
+        print(f"   remote refund calls: {len(remote.calls)}")
+        print("   the approval is still granted for the action the human actually saw")
+    finally:
+        store.close()
+
+
+if __name__ == "__main__":
+    main(Path.cwd())

--- a/examples/approval-replay/ctrlrun.yaml
+++ b/examples/approval-replay/ctrlrun.yaml
@@ -1,0 +1,13 @@
+# The policy this example runs under. Unknown actions are denied; there is no default-allow.
+schema: ctrlrun.policy/v1
+
+actions:
+  # Amounts are integer minor units (cents). This example's refund lands in the band that
+  # needs a human, which is what gives it an approval to replay.
+  stripe.refund:
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }      # €0.00 to €500.00 — autonomous
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 1000000 }    # €0.00 to €10,000.00 — a human
+        decision: approve
+      - decision: deny

--- a/examples/approval-replay/main.py
+++ b/examples/approval-replay/main.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""An approval is worth exactly one execution.
+
+The human's yes is spent the moment it authorizes a run. An agent that keeps the request id
+around — in a scratchpad, in a retry loop, in a replayed transcript — and presents it again
+is presenting something that no longer exists. The record says `consumed`, and consumption
+happens in the same store transaction as the reservation, so two processes racing on one
+approval cannot both win it.
+
+    python examples/approval-replay/main.py
+
+No network, and a state directory of its own under `.ctrlrun/examples/`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ctrlrun import (
+    ApprovalMismatch,
+    ApprovalRequired,
+    Control,
+    Policy,
+    SQLiteStateStore,
+    context,
+    protect,
+    with_approval,
+)
+
+HERE = Path(__file__).resolve().parent
+BLOCKED = "   ✗ BLOCKED — "
+AMOUNT = 200000  # €2,000.00, in integer minor units — needs a human
+
+
+class FakeStripe:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def refund(self, payment_id: str, amount: int) -> dict[str, Any]:
+        self.calls.append(payment_id)
+        return {"id": f"re_{payment_id}", "amount": amount, "status": "succeeded"}
+
+
+def state_dir(root: Path) -> Path:
+    """A store of this example's own, emptied so the example repeats.
+
+    An example that reserved effect keys in a live store would block real work. Only the
+    files this script writes are removed, and only by name: never a directory.
+    """
+    evidence = root / ".ctrlrun" / "examples" / HERE.name
+    evidence.mkdir(parents=True, exist_ok=True)
+    for name in ("state.db", "state.db-wal", "state.db-shm", "receipts.jsonl", "events.jsonl"):
+        (evidence / name).unlink(missing_ok=True)
+    return evidence
+
+
+def main(root: Path) -> None:
+    store = SQLiteStateStore(state_dir(root) / "state.db")
+    remote = FakeStripe()
+    control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+    @protect("stripe.refund", effect="refund:{payment_id}", control=control)
+    def refund(payment_id: str, amount: int) -> dict[str, Any]:
+        return remote.refund(payment_id, amount)
+
+    print("Approval replay")
+    try:
+        with context(agent="refund-agent"):
+            try:
+                refund(payment_id="txn_4", amount=AMOUNT)
+                raise SystemExit("the refund ran without a human; this example proved nothing")
+            except ApprovalRequired as pending:
+                request_id = pending.request_id
+
+            # What `ctrlrun approve <request_id>` does, in process.
+            store.grant_approval(request_id, "human:ops")
+            with with_approval(request_id):
+                refund(payment_id="txn_4", amount=AMOUNT)
+
+            used = f"approval {request_id} used once"
+            print(f"   {used}  →  consumed")
+            print(f"   {'same approval presented again':<{len(used)}}  →")
+
+            try:
+                with with_approval(request_id):
+                    refund(payment_id="txn_4", amount=AMOUNT)
+            except ApprovalMismatch as blocked:
+                print(f"{BLOCKED}single-use approval already {blocked.reason}")
+            else:
+                raise SystemExit("the replay was permitted; this example proved nothing")
+
+        print(f"   remote refund calls: {remote.calls.count('txn_4')}")
+        print("   the approval is checked before the effect key, so this is why it was refused")
+    finally:
+        store.close()
+
+
+if __name__ == "__main__":
+    main(Path.cwd())

--- a/examples/double-refund/ctrlrun.yaml
+++ b/examples/double-refund/ctrlrun.yaml
@@ -1,0 +1,11 @@
+# The policy this example runs under. Unknown actions are denied; there is no default-allow.
+schema: ctrlrun.policy/v1
+
+actions:
+  # Amounts are integer minor units (cents). Both ends are bound: `amount_lte` on its own
+  # lets a negative amount through, and a refund of a negative amount is a charge.
+  stripe.refund:
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }      # €0.00 to €500.00
+        decision: allow
+      - decision: deny

--- a/examples/double-refund/main.py
+++ b/examples/double-refund/main.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""A lost response is not a failure, and a blind retry is a second refund.
+
+The remote commits the refund and *then* the reply goes missing. That order is the whole
+point: a remote that fails before doing anything is easy, and an executor can say so by
+raising `NotExecuted`. This one is the dangerous kind, so CTRLRun records the outcome as
+AMBIGUOUS rather than failed and refuses the retry. Nothing in this process knows whether
+the money moved, and the one thing worse than not knowing is guessing.
+
+    python examples/double-refund/main.py
+
+No network, and a state directory of its own under `.ctrlrun/examples/`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ctrlrun import (
+    AmbiguousEffect,
+    Control,
+    Policy,
+    SQLiteStateStore,
+    context,
+    protect,
+)
+
+HERE = Path(__file__).resolve().parent
+BLOCKED = "   ✗ BLOCKED — "
+AMOUNT = 50000  # €500.00, in integer minor units (SPEC-v0.1 §2.3)
+
+
+class FakeStripe:
+    """Commits first, then loses the reply."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def refund(self, payment_id: str, amount: int) -> dict[str, Any]:
+        self.calls.append(payment_id)  # the money has moved by the time anything else runs
+        raise TimeoutError("no response from api.stripe.com after 30s")
+
+
+def state_dir(root: Path) -> Path:
+    """A store of this example's own, emptied so the example repeats.
+
+    An example that reserved effect keys in a live store would block real work. Only the
+    files this script writes are removed, and only by name: never a directory.
+    """
+    evidence = root / ".ctrlrun" / "examples" / HERE.name
+    evidence.mkdir(parents=True, exist_ok=True)
+    for name in ("state.db", "state.db-wal", "state.db-shm", "receipts.jsonl", "events.jsonl"):
+        (evidence / name).unlink(missing_ok=True)
+    return evidence
+
+
+def main(root: Path) -> None:
+    store = SQLiteStateStore(state_dir(root) / "state.db")
+    remote = FakeStripe()
+    control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+    @protect("stripe.refund", effect="refund:{payment_id}", control=control)
+    def refund(payment_id: str, amount: int) -> dict[str, Any]:
+        return remote.refund(payment_id, amount)
+
+    print("Duplicate effect after a lost response")
+    print("   refund €500.00  →  remote commits  →  response lost  →  effect: AMBIGUOUS")
+    try:
+        with context(agent="refund-agent"):
+            try:
+                refund(payment_id="txn_1", amount=AMOUNT)
+            except TimeoutError as lost:
+                print(f"   the executor saw:    {lost}")
+
+            print("   agent retries the same refund")
+            try:
+                refund(payment_id="txn_1", amount=AMOUNT)
+            except AmbiguousEffect:
+                print(f"{BLOCKED}effect may already have committed; blind retry refused")
+            else:
+                raise SystemExit("the retry was permitted; this example proved nothing")
+
+        for record in store.list_effects():
+            print(f"   effect record:       {record.effect_key}  {record.state}")
+        print(f"   remote refund calls: {remote.calls.count('txn_1')}")
+        print("   only a human moves it on:  ctrlrun resolve refund:txn_1 --committed|--failed")
+    finally:
+        store.close()
+
+
+if __name__ == "__main__":
+    main(Path.cwd())

--- a/examples/policies/devops.yaml
+++ b/examples/policies/devops.yaml
@@ -1,0 +1,42 @@
+# Starting point on the v0.1 kernel. Adapt before use.
+#
+# Unknown actions are denied. There is no default-allow: this file is the list of what an
+# agent may do, and anything not written here is refused.
+schema: ctrlrun.policy/v1
+
+actions:
+  # Reads and diagnostics: autonomous. Declare no effect key on these in code.
+  k8s.get_pod_logs:
+    decision: allow
+  k8s.describe_deployment:
+    decision: allow
+  metrics.query:
+    decision: allow
+
+  # Scaling is reversible, but only inside a band somebody chose on purpose. Both ends are
+  # bound: `replicas_lte` alone would let a scale-to-zero through as "small".
+  k8s.scale_deployment:
+    rules:
+      - when: { replicas_gte: 1, replicas_lte: 10 }
+        decision: allow
+      - when: { replicas_gte: 1, replicas_lte: 100 }
+        decision: approve
+      - decision: deny
+
+  # Restarts drop in-flight requests. Cheap to undo, not free.
+  k8s.restart_deployment:
+    decision: approve
+
+  # Infrastructure that outlives the agent: a human every time.
+  terraform.apply:
+    decision: approve
+  secrets.rotate:
+    decision: approve
+
+  # Never autonomous, and never with a human either — these belong outside the agent.
+  k8s.delete_namespace:
+    decision: deny
+  terraform.destroy:
+    decision: deny
+  iam.grant_admin:
+    decision: deny

--- a/examples/policies/e-commerce.yaml
+++ b/examples/policies/e-commerce.yaml
@@ -1,0 +1,49 @@
+# Starting point on the v0.1 kernel. Adapt before use.
+#
+# Unknown actions are denied. There is no default-allow: this file is the list of what an
+# agent may do, and anything not written here is refused.
+#
+# Money is in integer minor units (cents); quantities are whole units.
+schema: ctrlrun.policy/v1
+
+actions:
+  # Reads: autonomous.
+  catalog.read:
+    decision: allow
+  order.read:
+    decision: allow
+
+  # Cancelling an unshipped order is the routine support action. Bound by order value, so
+  # a wholesale order does not go the same way as a $30 one.
+  order.cancel:
+    rules:
+      - when: { total_gte: 0, total_lte: 20000 }          # $0 to $200
+        decision: allow
+      - decision: approve
+
+  # Refunds move money out.
+  order.refund:
+    rules:
+      - when: { amount_gte: 0, amount_lte: 10000 }        # $0 to $100
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 200000 }       # $0 to $2,000
+        decision: approve
+      - decision: deny
+
+  # Stock corrections are how an oversell happens twice.
+  inventory.adjust:
+    rules:
+      - when: { quantity_gte: -50, quantity_lte: 50 }
+        decision: allow
+      - decision: approve
+
+  # A wrong price is public, immediate, and honoured by somebody.
+  price.update:
+    decision: approve
+
+  shipment.create:
+    decision: allow
+
+  # Nothing an agent needs.
+  customer.delete:
+    decision: deny

--- a/examples/policies/government.yaml
+++ b/examples/policies/government.yaml
@@ -1,0 +1,43 @@
+# Starting point on the v0.1 kernel. Adapt before use.
+#
+# Unknown actions are denied. There is no default-allow: this file is the list of what an
+# agent may do, and anything not written here is refused.
+#
+# Amounts are integer minor units (cents). Nothing here is a statement about what your
+# statutory framework permits an automated system to decide; that question comes first, and
+# a template cannot answer it.
+schema: ctrlrun.policy/v1
+
+actions:
+  # Reads and status: autonomous.
+  case.read:
+    decision: allow
+  case.check_status:
+    decision: allow
+  eligibility.precheck:
+    decision: allow
+
+  # Paying a benefit. Small, routine, in-band payments are the volume.
+  benefit.approve_payment:
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }        # $0 to $500
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 500000 }       # $0 to $5,000
+        decision: approve
+      - decision: deny
+
+  # An adverse decision has to be explainable by the person who made it.
+  benefit.terminate:
+    decision: approve
+  benefit.reduce:
+    decision: approve
+
+  # Correspondence goes out under a seal.
+  notice.send:
+    decision: approve
+  record.amend:
+    decision: approve
+
+  # The record is the citizen's evidence as much as the agency's.
+  record.delete:
+    decision: deny

--- a/examples/policies/healthcare.yaml
+++ b/examples/policies/healthcare.yaml
@@ -1,0 +1,38 @@
+# Starting point on the v0.1 kernel. Adapt before use.
+#
+# Unknown actions are denied. There is no default-allow: this file is the list of what an
+# agent may do, and anything not written here is refused.
+#
+# Nothing in this file is a legal or regulatory judgement. It is a starting shape for the
+# actions an agent may take; which of them your setting permits at all is a question for
+# your clinical and legal owners, not for a template.
+schema: ctrlrun.policy/v1
+
+actions:
+  # Scheduling and logistics: autonomous.
+  appointment.read:
+    decision: allow
+  appointment.reschedule:
+    decision: allow
+  eligibility.check:
+    decision: allow
+
+  # Moving patient records outside the system is the action that cannot be taken back.
+  patient.export_record:
+    decision: approve
+  message.send_to_patient:
+    decision: approve
+
+  # Ordering is a clinical act. A human signs for it, whatever the agent suggested.
+  lab.order:
+    decision: approve
+  referral.create:
+    decision: approve
+
+  # Prescribing, dose changes and record destruction are not agent actions at any size.
+  prescription.issue:
+    decision: deny
+  prescription.change_dose:
+    decision: deny
+  patient.delete_record:
+    decision: deny

--- a/examples/policies/hr.yaml
+++ b/examples/policies/hr.yaml
@@ -1,0 +1,42 @@
+# Starting point on the v0.1 kernel. Adapt before use.
+#
+# Unknown actions are denied. There is no default-allow: this file is the list of what an
+# agent may do, and anything not written here is refused.
+#
+# Amounts are integer minor units (cents). Employment decisions carry obligations that
+# vary by jurisdiction; which of these an agent may take at all is not a template's call.
+schema: ctrlrun.policy/v1
+
+actions:
+  # Directory and self-service: autonomous.
+  directory.read:
+    decision: allow
+  pto.read_balance:
+    decision: allow
+  handbook.search:
+    decision: allow
+
+  # Approving leave inside an existing balance is the routine action.
+  pto.approve:
+    rules:
+      - when: { days_gte: 1, days_lte: 5 }
+        decision: allow
+      - decision: approve
+
+  # Pay changes compound every period and are awkward to unwind.
+  compensation.adjust:
+    rules:
+      - when: { delta_gte: 0, delta_lte: 100000 }         # up to $1,000, upward only
+        decision: approve
+      - decision: deny
+
+  payroll.run:
+    decision: approve
+  offer.send:
+    decision: approve
+
+  # Ending someone's employment, and erasing the file that would justify it.
+  employee.terminate:
+    decision: deny
+  employee.delete_record:
+    decision: deny

--- a/examples/policies/insurance.yaml
+++ b/examples/policies/insurance.yaml
@@ -1,0 +1,42 @@
+# Starting point on the v0.1 kernel. Adapt before use.
+#
+# Unknown actions are denied. There is no default-allow: this file is the list of what an
+# agent may do, and anything not written here is refused.
+#
+# Amounts are integer minor units (cents).
+schema: ctrlrun.policy/v1
+
+actions:
+  # Reads: autonomous.
+  policy.read:
+    decision: allow
+  claim.read:
+    decision: allow
+  claim.request_documents:
+    decision: allow
+
+  # Paying a claim is the consequential action here, and small ones are the volume.
+  claim.approve_payout:
+    rules:
+      - when: { amount_gte: 0, amount_lte: 100000 }       # $0 to $1,000
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 2500000 }      # $0 to $25,000
+        decision: approve
+      - decision: deny
+
+  # A denial is a decision a person has to be able to stand behind and explain.
+  claim.deny:
+    decision: approve
+
+  # Ending or repricing cover changes what someone is protected against.
+  policy.cancel:
+    decision: approve
+  premium.adjust:
+    rules:
+      - when: { delta_gte: -5000, delta_lte: 5000 }       # within $50 either way
+        decision: allow
+      - decision: approve
+
+  # The record is the evidence. An agent does not remove it.
+  policyholder.delete:
+    decision: deny

--- a/examples/policies/legal.yaml
+++ b/examples/policies/legal.yaml
@@ -1,0 +1,40 @@
+# Starting point on the v0.1 kernel. Adapt before use.
+#
+# Unknown actions are denied. There is no default-allow: this file is the list of what an
+# agent may do, and anything not written here is refused.
+#
+# Nothing in this file is legal advice about what may be delegated. It is a starting shape
+# for the actions an agent may take; a supervising lawyer decides which of them apply.
+schema: ctrlrun.policy/v1
+
+actions:
+  # Research and internal drafting: autonomous.
+  matter.read:
+    decision: allow
+  document.read:
+    decision: allow
+  research.search_caselaw:
+    decision: allow
+  document.draft_internal:
+    decision: allow
+
+  # Anything that leaves the firm carries the firm's name on it.
+  document.send_to_client:
+    decision: approve
+  engagement_letter.send:
+    decision: approve
+
+  # A filing is on the record the moment it lands, and a deadline missed by a retry loop
+  # is not recoverable by a second attempt.
+  document.file_with_court:
+    decision: approve
+
+  # Closing a matter stops the clock on limitation dates somebody is tracking.
+  matter.close:
+    decision: approve
+
+  # Binding the client, and destroying the file, are not agent actions.
+  contract.execute:
+    decision: deny
+  client.delete:
+    decision: deny

--- a/examples/policies/payments.yaml
+++ b/examples/policies/payments.yaml
@@ -1,0 +1,41 @@
+# Starting point on the v0.1 kernel. Adapt before use.
+#
+# Unknown actions are denied. There is no default-allow: this file is the list of what an
+# agent may do, and anything not written here is refused.
+#
+# Amounts are integer minor units (cents). Floats are rejected at construction, because
+# 0.1 and 0.10 are the same money and different hashes.
+schema: ctrlrun.policy/v1
+
+actions:
+  # Reads: autonomous.
+  invoice.read:
+    decision: allow
+  payment.read:
+    decision: allow
+
+  # Refunds move money out. First matching rule wins, so the autonomous band comes first,
+  # and both ends of every band are bound — an upper bound alone is not a range, and a
+  # refund of a negative amount is a charge.
+  stripe.refund:
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }       # $0 to $500 — autonomous
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 500000 }      # $0 to $5,000 — a human
+        decision: approve
+      - decision: deny
+
+  # Payouts leave the platform entirely. No autonomous band at all.
+  stripe.create_payout:
+    decision: approve
+
+  # Changing what a customer is billed, on a recurring basis, compounds.
+  stripe.update_subscription:
+    rules:
+      - when: { amount_gte: 0, amount_lte: 10000 }        # $0 to $100 per period
+        decision: allow
+      - decision: approve
+
+  # Deleting a customer destroys the record the receipts point at.
+  stripe.delete_customer:
+    decision: deny

--- a/examples/policies/security.yaml
+++ b/examples/policies/security.yaml
@@ -1,0 +1,47 @@
+# Starting point on the v0.1 kernel. Adapt before use.
+#
+# Unknown actions are denied. There is no default-allow: this file is the list of what an
+# agent may do, and anything not written here is refused.
+#
+# The asymmetry to keep: containment is cheap to undo and expensive to delay, so some of it
+# is autonomous. Widening access, and destroying evidence, never are.
+schema: ctrlrun.policy/v1
+
+actions:
+  # Triage: autonomous.
+  alert.read:
+    decision: allow
+  siem.query:
+    decision: allow
+  threat_intel.lookup:
+    decision: allow
+
+  # Containment on one endpoint, in the middle of an incident, beats waiting for a human.
+  host.isolate:
+    rules:
+      - when: { host_count_gte: 1, host_count_lte: 1 }
+        decision: allow
+      - decision: approve
+
+  # Locking one account out is recoverable; locking out a directory is an outage.
+  user.disable:
+    rules:
+      - when: { user_count_gte: 1, user_count_lte: 1 }
+        decision: allow
+      - decision: approve
+
+  # A rule that blocks is containment. A rule that permits is a hole.
+  firewall.add_deny_rule:
+    decision: allow
+  firewall.add_allow_rule:
+    decision: approve
+  firewall.delete_rule:
+    decision: approve
+
+  # Evidence, and the keys to everything.
+  audit_log.delete:
+    decision: deny
+  iam.grant_admin:
+    decision: deny
+  edr.disable_protection:
+    decision: deny

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -663,7 +663,15 @@ def test_the_shipped_example_policy_is_the_one_in_the_repository():
 
 #: Files outside the package that the test suite opens, and that must therefore travel in the
 #: sdist for a distribution packager to be able to run these tests at all.
-SOURCE_TREE_FIXTURES = ("ctrlrun.example.yaml", "tests/conftest.py")
+SOURCE_TREE_FIXTURES = (
+    "ctrlrun.example.yaml",
+    "tests/conftest.py",
+    # T31 runs every example script and loads every sector template out of the source tree
+    # (SPEC-v0.2 §1.1). CI builds the sdist and runs the suite from it, so both travel.
+    "examples/double-refund/main.py",
+    "examples/double-refund/ctrlrun.yaml",
+    "examples/policies/payments.yaml",
+)
 
 
 def _manifest_carries(manifest: str, path: str) -> bool:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,223 @@
+"""`examples/` and the sector policy templates. Build-list item 2; SPEC-v0.2 §1.1, T31.
+
+Two halves of one promise. The scripts each run the failure they exist to demonstrate and
+print the refusal, with no network and a state directory of their own. The templates are
+starting points on the v0.1 kernel — which is what lets this item land before §3 changes the
+policy schema — so every one declares `ctrlrun.policy/v1` and uses no key §3 adds.
+
+The network is not taken on trust: each script runs in a subprocess whose `sitecustomize`
+refuses every socket, so an example that grew a dependency on a live service fails here
+rather than on the reader's laptop.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from ctrlrun import Policy
+from ctrlrun.policy import POLICY_SCHEMA
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = REPO_ROOT / "examples"
+TEMPLATES = EXAMPLES / "policies"
+
+#: The four failure scenarios of SPEC-v0.2 §1.1, and the refusal each script must print.
+SCENARIOS: dict[str, str] = {
+    "double-refund": "blind retry refused",
+    "approval-mutation": "approved action ≠ requested action",
+    "agent-race": "already reserved",
+    "approval-replay": "single-use approval already consumed",
+}
+
+#: The nine sectors of SPEC-v0.2 §1.1.
+SECTORS = (
+    "devops",
+    "e-commerce",
+    "government",
+    "healthcare",
+    "hr",
+    "insurance",
+    "legal",
+    "payments",
+    "security",
+)
+
+#: SPEC-v0.2 §1.1 — the header every template carries, verbatim.
+HEADER = "Starting point on the v0.1 kernel. Adapt before use."
+
+#: Keys SPEC-v0.2 §3 adds. A template using one would not load on v0.1 at all, which is the
+#: whole reason §1.1 holds these to v0.1 primitives.
+V2_KEYS = ("effect:", "resource:", "mcp:")
+
+#: A template is a starting point, not an attestation. ROADMAP's sector rule holds until the
+#: milestone that earns a claim, and no template gets to imply one early.
+COMPLIANCE_WORDS = (
+    "compliant",
+    "compliance",
+    "certified",
+    "certification",
+    "accredited",
+    "attestation",
+    "conforms to",
+    "aligned with",
+)
+
+_REFUSE_EVERY_SOCKET = '''\
+"""Imported by `site` at startup: nothing under examples/ may open a socket."""
+
+import socket
+
+
+def _refuse(*args, **kwargs):
+    raise RuntimeError("an example opened a socket; examples must run with no network")
+
+
+socket.socket = _refuse
+socket.create_connection = _refuse
+socket.getaddrinfo = _refuse
+'''
+
+
+@pytest.fixture(scope="session")
+def no_network(tmp_path_factory):
+    """A `PYTHONPATH` entry whose `sitecustomize` refuses every socket (SPEC-v0.2 §1.1)."""
+    directory = tmp_path_factory.mktemp("no-network")
+    (directory / "sitecustomize.py").write_text(_REFUSE_EVERY_SOCKET, encoding="utf-8")
+    return directory
+
+
+def _run(scenario: str, cwd: Path, no_network: Path) -> subprocess.CompletedProcess[str]:
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(no_network), environment.get("PYTHONPATH", "")) if part
+    )
+    return subprocess.run(
+        [sys.executable, str(EXAMPLES / scenario / "main.py")],
+        cwd=cwd,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+def _templates() -> list[Path]:
+    return sorted(TEMPLATES.glob("*.yaml"))
+
+
+# --- T31: every example runs -----------------------------------------------------------
+
+
+def test_T31_the_four_scenarios_of_the_spec_are_the_ones_on_disk():
+    found = sorted(
+        path.name
+        for path in EXAMPLES.iterdir()
+        if path.is_dir() and path.name not in ("policies", "__pycache__")
+    )
+    assert found == sorted(SCENARIOS)
+
+
+@pytest.mark.parametrize("scenario", sorted(SCENARIOS))
+def test_T31_every_example_exits_zero_and_prints_its_refusal(scenario, tmp_path, no_network):
+    finished = _run(scenario, tmp_path, no_network)
+
+    assert finished.returncode == 0, f"{scenario} failed:\n{finished.stdout}\n{finished.stderr}"
+    assert "BLOCKED" in finished.stdout
+    assert SCENARIOS[scenario] in finished.stdout
+
+
+@pytest.mark.parametrize("scenario", sorted(SCENARIOS))
+def test_T31_every_example_keeps_its_state_under_its_own_directory(scenario, tmp_path, no_network):
+    """An example that reserved effect keys in a live store would block real work (§1.1)."""
+    _run(scenario, tmp_path, no_network)
+
+    assert (tmp_path / ".ctrlrun" / "examples" / scenario / "state.db").is_file()
+    written = {
+        path.relative_to(tmp_path).parts[0] for path in tmp_path.rglob("*") if path.is_file()
+    }
+    assert written == {".ctrlrun"}
+
+
+@pytest.mark.parametrize("scenario", sorted(SCENARIOS))
+def test_T31_every_example_is_repeatable(scenario, tmp_path, no_network):
+    """A second run in the same directory must refuse the same thing, not a stale record."""
+    first = _run(scenario, tmp_path, no_network)
+    second = _run(scenario, tmp_path, no_network)
+
+    assert first.returncode == 0, f"{scenario} failed on its first run:\n{first.stderr}"
+    assert second.returncode == 0, f"{scenario} is not repeatable:\n{second.stderr}"
+    assert SCENARIOS[scenario] in second.stdout
+
+
+# --- T31: every template loads ---------------------------------------------------------
+
+
+def test_T31_the_nine_sectors_of_the_spec_are_the_ones_on_disk():
+    assert sorted(path.stem for path in _templates()) == sorted(SECTORS)
+
+
+@pytest.mark.parametrize("sector", SECTORS)
+def test_T31_every_template_loads(sector):
+    policy = Policy.from_file(TEMPLATES / f"{sector}.yaml")
+
+    assert policy.actions, f"{sector}.yaml declares no actions"
+
+
+@pytest.mark.parametrize("sector", SECTORS)
+def test_T31_every_template_declares_schema_v1(sector):
+    """v0.1 primitives only, so a template loads on the shipped kernel (SPEC-v0.2 §1.1)."""
+    text = (TEMPLATES / f"{sector}.yaml").read_text(encoding="utf-8")
+
+    assert f"schema: {POLICY_SCHEMA}" in text
+
+
+@pytest.mark.parametrize("sector", SECTORS)
+def test_T31_every_template_carries_the_adapt_before_use_header(sector):
+    text = (TEMPLATES / f"{sector}.yaml").read_text(encoding="utf-8")
+
+    assert HEADER in text.splitlines()[0] or HEADER in "\n".join(text.splitlines()[:3])
+
+
+@pytest.mark.parametrize("sector", SECTORS)
+def test_T31_no_template_uses_a_key_added_by_section_3(sector):
+    text = (TEMPLATES / f"{sector}.yaml").read_text(encoding="utf-8")
+    used = [key for key in V2_KEYS if key in text]
+
+    assert not used, f"{sector}.yaml uses {used}, which SPEC-v0.2 §3 adds"
+
+
+@pytest.mark.parametrize("sector", SECTORS)
+def test_T31_no_template_claims_compliance(sector):
+    text = (TEMPLATES / f"{sector}.yaml").read_text(encoding="utf-8").lower()
+    claimed = [word for word in COMPLIANCE_WORDS if word in text]
+
+    assert not claimed, f"{sector}.yaml claims {claimed}; ROADMAP's sector rule forbids it"
+
+
+@pytest.mark.parametrize("sector", SECTORS)
+def test_T31_every_template_denies_an_unknown_action(sector):
+    """The kernel's floor, asserted per template: there is no default-allow (SPEC-v0.1 §3.3)."""
+    from ctrlrun import Action, Decision, Principal
+
+    policy = Policy.from_file(TEMPLATES / f"{sector}.yaml")
+    unknown = Action(
+        name="nothing.this.template.declares",
+        arguments={},
+        principal=Principal(agent="some-agent"),
+    )
+
+    assert policy.evaluate(unknown).decision is Decision.DENY
+
+
+@pytest.mark.parametrize("sector", SECTORS)
+def test_T31_every_template_has_at_least_one_deny(sector):
+    """A template that never says no is a template that taught nothing (SPEC-v0.2 §1.1)."""
+    text = (TEMPLATES / f"{sector}.yaml").read_text(encoding="utf-8")
+
+    assert "decision: deny" in text

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -144,6 +144,34 @@ def test_T31_every_example_keeps_its_state_under_its_own_directory(scenario, tmp
     assert written == {".ctrlrun"}
 
 
+def test_T31_every_file_an_example_needs_is_tracked_by_git():
+    """A file `.gitignore` swallows runs locally and is missing from every clone.
+
+    `.gitignore` ignores the operator's own policy at the repo root. The pattern was
+    unanchored once, which matched `examples/*/ctrlrun.yaml` too and kept every example's
+    policy out of this item's first commit — green locally, red on the first CI run against
+    a fresh checkout. This is that failure, caught before the push.
+    """
+    if not (REPO_ROOT / ".git").exists():
+        pytest.skip("no repository checkout")
+
+    listed = subprocess.run(
+        ["git", "ls-files", "examples"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    tracked = set(listed.stdout.split())
+    needed = {
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in EXAMPLES.rglob("*")
+        if path.is_file() and path.suffix in (".py", ".yaml")
+    }
+
+    assert not needed - tracked, f"untracked: {sorted(needed - tracked)}"
+
+
 @pytest.mark.parametrize("scenario", sorted(SCENARIOS))
 def test_T31_every_example_is_repeatable(scenario, tmp_path, no_network):
     """A second run in the same directory must refuse the same thing, not a stale record."""


### PR DESCRIPTION
Build-list item 2. SPEC-v0.2 §1.1, acceptance test T31.

This item sits early because it needs nothing this release adds: **v0.1 primitives only**, which is what lets it land before §3 changes the policy schema.

## `examples/`

Four standalone scripts, one per failure scenario. Each has its own `ctrlrun.yaml`, runs the failure it exists to demonstrate, prints the refusal, and exits 0.

| Scenario | What it blocks |
|---|---|
| `double-refund/` | `effect may already have committed; blind retry refused` |
| `approval-mutation/` | `approved action ≠ requested action (mismatch)` |
| `agent-race/` | `already reserved (in_progress)` |
| `approval-replay/` | `single-use approval already consumed` |

Three decisions worth naming:

- **Each keeps its own state directory**, under `.ctrlrun/examples/<scenario>/`, and clears it first so the example repeats. An example that reserved effect keys in the store a real agent is using would block live work — the same reason `ctrlrun demo` keeps its evidence separate.
- **A scenario that is not blocked exits non-zero.** Every script has an `else: raise SystemExit(...)` on the call that must be refused, so an example that silently starts working fails loudly instead of printing a line that says it worked.
- **`agent-race` is deterministic, not raced for.** Agent B runs from inside agent A's remote call, which is exactly the window that matters and needs no sleeping to hit. The docstring says so, and says the cross-process guarantee is the one enforced by `BEGIN IMMEDIATE` and the unique constraint rather than by a lock in this interpreter.

## `examples/policies/`

Nine sector templates: devops, payments, e-commerce, insurance, healthcare, legal, security, government, hr. Each declares `schema: ctrlrun.policy/v1`, uses no key §3 adds, carries the header `Starting point on the v0.1 kernel. Adapt before use.`, and says no to something.

They are shaped around one asymmetry rather than around a sector's vocabulary: what is cheap to undo can be autonomous, what leaves the building needs a human, and what destroys the evidence is denied outright. `security.yaml` is the clearest case — `firewall.add_deny_rule` is containment and allowed, `firewall.add_allow_rule` is a hole and needs a human, `audit_log.delete` is denied.

No template describes itself as compliant with anything, per ROADMAP's sector rule. The three templates over regulated work say in a comment that the question of what may be delegated at all comes first and a template cannot answer it.

## T31

77 tests. The one worth calling out: **the "no network" claim is asserted, not trusted.** Each script runs in a subprocess whose `sitecustomize` replaces `socket.socket`, `create_connection` and `getaddrinfo` with a refusal, so an example that grows a dependency on a live service fails in CI rather than on a reader's laptop.

## Packaging

`MANIFEST.in` now carries `examples/`. CI's `package` job extracts the sdist and runs the suite from it, so a T31 that reads the source tree needs both halves to travel — the failure mode `fix: the sdist shipped tests it could not run` already fixed once. Verified by hand: the sdist carries 24 example paths and T31 passes from the extracted tree.

## Mutation table

Every MUST in §1.1 and every clause of T31, broken one at a time:

| # | Rule | Result |
|---|---|---|
| M1 | a template MUST declare `schema: ctrlrun.policy/v1` | red |
| M2 | a template MUST NOT use `effect:` / `resource:` / `mcp:` | red |
| M3 | each carries the "Adapt before use" header | red |
| M4 | no template claims compliance | red |
| M5 | a template that never says no teaches nothing | red |
| M6 | each script prints the refusal it demonstrates | red |
| M7 | each script runs with no network | red |
| M8 | each script keeps state under its own directory | red |
| M9 | each script repeats | red |
| M10 | all nine sectors present | red |
| M11 | all four scenarios present | red |

## Verification

802 tests pass (725 → 802), `mypy --strict src/` and `ruff check` clean, `ruff format --check` clean, `ctrlrun demo` still runs the four scenarios in 0.07s with no network. All four example scripts verified by hand from a scratch directory.