### PR TITLE
templates: state the rule the decisions follow

### DIFF
--- a/examples/policies/devops.yaml
+++ b/examples/policies/devops.yaml
@@ -1,5 +1,10 @@
 # Starting point on the v0.1 kernel. Adapt before use.
 #
+# The rule these decisions follow, so you can apply it to actions not listed here:
+#   cheap to undo          → allow    (autonomous)
+#   leaves the building    → approve  (a human, every time)
+#   destroys the evidence  → deny     (not an agent action at any size)
+#
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 schema: ctrlrun.policy/v1

--- a/examples/policies/e-commerce.yaml
+++ b/examples/policies/e-commerce.yaml
@@ -1,5 +1,10 @@
 # Starting point on the v0.1 kernel. Adapt before use.
 #
+# The rule these decisions follow, so you can apply it to actions not listed here:
+#   cheap to undo          → allow    (autonomous)
+#   leaves the building    → approve  (a human, every time)
+#   destroys the evidence  → deny     (not an agent action at any size)
+#
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 #

--- a/examples/policies/government.yaml
+++ b/examples/policies/government.yaml
@@ -1,5 +1,10 @@
 # Starting point on the v0.1 kernel. Adapt before use.
 #
+# The rule these decisions follow, so you can apply it to actions not listed here:
+#   cheap to undo          → allow    (autonomous)
+#   leaves the building    → approve  (a human, every time)
+#   destroys the evidence  → deny     (not an agent action at any size)
+#
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 #

--- a/examples/policies/healthcare.yaml
+++ b/examples/policies/healthcare.yaml
@@ -1,5 +1,10 @@
 # Starting point on the v0.1 kernel. Adapt before use.
 #
+# The rule these decisions follow, so you can apply it to actions not listed here:
+#   cheap to undo          → allow    (autonomous)
+#   leaves the building    → approve  (a human, every time)
+#   destroys the evidence  → deny     (not an agent action at any size)
+#
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 #

--- a/examples/policies/hr.yaml
+++ b/examples/policies/hr.yaml
@@ -1,5 +1,10 @@
 # Starting point on the v0.1 kernel. Adapt before use.
 #
+# The rule these decisions follow, so you can apply it to actions not listed here:
+#   cheap to undo          → allow    (autonomous)
+#   leaves the building    → approve  (a human, every time)
+#   destroys the evidence  → deny     (not an agent action at any size)
+#
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 #

--- a/examples/policies/insurance.yaml
+++ b/examples/policies/insurance.yaml
@@ -1,5 +1,10 @@
 # Starting point on the v0.1 kernel. Adapt before use.
 #
+# The rule these decisions follow, so you can apply it to actions not listed here:
+#   cheap to undo          → allow    (autonomous)
+#   leaves the building    → approve  (a human, every time)
+#   destroys the evidence  → deny     (not an agent action at any size)
+#
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 #

--- a/examples/policies/legal.yaml
+++ b/examples/policies/legal.yaml
@@ -1,5 +1,10 @@
 # Starting point on the v0.1 kernel. Adapt before use.
 #
+# The rule these decisions follow, so you can apply it to actions not listed here:
+#   cheap to undo          → allow    (autonomous)
+#   leaves the building    → approve  (a human, every time)
+#   destroys the evidence  → deny     (not an agent action at any size)
+#
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 #

--- a/examples/policies/payments.yaml
+++ b/examples/policies/payments.yaml
@@ -1,5 +1,10 @@
 # Starting point on the v0.1 kernel. Adapt before use.
 #
+# The rule these decisions follow, so you can apply it to actions not listed here:
+#   cheap to undo          → allow    (autonomous)
+#   leaves the building    → approve  (a human, every time)
+#   destroys the evidence  → deny     (not an agent action at any size)
+#
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 #

--- a/examples/policies/security.yaml
+++ b/examples/policies/security.yaml
@@ -1,10 +1,16 @@
 # Starting point on the v0.1 kernel. Adapt before use.
 #
+# The rule these decisions follow, so you can apply it to actions not listed here:
+#   cheap to undo          → allow    (autonomous)
+#   leaves the building    → approve  (a human, every time)
+#   destroys the evidence  → deny     (not an agent action at any size)
+#
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 #
-# The asymmetry to keep: containment is cheap to undo and expensive to delay, so some of it
-# is autonomous. Widening access, and destroying evidence, never are.
+# Security is where the first line earns its keep: containment is cheap to undo *and*
+# expensive to delay, so a single-host action is autonomous where the same verb across a
+# fleet is not. Read `firewall.add_deny_rule` against `firewall.add_allow_rule` below.
 schema: ctrlrun.policy/v1
 
 actions:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -50,6 +50,15 @@ SECTORS = (
 #: SPEC-v0.2 §1.1 — the header every template carries, verbatim.
 HEADER = "Starting point on the v0.1 kernel. Adapt before use."
 
+#: The rule the templates are shaped by, stated at the top of each so a reader can apply it
+#: to the actions their own system has rather than only to the ones listed. A template whose
+#: decisions cannot be re-derived is a list to copy, which is not what a template is for.
+DECISION_RULE = (
+    "cheap to undo",
+    "leaves the building",
+    "destroys the evidence",
+)
+
 #: Keys SPEC-v0.2 §3 adds. A template using one would not load on v0.1 at all, which is the
 #: whole reason §1.1 holds these to v0.1 primitives.
 V2_KEYS = ("effect:", "resource:", "mcp:")
@@ -210,6 +219,19 @@ def test_T31_every_template_carries_the_adapt_before_use_header(sector):
     text = (TEMPLATES / f"{sector}.yaml").read_text(encoding="utf-8")
 
     assert HEADER in text.splitlines()[0] or HEADER in "\n".join(text.splitlines()[:3])
+
+
+@pytest.mark.parametrize("sector", SECTORS)
+def test_T31_every_template_states_the_rule_its_decisions_follow(sector):
+    """The teaching, not the list: a reader has to be able to decide an action not shown.
+
+    Asserted in the preamble — the first dozen lines, above `schema:` — because a rule
+    buried under forty lines of YAML is a rule nobody reads before copying the file.
+    """
+    preamble = (TEMPLATES / f"{sector}.yaml").read_text(encoding="utf-8").split("schema:")[0]
+    missing = [clause for clause in DECISION_RULE if clause not in preamble]
+
+    assert not missing, f"{sector}.yaml does not state: {missing}"
 
 
 @pytest.mark.parametrize("sector", SECTORS)


### PR DESCRIPTION
Follow-up to item 2, on your read of the templates: the framing transfers, the sector vocabulary does not.

Every one of the nine now opens with the asymmetry its entries were shaped by, in the preamble above `schema:` where a reader meets it before copying the file:

```
# The rule these decisions follow, so you can apply it to actions not listed here:
#   cheap to undo          → allow    (autonomous)
#   leaves the building    → approve  (a human, every time)
#   destroys the evidence  → deny     (not an agent action at any size)
```

A template's job is not to be the list somebody copies — it is to let them decide the actions their own system has, which these nine cannot enumerate. Stating the rule is the difference between the two.

`security.yaml` had its own wording of the asymmetry, which the new preamble made redundant. It now says the thing only that sector can: containment is cheap to undo **and** expensive to delay, which is why `firewall.add_deny_rule` is autonomous where `firewall.add_allow_rule` needs a human — the pair below it is the worked example.

`test_T31_every_template_states_the_rule_its_decisions_follow` keeps it from drifting out, asserted against the preamble (everything above `schema:`) rather than the whole file, because a rule buried under forty lines of YAML is a rule nobody reads in time. Mutation-checked by dropping one clause from one template: red.

The "Adapt before use" header stays on line 1. SPEC-v0.2 §1.1 requires it, and it is the load-bearing disclaimer; the rule reads better as the paragraph under it than above it.

812 tests pass (803 → 812), `ruff check` and `ruff format --check` clean.