### PR TITLE
item 4: EventSink protocol, and JSONL becomes a sink

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -138,9 +138,9 @@ Pragmas: `journal_mode=WAL`, `busy_timeout=5000`, `synchronous=NORMAL`.
 | `policy.py` | YAML → rules → Decision; `effect:`/`resource:` templates | approvals, effect *state* |
 | `approval.py` | request/grant/consume, providers | executors |
 | `effect.py` | key templating, state enum, transition rules | SQLite |
-| `state.py` | `StateStore` protocol + SQLite/in-memory impls | policy, decorator |
+| `state.py` | `StateStore` protocol + SQLite/in-memory impls | policy, decorator, sinks |
 | `control.py` | `Control` orchestration, decorator, context | CLI |
-| `receipt.py` | Receipt/Event models, JSONL writer | everything else |
+| `receipt.py` | Receipt/Event models, `EventSink`, JSONL sink | everything else |
 | `cli/` | click commands, demo | internals beyond `Control` |
 
 Dependencies point downward only. `Control` is the only module that composes the others.

--- a/docs/SPEC-v0.1.md
+++ b/docs/SPEC-v0.1.md
@@ -298,9 +298,15 @@ class StateStore(Protocol):
     # approvals
     def put_approval_request(...); def grant_approval(...); def deny_approval(...)
     # evidence
-    def append_event(self, event: Event) -> None: ...
+    def append_event(self, event: Event) -> Event: ...   # v0.2 §4.1: returns it as stored
     def put_receipt(self, receipt: Receipt) -> None: ...
 ```
+
+`append_event` returned `None` in v0.1. SPEC-v0.2 §4.1 requires `Control` to hand every event
+to its `EventSink`s **with the `event_id` the store assigned**, and the store is the only thing
+that knows it, so the stored event is returned. Callers that ignore the return value are
+unaffected; this is stated here rather than only in the v0.2 delta because §8 is where a store
+implementor reads the protocol.
 
 `consume_approval_and_reserve` is what §4.2 A4 asks for, and a caller MUST NOT reconstruct it by sequencing `consume_approval` and `reserve_effect`: two calls cannot share a transaction, so the split consumes an approval for an attempt that then fails to reserve — the exact hole A4 closes. `reserve_effect` is for an action with no approval to take (`ALLOW` with an `effect=`), `consume_approval` for an approved action with no effect key (§5.1); neither is a building block for the other case.
 

--- a/docs/SPEC-v0.2.md
+++ b/docs/SPEC-v0.2.md
@@ -1317,8 +1317,14 @@ StateStore.hold_continuation(effect_key, action_id, request_state: str) -> None
 StateStore.take_continuation(effect_key, request_state: str) -> EffectRecord
 ```
 
-**Removed:** `SQLiteStateStore.journal`. The store no longer writes JSONL; `Control` does,
-through `JSONLEventSink` (§4.3). The files it writes, and where, are unchanged.
+**Removed:** `SQLiteStateStore.journal`, and the `EventLog` behind it — `JSONLEventSink` is
+that class under the sink interface. The store no longer writes JSONL; `Control` does, through
+`JSONLEventSink` (§4.3). The files it writes, and where, are unchanged.
+
+**Changed:** `StateStore.append_event(event) -> Event` returns the event as stored, where v0.1
+returned `None`. §4.1 requires a sink to be called with the `event_id` the store assigned, and
+the store is the only thing that knows it. Callers that ignore the return value are unaffected.
+v0.1 §8 records this too, because that is where a store implementor reads the protocol.
 
 Four event types join v0.1 §6.2: `RECONCILIATION_STARTED`, `RECONCILIATION_RESOLVED`,
 `EXECUTION_SUSPENDED`, `EXECUTION_RESUMED`. The last two are named for what happens to the

--- a/src/ctrlrun/__init__.py
+++ b/src/ctrlrun/__init__.py
@@ -27,7 +27,7 @@ from .errors import (
     PolicyError,
 )
 from .policy import Decision, Policy
-from .receipt import Event, Receipt
+from .receipt import Event, EventSink, JSONLEventSink, Receipt
 from .state import InMemoryStateStore, SQLiteStateStore, StateStore
 
 __all__ = [
@@ -48,8 +48,10 @@ __all__ = [
     "EffectRecord",
     "EffectState",
     "Event",
+    "EventSink",
     "InMemoryStateStore",
     "InvalidArgument",
+    "JSONLEventSink",
     "LocalApprovalProvider",
     "NotExecuted",
     "Policy",

--- a/src/ctrlrun/cli/demo.py
+++ b/src/ctrlrun/cli/demo.py
@@ -27,7 +27,7 @@ from ..errors import (
     DuplicateEffect,
 )
 from ..policy import Policy
-from ..receipt import EVENTS_FILENAME, RECEIPTS_FILENAME
+from ..receipt import EVENTS_FILENAME, RECEIPTS_FILENAME, JSONLEventSink
 from ..state import SQLiteStateStore
 
 #: Where the demo keeps its own store and evidence, under `.ctrlrun/`.
@@ -130,7 +130,14 @@ def run_demo(root: Path) -> None:
     # Two grants: scenario 2's human, and scenario 4's. A scripted approver never grants
     # more than it was told to, so a scenario that asked twice would fail loudly.
     approvals = ScriptedApprovalProvider(store, ["grant", "grant"], approver="human:demo")
-    control = Control(Policy.from_yaml(DEMO_POLICY, source="<demo>"), store, approvals)
+    # SPEC-v0.2 §4.3 — the JSONL evidence is a Control sink now. The demo prints where
+    # both files landed, so it installs one on its own evidence directory.
+    control = Control(
+        Policy.from_yaml(DEMO_POLICY, source="<demo>"),
+        store,
+        approvals,
+        sinks=[JSONLEventSink(evidence)],
+    )
 
     @protect("stripe.refund", effect="refund:{payment_id}", control=control)
     def refund(payment_id: str, amount: int, currency: str = "EUR") -> dict[str, Any]:

--- a/src/ctrlrun/control.py
+++ b/src/ctrlrun/control.py
@@ -11,7 +11,7 @@ import functools
 import inspect
 import logging
 import os
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -51,7 +51,16 @@ from .errors import (
     NotExecuted,
 )
 from .policy import Decision, Evaluation, Policy, discover_policy_path
-from .receipt import Event, EventType, Receipt, ReceiptResult, iso_timestamp, new_receipt_id
+from .receipt import (
+    Event,
+    EventSink,
+    EventType,
+    JSONLEventSink,
+    Receipt,
+    ReceiptResult,
+    iso_timestamp,
+    new_receipt_id,
+)
 from .state import SQLiteStateStore, StateStore
 
 _LOG = logging.getLogger(__name__)
@@ -199,6 +208,7 @@ class Control:
         clock: Callable[[], datetime] = _utc_now,
         approval_ttl: timedelta = DEFAULT_APPROVAL_TTL,
         lease: timedelta = DEFAULT_LEASE,
+        sinks: Sequence[EventSink] = (),
     ) -> None:
         self._policy = policy
         self._store = store
@@ -208,6 +218,7 @@ class Control:
         self._clock = clock
         self._approval_ttl = approval_ttl
         self._lease = _checked_lease(lease, "Control(lease=...)")
+        self._sinks = tuple(sinks)
 
     @classmethod
     def from_file(cls, path: str | os.PathLike[str] | None = None) -> Control:
@@ -219,8 +230,16 @@ class Control:
         are shared by every worker that loaded the same policy (§5.3 E1, §8).
         """
         policy = Policy.from_file(path)
-        store = SQLiteStateStore(state_path(policy.source))
-        return cls(policy, store, LocalApprovalProvider(store))
+        state = state_path(policy.source)
+        store = SQLiteStateStore(state)
+        # SPEC-v0.2 §4.3 — the two files of v0.1 §6 land exactly where v0.1 put them,
+        # so an existing evidence directory is unchanged by the move out of the store.
+        return cls(
+            policy,
+            store,
+            LocalApprovalProvider(store),
+            sinks=[JSONLEventSink(state.parent)],
+        )
 
     @property
     def policy(self) -> Policy:
@@ -746,7 +765,7 @@ class Control:
         approval: Approval | None = None,
         approval_id: str | None = None,
     ) -> None:
-        self._store.append_event(
+        stored = self._store.append_event(
             Event(
                 type=type_,
                 action_id=action.action_id,
@@ -756,6 +775,7 @@ class Control:
                 approval_id=approval_id if approval is None else approval.approval_id,
             )
         )
+        self._fan_out("on_event", stored, str(stored.type))
 
     def _record(
         self,
@@ -792,7 +812,35 @@ class Control:
             error=error,
         )
         self._store.put_receipt(receipt)
+        self._fan_out("on_receipt", receipt, receipt.receipt_id)
         return receipt
+
+    def _fan_out(self, method: str, record: Event | Receipt, described: str) -> None:
+        """Hand one record to every sink, in registration order (SPEC-v0.2 §4.1, §4.2).
+
+        Called only after the authoritative store write for that record succeeded, so a sink
+        that reads the store finds what it was just handed.
+
+        A sink that raises is logged and skipped, and the remaining sinks still run: by the
+        time this executes the effect has committed at the remote and the record is durable,
+        and raising here would reach the caller as an exception on a successful action —
+        which an agent reads as a failure, and retries. That is the one mistake this library
+        exists to prevent, so it is not going to be introduced by a telemetry exporter.
+
+        A `BaseException` that is not an `Exception` propagates, for the reason in v0.1 §5.5:
+        swallowing a `KeyboardInterrupt` while exporting is worse than losing the export.
+        """
+        for sink in self._sinks:
+            try:
+                getattr(sink, method)(record)
+            except Exception as exc:
+                _LOG.warning(
+                    "%s.%s(%s) failed and was skipped: %s",
+                    type(sink).__name__,
+                    method,
+                    described,
+                    exc,
+                )
 
 
 def _refusal_data(refused: DuplicateEffect | AmbiguousEffect) -> dict[str, str]:

--- a/src/ctrlrun/receipt.py
+++ b/src/ctrlrun/receipt.py
@@ -1,7 +1,7 @@
 """Receipts and the event log. Build-list item 8; SPEC-v0.1 §6.
 
 `Control` produces a `Receipt` for every action that reaches a terminal state, and an `Event`
-for every step it takes. `EventLog` is where those land on disk: `.ctrlrun/receipts.jsonl`
+for every step it takes. `JSONLEventSink` is where those land on disk: `.ctrlrun/receipts.jsonl`
 and `.ctrlrun/events.jsonl`, one JSON object per line, in append order.
 
 A receipt is evidence, and evidence has to outlive the tool that wrote it — so the file form
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, Final
+from typing import Any, Final, Protocol
 
 from .action import Principal
 from .policy import Decision
@@ -191,7 +191,26 @@ class Receipt:
         return cls.from_dict(document)
 
 
-class EventLog:
+class EventSink(Protocol):
+    """Somewhere a copy of every `Event` and `Receipt` goes (SPEC-v0.2 §4.1).
+
+    `Control` calls a sink *after* the authoritative store write for that record has
+    succeeded, in registration order, with the `event_id` the store assigned. A sink is the
+    interface for the copies; it is not the interface for the record — the store's own
+    `events` and `receipts` tables are written inside the store, in its transaction, before
+    any sink runs (§4.3).
+
+    Sinks are not transactional, not ordered across processes, and not retried. A sink that
+    must not lose records buffers and retries inside itself. And a sink never raises into the
+    kernel: `Control` catches every `Exception` and carries on (§4.2).
+    """
+
+    def on_event(self, event: Event) -> None: ...
+
+    def on_receipt(self, receipt: Receipt) -> None: ...
+
+
+class JSONLEventSink:
     """The JSONL half of the evidence: two append-only files in one directory (SPEC §6).
 
     `receipts.jsonl` and `events.jsonl` beside the state database, so `.ctrlrun/` holds the
@@ -200,6 +219,10 @@ class EventLog:
 
     Each write opens, appends one line and closes, so several processes sharing a store
     (SPEC-v0.1 §5.3 E1) interleave whole lines rather than fragments of them.
+
+    SPEC-v0.2 §4.3 — this used to live inside `SQLiteStateStore`, which wrote both halves.
+    `Control` owns it now, as one `EventSink` among however many an application registers.
+    The files it writes, and where, are unchanged.
     """
 
     def __init__(self, directory: str | os.PathLike[str]) -> None:
@@ -217,11 +240,11 @@ class EventLog:
     def events_path(self) -> Path:
         return self._directory / EVENTS_FILENAME
 
-    def put_receipt(self, receipt: Receipt) -> None:
+    def on_receipt(self, receipt: Receipt) -> None:
         """Append one receipt as a JSON line."""
         self._append(self.receipts_path, receipt.to_json())
 
-    def append_event(self, event: Event) -> None:
+    def on_event(self, event: Event) -> None:
         """Append one event as a JSON line, in the order the store assigned it."""
         self._append(self.events_path, event.to_json())
 

--- a/src/ctrlrun/state.py
+++ b/src/ctrlrun/state.py
@@ -48,7 +48,7 @@ from .effect import (
     plan_reservation,
 )
 from .errors import AmbiguousEffect, DuplicateEffect, InvalidArgument
-from .receipt import Event, EventLog, EventType, Receipt
+from .receipt import Event, EventType, Receipt
 
 _LOG = logging.getLogger(__name__)
 
@@ -346,8 +346,13 @@ class StateStore(ApprovalStore, Protocol):
         """Every effect record, oldest first, optionally narrowed to one state."""
         ...
 
-    def append_event(self, event: Event) -> None:
-        """Append an event, assigning it the next `event_id`."""
+    def append_event(self, event: Event) -> Event:
+        """Append an event, assigning it the next `event_id`, and return it as stored.
+
+        The stored event is handed back because `Control` fans it out to its `EventSink`s
+        with the id this store assigned (SPEC-v0.2 §4.1). A sink that could not join its
+        export back to the record would be exporting something else.
+        """
         ...
 
     def put_receipt(self, receipt: Receipt) -> None:
@@ -382,9 +387,11 @@ class InMemoryStateStore:
 
     # --- evidence ---------------------------------------------------------------------
 
-    def append_event(self, event: Event) -> None:
+    def append_event(self, event: Event) -> Event:
         with self._lock:
-            self._events.append(replace(event, event_id=len(self._events) + 1))
+            stored = replace(event, event_id=len(self._events) + 1)
+            self._events.append(stored)
+        return stored
 
     def put_receipt(self, receipt: Receipt) -> None:
         with self._lock:
@@ -616,17 +623,11 @@ class SQLiteStateStore:
         self._open: set[sqlite3.Connection] = set()
         self._open_lock = threading.Lock()
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._journal = EventLog(self._path.parent)
         self._connection().executescript(_SCHEMA)
 
     @property
     def path(self) -> Path:
         return self._path
-
-    @property
-    def journal(self) -> EventLog:
-        """The JSONL evidence written beside the database (SPEC-v0.1 §6)."""
-        return self._journal
 
     def close(self) -> None:
         """Close every connection this store opened, on whichever thread opened it.
@@ -671,7 +672,7 @@ class SQLiteStateStore:
 
     # --- evidence ---------------------------------------------------------------------
 
-    def append_event(self, event: Event) -> None:
+    def append_event(self, event: Event) -> Event:
         cursor = self._connection().execute(
             "INSERT INTO events(ts, type, action_id, effect_key, approval_id, data_json) "
             "VALUES(?,?,?,?,?,?)",
@@ -684,7 +685,7 @@ class SQLiteStateStore:
                 json.dumps(dict(event.data), ensure_ascii=False, separators=(",", ":")),
             ),
         )
-        self._mirror(self._journal.append_event, replace(event, event_id=cursor.lastrowid))
+        return replace(event, event_id=cursor.lastrowid)
 
     def put_receipt(self, receipt: Receipt) -> None:
         self._connection().execute(
@@ -699,23 +700,6 @@ class SQLiteStateStore:
                 _iso(receipt.finished_at),
             ),
         )
-        self._mirror(self._journal.put_receipt, receipt)
-
-    @staticmethod
-    def _mirror(write: Callable[[_T], None], record: _T) -> None:
-        """Copy a record the database already holds into the JSONL evidence (SPEC §6).
-
-        SPEC: §6 — the spec requires both, and does not say what happens when only one can
-        be written. The record is already durable in the database by the time this runs, so
-        a failing file is logged rather than raised: raising would turn an effect that has
-        committed at the remote into an exception the caller reads as a failure, which is
-        the one mistake this library exists to prevent. `ctrlrun receipts` reads the
-        database, so nothing is hidden by the loss.
-        """
-        try:
-            write(record)
-        except OSError as exc:
-            _LOG.warning("could not write JSONL evidence: %s", exc)
 
     def events(self) -> tuple[Event, ...]:
         rows = self._connection().execute("SELECT * FROM events ORDER BY event_id").fetchall()

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -17,6 +17,7 @@ import sys
 import threading
 import time
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import pytest
 
@@ -28,6 +29,7 @@ from ctrlrun import (
     Control,
     DuplicateEffect,
     InvalidArgument,
+    JSONLEventSink,
     Policy,
     Principal,
     SQLiteStateStore,
@@ -36,7 +38,7 @@ from ctrlrun import (
 )
 from ctrlrun.approval import DEFAULT_APPROVAL_TTL, ApprovalStatus
 from ctrlrun.effect import DEFAULT_LEASE, EffectState
-from ctrlrun.receipt import ReceiptResult
+from ctrlrun.receipt import EVENTS_FILENAME, RECEIPTS_FILENAME, ReceiptResult
 
 POLICY = """
 schema: ctrlrun.policy/v1
@@ -85,7 +87,9 @@ def _fake_remote(log_path: str) -> str:
 def _refund_worker(db_path: str, log_path: str, barrier) -> int:
     """One agent process: reserve `refund:txn_9`, and execute only if the reservation won."""
     store = SQLiteStateStore(db_path)
-    control = Control(Policy.from_yaml(POLICY), store)
+    # SPEC-v0.2 §4.3 — the JSONL is Control's now, so each worker installs its own sink
+    # on the shared directory. That is what this test is about: eight processes, one file.
+    control = Control(Policy.from_yaml(POLICY), store, sinks=[JSONLEventSink(Path(db_path).parent)])
 
     @protect("stripe.refund", effect="refund:{payment_id}", control=control)
     def refund(payment_id: str, amount: int) -> str:
@@ -181,15 +185,19 @@ def test_T3_eight_processes_leave_the_jsonl_evidence_intact(race):
 
     One `O_APPEND` write per record, as the fake remote does above: whole lines interleave,
     fragments do not. A torn line would make the evidence unreadable to everything.
+
+    Since SPEC-v0.2 §4.3 the writer is each process's `JSONLEventSink` rather than the
+    store, which is more of this guarantee under test, not less: the appends are no longer
+    serialized by anything the store does.
     """
     store, _, _ = race
-    written = [json.loads(line) for line in _jsonl(store.journal.receipts_path)]
+    written = [json.loads(line) for line in _jsonl(store.path.parent / RECEIPTS_FILENAME)]
 
     assert len(written) == WORKERS
     assert {document["receipt_id"] for document in written} == {
         receipt.receipt_id for receipt in store.receipts()
     }
-    assert all(json.loads(line) for line in _jsonl(store.journal.events_path))
+    assert all(json.loads(line) for line in _jsonl(store.path.parent / EVENTS_FILENAME))
 
 
 # --- one approval, eight processes (SPEC §4.2 A2, A4) ---------------------------------

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -41,7 +41,14 @@ from ctrlrun.cli.demo import (
     written_path,
 )
 from ctrlrun.cli.main import EXAMPLE_POLICY, main
-from ctrlrun.receipt import RECEIPT_SCHEMA, EventLog, EventType, ReceiptResult
+from ctrlrun.receipt import (
+    EVENTS_FILENAME,
+    RECEIPT_SCHEMA,
+    RECEIPTS_FILENAME,
+    EventType,
+    JSONLEventSink,
+    ReceiptResult,
+)
 
 POLICY = """
 schema: ctrlrun.policy/v1
@@ -112,8 +119,18 @@ def store(workspace):
 
 
 @pytest.fixture
-def control(workspace, store):
-    return Control(Policy.from_file(workspace / "ctrlrun.yaml"), store)
+def journal(workspace):
+    """SPEC-v0.2 §4.3 — the JSONL evidence is a `Control` sink now, not the store's job.
+
+    Pointed at the directory `Control.from_file()` would point it at, so every assertion
+    below still reads the files v0.1 §6 names, in the place v0.1 put them.
+    """
+    return JSONLEventSink(workspace / ".ctrlrun")
+
+
+@pytest.fixture
+def control(workspace, store, journal):
+    return Control(Policy.from_file(workspace / "ctrlrun.yaml"), store, sinks=[journal])
 
 
 @pytest.fixture
@@ -154,7 +171,7 @@ def _lines(path: Path) -> list[str]:
 # --- the JSONL evidence writers (SPEC §6.1, §6.2) -------------------------------------
 
 
-def test_a_receipt_is_appended_to_receipts_jsonl_beside_the_state_database(control, store):
+def test_a_receipt_is_appended_to_receipts_jsonl_beside_the_state_database(control, journal):
     @protect("stripe.refund", effect="refund:{payment_id}", control=control)
     def refund(payment_id: str, amount: int) -> str:
         return "re_1"
@@ -162,11 +179,11 @@ def test_a_receipt_is_appended_to_receipts_jsonl_beside_the_state_database(contr
     with context(agent="refund-agent"):
         refund(payment_id="txn_1", amount=200)
 
-    (line,) = _lines(store.journal.receipts_path)
+    (line,) = _lines(journal.receipts_path)
     assert json.loads(line)["result"] == "committed"
 
 
-def test_the_jsonl_receipt_parses_back_into_the_receipt_the_store_holds(control, store):
+def test_the_jsonl_receipt_parses_back_into_the_receipt_the_store_holds(control, store, journal):
     @protect("stripe.refund", effect="refund:{payment_id}", control=control)
     def refund(payment_id: str, amount: int) -> str:
         return "re_1"
@@ -174,11 +191,11 @@ def test_the_jsonl_receipt_parses_back_into_the_receipt_the_store_holds(control,
     with context(agent="refund-agent"):
         refund(payment_id="txn_1", amount=200)
 
-    (line,) = _lines(store.journal.receipts_path)
+    (line,) = _lines(journal.receipts_path)
     assert Receipt.from_json(line) == store.receipts()[0]
 
 
-def test_every_event_is_appended_to_events_jsonl_in_order(control, store):
+def test_every_event_is_appended_to_events_jsonl_in_order(control, store, journal):
     @protect("stripe.refund", effect="refund:{payment_id}", control=control)
     def refund(payment_id: str, amount: int) -> str:
         return "re_1"
@@ -186,14 +203,14 @@ def test_every_event_is_appended_to_events_jsonl_in_order(control, store):
     with context(agent="refund-agent"):
         refund(payment_id="txn_1", amount=200)
 
-    written = [json.loads(line) for line in _lines(store.journal.events_path)]
+    written = [json.loads(line) for line in _lines(journal.events_path)]
     assert [document["type"] for document in written] == [
         str(event.type) for event in store.events()
     ]
     assert [document["event_id"] for document in written] == [1, 2, 3, 4, 5]
 
 
-def test_every_jsonl_event_carries_the_fields_the_spec_names(control, store):
+def test_every_jsonl_event_carries_the_fields_the_spec_names(control, journal):
     @protect("stripe.refund", effect="refund:{payment_id}", control=control)
     def refund(payment_id: str, amount: int) -> str:
         return "re_1"
@@ -201,7 +218,7 @@ def test_every_jsonl_event_carries_the_fields_the_spec_names(control, store):
     with context(agent="refund-agent"):
         refund(payment_id="txn_1", amount=200)
 
-    for line in _lines(store.journal.events_path):
+    for line in _lines(journal.events_path):
         assert set(json.loads(line)) == {
             "event_id",
             "ts",
@@ -213,12 +230,28 @@ def test_every_jsonl_event_carries_the_fields_the_spec_names(control, store):
         }
 
 
-def test_the_jsonl_files_land_in_the_state_directory(store, workspace):
-    assert store.journal.receipts_path == workspace / ".ctrlrun" / "receipts.jsonl"
-    assert store.journal.events_path == workspace / ".ctrlrun" / "events.jsonl"
+def test_the_jsonl_files_land_in_the_state_directory(workspace):
+    """SPEC-v0.2 §4.3 — `Control.from_file()` installs the sink, and it writes where v0.1
+    wrote: an existing evidence directory is unchanged by the move out of the store."""
+    control = Control.from_file()
+    try:
+
+        @protect("stripe.refund", effect="refund:{payment_id}", control=control)
+        def refund(payment_id: str, amount: int) -> str:
+            return "re_1"
+
+        with context(agent="refund-agent"):
+            refund(payment_id="txn_1", amount=200)
+    finally:
+        control.store.close()
+
+    assert (workspace / ".ctrlrun" / RECEIPTS_FILENAME).is_file()
+    assert (workspace / ".ctrlrun" / EVENTS_FILENAME).is_file()
 
 
-def test_a_new_store_on_the_same_directory_appends_rather_than_truncates(control, store, workspace):
+def test_a_new_store_on_the_same_directory_appends_rather_than_truncates(
+    control, journal, workspace
+):
     @protect("stripe.refund", effect="refund:{payment_id}", control=control)
     def refund(payment_id: str, amount: int) -> str:
         return "re_1"
@@ -227,7 +260,11 @@ def test_a_new_store_on_the_same_directory_appends_rather_than_truncates(control
         refund(payment_id="txn_1", amount=200)
     reopened = SQLiteStateStore(workspace / ".ctrlrun" / "state.db")
     try:
-        second = Control(Policy.from_file(workspace / "ctrlrun.yaml"), reopened)
+        second = Control(
+            Policy.from_file(workspace / "ctrlrun.yaml"),
+            reopened,
+            sinks=[JSONLEventSink(workspace / ".ctrlrun")],
+        )
 
         @protect("stripe.refund", effect="refund:{payment_id}", control=second)
         def other(payment_id: str, amount: int) -> str:
@@ -238,10 +275,10 @@ def test_a_new_store_on_the_same_directory_appends_rather_than_truncates(control
     finally:
         reopened.close()
 
-    assert len(_lines(store.journal.receipts_path)) == 2
+    assert len(_lines(journal.receipts_path)) == 2
 
 
-def test_a_receipt_line_is_written_only_after_the_store_accepted_it(control, store):
+def test_a_receipt_line_is_written_only_after_the_store_accepted_it(control, journal):
     @protect("stripe.refund", control=control)
     def denied(payment_id: str, amount: int) -> str:
         raise AssertionError("a denied action never executes")
@@ -249,13 +286,15 @@ def test_a_receipt_line_is_written_only_after_the_store_accepted_it(control, sto
     with context(agent="refund-agent"), pytest.raises(ActionDenied):
         denied(payment_id="txn_1", amount=999999)
 
-    (line,) = _lines(store.journal.receipts_path)
+    (line,) = _lines(journal.receipts_path)
     assert json.loads(line)["result"] == "denied"
 
 
 def test_an_unwritable_journal_never_fails_an_action_the_store_already_recorded(
-    control, store, monkeypatch, caplog
+    control, store, journal, monkeypatch, caplog
 ):
+    """v0.1 §6's rule, enforced since SPEC-v0.2 §4.2 by Control's general one about sinks."""
+
     @protect("stripe.refund", effect="refund:{payment_id}", control=control)
     def refund(payment_id: str, amount: int) -> str:
         return "re_1"
@@ -263,8 +302,8 @@ def test_an_unwritable_journal_never_fails_an_action_the_store_already_recorded(
     def refuse(_line: str) -> None:
         raise OSError("read-only file system")
 
-    monkeypatch.setattr(store.journal, "put_receipt", lambda receipt: refuse("receipt"))
-    monkeypatch.setattr(store.journal, "append_event", lambda event: refuse("event"))
+    monkeypatch.setattr(journal, "on_receipt", lambda receipt: refuse("receipt"))
+    monkeypatch.setattr(journal, "on_event", lambda event: refuse("event"))
     with context(agent="refund-agent"), caplog.at_level("WARNING", logger="ctrlrun"):
         assert refund(payment_id="txn_1", amount=200) == "re_1"
 
@@ -967,8 +1006,8 @@ def test_the_decision_a_receipt_records_survives_the_round_trip(control, store, 
     assert Receipt.from_json(receipt.to_json()) == receipt
 
 
-def test_an_event_log_writes_to_the_directory_it_was_given(tmp_path):
-    log = EventLog(tmp_path / "evidence")
+def test_a_jsonl_sink_writes_to_the_directory_it_was_given(tmp_path):
+    log = JSONLEventSink(tmp_path / "evidence")
 
     assert log.receipts_path == tmp_path / "evidence" / "receipts.jsonl"
     assert log.events_path == tmp_path / "evidence" / "events.jsonl"

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -185,19 +185,23 @@ def test_sinks_run_in_registration_order(store):
     assert order == ["first", "second"] * (len(order) // 2)
 
 
-def test_a_sink_sees_the_event_id_the_store_assigned(store):
-    """§4.1 — the id is the store's, so an export can be joined back to the record."""
+def test_a_sink_sees_the_event_id_the_store_assigned(state_store):
+    """§4.1 — the id is the store's, so an export can be joined back to the record.
+
+    Parametrized over both stores: the id comes from `lastrowid` in one and from a list
+    length in the other, and a sink cannot tell which store it is behind.
+    """
     recorder = Recorder()
-    control = _control(store, recorder)
+    control = _control(state_store, recorder)
     refund = _refund(control)
 
     with context(agent="refund-agent"):
         refund(payment_id="txn_1", amount=200)
 
     assert [event.event_id for event in recorder.events] == [
-        event.event_id for event in store.events()
+        event.event_id for event in state_store.events()
     ]
-    assert all(event.event_id is not None for event in recorder.events)
+    assert [event.event_id for event in recorder.events] == [1, 2, 3, 4, 5]
 
 
 def test_a_sink_runs_only_after_the_store_accepted_the_record(store):
@@ -357,20 +361,22 @@ def test_the_event_sink_protocol_is_structural(store):
     assert sink.seen == len(store.events()) + 1
 
 
-def test_the_store_returns_the_event_it_stored(store):
-    """§4.1 needs the assigned id, so `append_event` hands the stored event back."""
+def test_the_store_returns_the_event_it_stored(state_store):
+    """§4.1 needs the assigned id, so `append_event` hands the stored event back.
+
+    Against both stores, because this is the half of the contract `Control` depends on and
+    a double that returned the caller's own event would hide every id bug behind it.
+    """
     from datetime import UTC, datetime
 
     from ctrlrun.receipt import EventType
 
-    stored: Any = store.append_event(
+    first: Any = state_store.append_event(
         Event(type=EventType.ACTION_PROPOSED, action_id="act_1", ts=datetime.now(UTC))
     )
-
-    assert stored.event_id == 1
-    assert (
-        store.append_event(
-            Event(type=EventType.ACTION_PROPOSED, action_id="act_2", ts=datetime.now(UTC))
-        ).event_id
-        == 2
+    second: Any = state_store.append_event(
+        Event(type=EventType.ACTION_PROPOSED, action_id="act_2", ts=datetime.now(UTC))
     )
+
+    assert (first.event_id, second.event_id) == (1, 2)
+    assert [event.event_id for event in state_store.events()] == [1, 2]

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -1,0 +1,376 @@
+"""`EventSink` and `JSONLEventSink`. Build-list item 4; SPEC-v0.2 §4, acceptance test T17.
+
+The store is authoritative and everything else is a convenience export of what it already
+holds. That is the whole shape of this item: sinks run *after* the store write succeeded,
+they see the `event_id` the store assigned, and one of them failing cannot reach the caller
+— because by then the effect has committed at the remote, and an exception on a successful
+action is read by an agent as a failure, and retried.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ctrlrun import (
+    ActionDenied,
+    Control,
+    EffectState,
+    Event,
+    EventSink,
+    InMemoryStateStore,
+    JSONLEventSink,
+    Policy,
+    Receipt,
+    SQLiteStateStore,
+    context,
+    protect,
+)
+from ctrlrun.receipt import EVENTS_FILENAME, RECEIPTS_FILENAME, ReceiptResult
+
+POLICY = """
+schema: ctrlrun.policy/v1
+actions:
+  stripe.refund:
+    rules:
+      - when: { amount_lte: 500 }
+        decision: allow
+      - decision: deny
+"""
+
+
+class Recorder:
+    """A sink that remembers what it was handed, in the order it was handed it."""
+
+    def __init__(self) -> None:
+        self.events: list[Event] = []
+        self.receipts: list[Receipt] = []
+
+    def on_event(self, event: Event) -> None:
+        self.events.append(event)
+
+    def on_receipt(self, receipt: Receipt) -> None:
+        self.receipts.append(receipt)
+
+
+class Exploding:
+    """A sink that fails every way it can. Nothing it does may reach the caller (§4.2)."""
+
+    def __init__(self, error: type[BaseException] = RuntimeError) -> None:
+        self._error = error
+        self.calls = 0
+
+    def on_event(self, event: Event) -> None:
+        self.calls += 1
+        raise self._error("the sink is down")
+
+    def on_receipt(self, receipt: Receipt) -> None:
+        self.calls += 1
+        raise self._error("the sink is down")
+
+
+@pytest.fixture
+def store():
+    store = InMemoryStateStore()
+    yield store
+    store.close()
+
+
+def _control(store, *sinks: EventSink) -> Control:
+    return Control(Policy.from_yaml(POLICY), store, sinks=sinks)
+
+
+def _refund(control: Control):
+    @protect("stripe.refund", effect="refund:{payment_id}", control=control)
+    def refund(payment_id: str, amount: int) -> str:
+        return f"re_{payment_id}"
+
+    return refund
+
+
+# --- T17: a failing sink cannot affect an action ---------------------------------------
+
+
+def test_T17_a_failing_sink_does_not_stop_the_action_committing(store, caplog):
+    broken = Exploding()
+    control = _control(store, broken)
+    refund = _refund(control)
+
+    with caplog.at_level(logging.WARNING, logger="ctrlrun"), context(agent="refund-agent"):
+        assert refund(payment_id="txn_1", amount=200) == "re_txn_1"
+
+    assert store.get_effect("refund:txn_1").state is EffectState.COMMITTED
+    assert store.receipts()[-1].result is ReceiptResult.COMMITTED
+    assert broken.calls == len(store.events()) + 1  # every event, and the receipt
+
+
+def test_T17_the_warning_names_the_sink_class_and_the_record(store, caplog):
+    control = _control(store, Exploding())
+    refund = _refund(control)
+
+    with caplog.at_level(logging.WARNING, logger="ctrlrun"), context(agent="refund-agent"):
+        refund(payment_id="txn_1", amount=200)
+
+    warnings = [
+        record.getMessage() for record in caplog.records if "Exploding" in record.getMessage()
+    ]
+    assert warnings
+    assert any("ACTION_PROPOSED" in message for message in warnings)
+    assert any("ctr_" in message for message in warnings)
+
+
+def test_T17_a_working_sink_registered_after_a_failing_one_still_sees_everything(store):
+    broken, working = Exploding(), Recorder()
+    control = _control(store, broken, working)
+    refund = _refund(control)
+
+    with context(agent="refund-agent"):
+        refund(payment_id="txn_1", amount=200)
+
+    assert [event.type for event in working.events] == [event.type for event in store.events()]
+    assert [receipt.receipt_id for receipt in working.receipts] == [
+        receipt.receipt_id for receipt in store.receipts()
+    ]
+
+
+def test_T17_a_failing_sink_does_not_change_the_exception_the_caller_sees(store):
+    """§4.2 — not a decision, not an effect state, not a receipt, and not this either."""
+    control = _control(store, Exploding())
+
+    @protect("stripe.refund", effect="refund:{payment_id}", control=control)
+    def refund(payment_id: str, amount: int) -> str:
+        raise AssertionError("a denied action never executes")
+
+    with context(agent="refund-agent"), pytest.raises(ActionDenied):
+        refund(payment_id="txn_1", amount=999999)
+
+    assert store.receipts()[-1].result is ReceiptResult.DENIED
+    assert store.get_effect("refund:txn_1") is None
+
+
+def test_T17_a_base_exception_from_a_sink_propagates(store):
+    """Swallowing a KeyboardInterrupt while exporting telemetry is worse than losing it."""
+    control = _control(store, Exploding(KeyboardInterrupt))
+    refund = _refund(control)
+
+    with context(agent="refund-agent"), pytest.raises(KeyboardInterrupt):
+        refund(payment_id="txn_1", amount=200)
+
+
+# --- §4.1: when sinks run, in what order, and with what -------------------------------
+
+
+def test_sinks_run_in_registration_order(store):
+    order: list[str] = []
+
+    class Named(Recorder):
+        def __init__(self, label: str) -> None:
+            super().__init__()
+            self.label = label
+
+        def on_event(self, event: Event) -> None:
+            order.append(self.label)
+
+    control = _control(store, Named("first"), Named("second"))
+    refund = _refund(control)
+
+    with context(agent="refund-agent"):
+        refund(payment_id="txn_1", amount=200)
+
+    assert order[:2] == ["first", "second"]
+    assert order == ["first", "second"] * (len(order) // 2)
+
+
+def test_a_sink_sees_the_event_id_the_store_assigned(store):
+    """§4.1 — the id is the store's, so an export can be joined back to the record."""
+    recorder = Recorder()
+    control = _control(store, recorder)
+    refund = _refund(control)
+
+    with context(agent="refund-agent"):
+        refund(payment_id="txn_1", amount=200)
+
+    assert [event.event_id for event in recorder.events] == [
+        event.event_id for event in store.events()
+    ]
+    assert all(event.event_id is not None for event in recorder.events)
+
+
+def test_a_sink_runs_only_after_the_store_accepted_the_record(store):
+    """A sink that reads the store must find the record it was just handed (§4.1)."""
+    seen: list[bool] = []
+
+    class ReadsBack:
+        def on_event(self, event: Event) -> None:
+            seen.append(any(held.event_id == event.event_id for held in store.events()))
+
+        def on_receipt(self, receipt: Receipt) -> None:
+            seen.append(receipt.receipt_id in {held.receipt_id for held in store.receipts()})
+
+    control = _control(store, ReadsBack())
+    refund = _refund(control)
+
+    with context(agent="refund-agent"):
+        refund(payment_id="txn_1", amount=200)
+
+    assert seen and all(seen)
+
+
+def test_no_sinks_is_the_default(store):
+    """A Control built without sinks writes no files and calls nothing (§4.3)."""
+    control = Control(Policy.from_yaml(POLICY), store)
+    refund = _refund(control)
+
+    with context(agent="refund-agent"):
+        refund(payment_id="txn_1", amount=200)
+
+    assert store.receipts()[-1].result is ReceiptResult.COMMITTED
+
+
+# --- §4.3: JSONLEventSink, and the store that no longer writes files -------------------
+
+
+def test_the_store_no_longer_writes_jsonl(tmp_path):
+    """§11 — `SQLiteStateStore.journal` is removed; `Control` owns the files now."""
+    store = SQLiteStateStore(tmp_path / ".ctrlrun" / "state.db")
+    try:
+        assert not hasattr(store, "journal")
+        control = Control(Policy.from_yaml(POLICY), store)
+        refund = _refund(control)
+        with context(agent="refund-agent"):
+            refund(payment_id="txn_1", amount=200)
+
+        assert not (tmp_path / ".ctrlrun" / RECEIPTS_FILENAME).exists()
+        assert not (tmp_path / ".ctrlrun" / EVENTS_FILENAME).exists()
+    finally:
+        store.close()
+
+
+def test_the_jsonl_sink_writes_the_two_files_of_v0_1_section_6(store, tmp_path):
+    sink = JSONLEventSink(tmp_path)
+    control = _control(store, sink)
+    refund = _refund(control)
+
+    with context(agent="refund-agent"):
+        refund(payment_id="txn_1", amount=200)
+
+    assert sink.receipts_path == tmp_path / RECEIPTS_FILENAME
+    assert sink.events_path == tmp_path / EVENTS_FILENAME
+    receipts = sink.receipts_path.read_text(encoding="utf-8").strip().splitlines()
+    events = sink.events_path.read_text(encoding="utf-8").strip().splitlines()
+    assert json.loads(receipts[-1])["result"] == "committed"
+    assert [json.loads(line)["event_id"] for line in events] == [1, 2, 3, 4, 5]
+
+
+def test_the_jsonl_sink_round_trips_the_receipt_the_store_holds(store, tmp_path):
+    """The file form is lossless to the millisecond `iso_timestamp` records (v0.1 §6.1), so
+    the clock is pinned rather than the assertion loosened."""
+    from datetime import UTC, datetime
+
+    pinned = datetime(2026, 9, 3, 10, 12, 1, tzinfo=UTC)
+    sink = JSONLEventSink(tmp_path)
+    control = Control(Policy.from_yaml(POLICY), store, sinks=[sink], clock=lambda: pinned)
+    refund = _refund(control)
+
+    with context(agent="refund-agent"):
+        refund(payment_id="txn_1", amount=200)
+
+    (line,) = sink.receipts_path.read_text(encoding="utf-8").strip().splitlines()
+    assert Receipt.from_json(line) == store.receipts()[0]
+
+
+def test_control_from_file_installs_the_jsonl_sink_where_v0_1_put_it(tmp_path, monkeypatch):
+    """§4.3 — existing evidence directories are unchanged by this refactor."""
+    (tmp_path / "ctrlrun.yaml").write_text(POLICY, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("CTRLRUN_CONFIG", raising=False)
+    monkeypatch.delenv("CTRLRUN_STATE", raising=False)
+
+    control = Control.from_file()
+    try:
+        refund = _refund(control)
+        with context(agent="refund-agent"):
+            refund(payment_id="txn_1", amount=200)
+    finally:
+        control.store.close()
+
+    assert (tmp_path / ".ctrlrun" / RECEIPTS_FILENAME).is_file()
+    assert (tmp_path / ".ctrlrun" / EVENTS_FILENAME).is_file()
+
+
+def test_an_unwritable_jsonl_sink_never_fails_an_action(store, tmp_path, caplog):
+    """v0.1 §6's rule, now enforced by §4.2's general one rather than by the store."""
+    sink = JSONLEventSink(tmp_path / "nowhere")
+
+    def refuse(path: Path, line: str) -> None:
+        raise OSError("read-only file system")
+
+    sink._append = refuse  # type: ignore[method-assign]
+    control = _control(store, sink)
+    refund = _refund(control)
+
+    with caplog.at_level(logging.WARNING, logger="ctrlrun"), context(agent="refund-agent"):
+        assert refund(payment_id="txn_1", amount=200) == "re_txn_1"
+
+    assert store.get_effect("refund:txn_1").state is EffectState.COMMITTED
+    assert [record for record in caplog.records if "JSONLEventSink" in record.getMessage()]
+
+
+def test_a_second_sink_on_the_same_directory_appends_rather_than_truncates(store, tmp_path):
+    first, second = JSONLEventSink(tmp_path), JSONLEventSink(tmp_path)
+    refund_one = _refund(_control(store, first))
+    with context(agent="refund-agent"):
+        refund_one(payment_id="txn_1", amount=200)
+
+    refund_two = _refund(_control(store, second))
+    with context(agent="refund-agent"):
+        refund_two(payment_id="txn_2", amount=200)
+
+    assert len(second.receipts_path.read_text(encoding="utf-8").strip().splitlines()) == 2
+
+
+def test_the_event_sink_protocol_is_structural(store):
+    """`EventSink` is a Protocol: anything with the two methods is one (§4.1)."""
+
+    class Anything:
+        def __init__(self) -> None:
+            self.seen = 0
+
+        def on_event(self, event: Event) -> None:
+            self.seen += 1
+
+        def on_receipt(self, receipt: Receipt) -> None:
+            self.seen += 1
+
+    sink: EventSink = Anything()
+    control = _control(store, sink)
+    refund = _refund(control)
+
+    with context(agent="refund-agent"):
+        refund(payment_id="txn_1", amount=200)
+
+    assert isinstance(sink, Anything)
+    assert sink.seen == len(store.events()) + 1
+
+
+def test_the_store_returns_the_event_it_stored(store):
+    """§4.1 needs the assigned id, so `append_event` hands the stored event back."""
+    from datetime import UTC, datetime
+
+    from ctrlrun.receipt import EventType
+
+    stored: Any = store.append_event(
+        Event(type=EventType.ACTION_PROPOSED, action_id="act_1", ts=datetime.now(UTC))
+    )
+
+    assert stored.event_id == 1
+    assert (
+        store.append_event(
+            Event(type=EventType.ACTION_PROPOSED, action_id="act_2", ts=datetime.now(UTC))
+        ).event_id
+        == 2
+    )


### PR DESCRIPTION
Build-list item 4. SPEC-v0.2 §4, acceptance test T17.

## The protocol

```python
class EventSink(Protocol):
    def on_event(self, event: Event) -> None: ...
    def on_receipt(self, receipt: Receipt) -> None: ...

Control(..., sinks: Sequence[EventSink] = ())
```

Sinks are called **after** the authoritative store write for that record has succeeded, in registration order, with the `event_id` the store assigned.

## A sink never raises into the kernel

`Control` catches every `Exception`, logs a warning naming the sink's class and the record, and carries on with the remaining sinks. By the time a sink runs, the effect has committed at the remote and the record is durable — raising there would reach the caller as an exception on a **successful** action, which an agent reads as a failure and retries. That is the one mistake this library exists to prevent, and it is not going to be introduced by a telemetry exporter.

A `BaseException` that is not an `Exception` still propagates: swallowing a `KeyboardInterrupt` while exporting is worse than losing the export.

## JSONL moves out of the store

`JSONLEventSink` is the old `EventLog` under the sink interface. `SQLiteStateStore.journal` and the `_mirror` helper are gone. `Control.from_file()` installs `JSONLEventSink(state_path().parent)`, so the two files of v0.1 §6 land exactly where v0.1 put them and an existing evidence directory is unchanged.

The store's own `events` and `receipts` tables are **not** sinks. They are written inside the store, in its transaction, before any sink runs. Demoting the authoritative write to one of a list of best-effort exporters would leave "the store is authoritative" as a sentence with nothing behind it.

## Three consequences worth reading

**`ctrlrun demo` had to be fixed, not just its tests.** The demo builds its own `Control`, so after this change it printed paths to two files it no longer wrote. It installs a sink on its own evidence directory now. The T11 tests caught it.

**`StateStore.append_event` now returns the event as stored**, where v0.1 returned `None`. §4.1 requires a sink be called with the assigned `event_id` and the store is the only thing that knows it. That signature is frozen in SPEC-v0.1 §8, so I updated §8 *and* §11 in this PR per `CLAUDE.md`. Callers that ignore the return value are unaffected.

**The eight-process JSONL test got stronger.** Each worker now installs its own `JSONLEventSink` on the shared directory, so the interleaved appends are no longer serialized by anything the store does — more of that guarantee under test, not less.

## Mutation table — §4, and a gap it found

| # | Rule | Result |
|---|---|---|
| M1 | Control catches every `Exception` a sink raises | red |
| M2 | the warning names the sink's class and the record | red |
| M3 | the remaining sinks still run | red |
| M4 | a non-`Exception` `BaseException` propagates | red |
| M5 | events reach the sinks | red |
| M6 | receipts reach the sinks | red |
| M7 | sinks run in registration order | red |
| M8 | the sink sees the `event_id` **SQLite** assigned | **green first — gap**, now red |
| M9 | the in-memory store assigns an id too | red |
| M10 | sinks run *after* the store write | red |
| M11 | `Control.from_file` installs the JSONL sink | red |
| M12 | the JSONL sink writes both files where v0.1 put them | red |
| M13 | the store no longer writes files | red |
| M14 | the demo still writes the evidence it prints | red |

M8 is the interesting one, and it is `CLAUDE.md`'s test-double rule biting from the other side: `SQLiteStateStore.append_event` could have returned the caller's own event, `event_id` and all missing, and stayed green — because both tests that checked the assigned id ran against `InMemoryStateStore`. The id comes from `lastrowid` in one store and a list length in the other, and a sink cannot tell which one it is behind, so both tests now run against both.

## Verification

867 tests pass (848 → 867), `mypy --strict src/`, `ruff check` and `ruff format --check` clean. Every SPEC-v0.1 §7 acceptance test still passes, `ctrlrun demo` still writes and prints both files, and the eight-process concurrency test is unchanged in intent.