### PR TITLE
item 5: ctrlrun inspect

### DIFF
--- a/docs/SPEC-v0.2.md
+++ b/docs/SPEC-v0.2.md
@@ -1309,6 +1309,7 @@ Policy.mcp_options(action_name: str) -> McpOptions
 class McpOptions:
     not_executed_on_error: bool = False
 
+StateStore.approvals_for(action_hash: str) -> tuple[ApprovalRecord, ...]
 StateStore.find_granted_approval(action_hash: str) -> Approval | None
 StateStore.find_denied_request(action_hash: str) -> ApprovalRequest | None
 StateStore.resolve_effect(effect_key, state, *, resolved_by: str) -> None

--- a/src/ctrlrun/cli/main.py
+++ b/src/ctrlrun/cli/main.py
@@ -11,12 +11,17 @@ agent is waiting on in another shell.
 
 from __future__ import annotations
 
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Final
+from typing import Any, Final
 
 import click
 
+from ..action import Principal
+from ..approval import ApprovalRecord
 from ..control import DEFAULT_STATE_DIR, state_path
 from ..effect import RESOLVED_BY_HUMAN, EffectRecord, EffectState
 from ..errors import CTRLRunError
@@ -27,6 +32,9 @@ from .demo import run_demo
 
 #: Who the CLI records as the answer's author. Free text in v0.1 (SPEC-v0.1 §4.1).
 CLI_APPROVER: Final = "cli:local"
+
+#: SPEC-v0.2 §5 — the schema of one `ctrlrun inspect --json` document.
+INSPECTION_SCHEMA: Final = "ctrlrun.inspection/v1"
 
 #: `ctrlrun init` writes this. It is `ctrlrun.example.yaml` in the repository, and
 #: `test_the_shipped_example_policy_is_the_one_in_the_repository` keeps the two identical.
@@ -240,6 +248,198 @@ def resolve(effect_key: str, committed: bool, failed: bool) -> None:
     click.echo(f"{effect_key} resolved {record.state} by {CLI_APPROVER}")
     if record.state is EffectState.FAILED:
         click.echo("a retry of this effect is now permitted")
+
+
+@main.command()
+@click.argument("action_id")
+@click.option("--json", "as_json", is_flag=True, help="Emit one JSON object instead.")
+def inspect(action_id: str, as_json: bool) -> None:
+    """Show one action's whole history: proposal, decision, approval, effect, receipt."""
+    store = _store()
+    try:
+        events = tuple(event for event in store.events() if event.action_id == action_id)
+        receipt = next((found for found in store.receipts() if found.action_id == action_id), None)
+    except CTRLRunError as exc:
+        raise _fail(exc) from exc
+
+    if not events and receipt is None:
+        # SPEC-v0.2 §5 — non-zero, on stderr, with nothing on stdout, so a script cannot
+        # mistake "no such action" for "an action with no events". Matched exactly: no
+        # prefixes and no globs, as v0.1 §3.1 matches an action name.
+        raise click.ClickException(f"no action {action_id}")
+
+    approvals = _approvals_for(store, receipt, events)
+    effect = _effect_of(store, receipt, events)
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "schema": INSPECTION_SCHEMA,
+                    "action_id": action_id,
+                    "receipt": None if receipt is None else receipt.to_dict(),
+                    "effect": None if effect is None else _effect_dict(effect),
+                    "approvals": [_approval_dict(record) for record in approvals],
+                    "events": [event.to_dict() for event in events],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+        return
+    for line in _inspection_lines(action_id, receipt, effect, approvals, events):
+        click.echo(line)
+
+
+def _approvals_for(
+    store: SQLiteStateStore, receipt: Receipt | None, events: tuple[Event, ...]
+) -> tuple[ApprovalRecord, ...]:
+    """Every approval carrying this action's hash (SPEC-v0.2 §5).
+
+    The hash comes from the receipt, or from `ACTION_PROPOSED` for an action still awaiting
+    a human — which has no receipt yet (v0.1 §6.1) and is exactly the case where the pending
+    request is the only thing there is to show.
+    """
+    action_hash = receipt.action_hash if receipt is not None else None
+    if action_hash is None:
+        action_hash = next(
+            (
+                str(event.data["action_hash"])
+                for event in events
+                if event.type is EventType.ACTION_PROPOSED and "action_hash" in event.data
+            ),
+            None,
+        )
+    if action_hash is None:
+        return ()
+    return store.approvals_for(action_hash)
+
+
+def _effect_of(
+    store: SQLiteStateStore, receipt: Receipt | None, events: tuple[Event, ...]
+) -> EffectRecord | None:
+    """This action's effect record, or `None` where it has no effect key (SPEC-v0.2 §5)."""
+    key = receipt.effect_key if receipt is not None else None
+    if key is None:
+        key = next((event.effect_key for event in events if event.effect_key), None)
+    return None if key is None else store.get_effect(key)
+
+
+def _inspection_lines(
+    action_id: str,
+    receipt: Receipt | None,
+    effect: EffectRecord | None,
+    approvals: tuple[ApprovalRecord, ...],
+    events: tuple[Event, ...],
+) -> list[str]:
+    """The header block and the event timeline of SPEC-v0.2 §5."""
+    proposed = _proposed_action(receipt, approvals)
+    name = "-" if proposed is None else proposed.name
+    lines = [f"{action_id}  {name}", ""]
+    if proposed is not None:
+        user = "" if proposed.principal.user is None else f" (user: {proposed.principal.user})"
+        lines += [
+            f"principal   {proposed.principal.agent}{user}",
+            f"resource    {proposed.resource or '-'}",
+            f"environment {proposed.environment}",
+            f"arguments   {json.dumps(dict(proposed.arguments), ensure_ascii=False)}",
+        ]
+    if receipt is not None:
+        lines.append(f"decision    {receipt.decision}  ({receipt.decision_reason})")
+    for record in approvals:
+        lines.append(f"approval    {_approval_summary(record)}")
+    if effect is not None:
+        lines.append(f"effect      {effect.effect_key}  {effect.state}  attempt {effect.attempt}")
+    if receipt is not None:
+        lines.append(f"receipt     {receipt.receipt_id}  {receipt.result}")
+    else:
+        # v0.1 §6.1 — an action suspended awaiting a human is not terminal, so there is no
+        # receipt to show, and saying so beats an empty line the reader has to interpret.
+        lines.append("receipt     -  (awaiting a human)")
+    lines.append("")
+    lines += [f"  {_event_line(event)}" for event in events]
+    return lines
+
+
+@dataclass(frozen=True)
+class _Proposal:
+    """The header fields of SPEC-v0.2 §5, from whichever record still holds them."""
+
+    name: str
+    principal: Principal
+    resource: str | None
+    environment: str
+    arguments: Mapping[str, Any]
+
+
+def _proposed_action(
+    receipt: Receipt | None, approvals: tuple[ApprovalRecord, ...]
+) -> _Proposal | None:
+    """The action as proposed: from the receipt, else from an approval request.
+
+    An action still awaiting a human has no receipt, and an `Event` carries neither the
+    action's name nor its arguments — but the approval request stores the whole `Action`
+    (v0.1 §4.1), which is the only reason a suspended action can be inspected at all. The two
+    sources spell the same fields differently (`Receipt.action` is `Action.name`), so they
+    are normalized here rather than duck-typed at the call site.
+    """
+    if receipt is not None:
+        return _Proposal(
+            name=receipt.action,
+            principal=receipt.principal,
+            resource=receipt.resource,
+            environment=receipt.environment,
+            arguments=receipt.arguments,
+        )
+    if not approvals:
+        return None
+    action = approvals[0].request.action
+    return _Proposal(
+        name=action.name,
+        principal=action.principal,
+        resource=action.resource,
+        environment=action.environment,
+        arguments=action.canonical_arguments,
+    )
+
+
+def _approval_summary(record: ApprovalRecord) -> str:
+    answered = "" if record.approver is None else f" by {record.approver}"
+    return f"{record.approval_id}  {record.status}{answered}"
+
+
+def _event_line(event: Event) -> str:
+    rendered = " ".join(f"{key}={value}" for key, value in event.data.items())
+    return f"{event.event_id:>3}  {iso_timestamp(event.ts)}  {event.type:<28}{rendered}".rstrip()
+
+
+def _effect_dict(record: EffectRecord) -> dict[str, Any]:
+    """The effect record as plain JSON data, enums by value (v0.1 §6.1)."""
+    return {
+        "effect_key": record.effect_key,
+        "state": str(record.state),
+        "action_id": record.action_id,
+        "attempt": record.attempt,
+        "created_at": iso_timestamp(record.created_at),
+        "updated_at": iso_timestamp(record.updated_at),
+        "lease_expires_at": (
+            None if record.lease_expires_at is None else iso_timestamp(record.lease_expires_at)
+        ),
+        "error": record.error,
+    }
+
+
+def _approval_dict(record: ApprovalRecord) -> dict[str, Any]:
+    """One approval record as plain JSON data, enums by value (v0.1 §6.1)."""
+    return {
+        "approval_id": record.approval_id,
+        "action_hash": record.action_hash,
+        "status": str(record.status),
+        "approver": record.approver,
+        "created_at": iso_timestamp(record.request.created_at),
+        "expires_at": iso_timestamp(record.expires_at),
+        "granted_at": None if record.granted_at is None else iso_timestamp(record.granted_at),
+        "consumed_at": None if record.consumed_at is None else iso_timestamp(record.consumed_at),
+    }
 
 
 def _receipt_line(receipt: Receipt) -> str:

--- a/src/ctrlrun/state.py
+++ b/src/ctrlrun/state.py
@@ -346,6 +346,18 @@ class StateStore(ApprovalStore, Protocol):
         """Every effect record, oldest first, optionally narrowed to one state."""
         ...
 
+    def approvals_for(self, action_hash: str) -> tuple[ApprovalRecord, ...]:
+        """Every approval record carrying `action_hash`, oldest first (SPEC-v0.2 §5).
+
+        Every one, not only the consumed one: an invalidated, expired or denied request is
+        part of an action's history, and `ctrlrun inspect` exists to show that history.
+
+        On `StateStore` rather than on `ApprovalStore`, which is deliberately the slice an
+        approval provider depends on. A provider answers one request; it has no business
+        enumerating them.
+        """
+        ...
+
     def append_event(self, event: Event) -> Event:
         """Append an event, assigning it the next `event_id`, and return it as stored.
 
@@ -420,6 +432,12 @@ class InMemoryStateStore:
     def get_approval(self, approval_id: str) -> ApprovalRecord | None:
         with self._lock:
             return self._approvals.get(approval_id)
+
+    def approvals_for(self, action_hash: str) -> tuple[ApprovalRecord, ...]:
+        with self._lock:
+            return tuple(
+                record for record in self._approvals.values() if record.action_hash == action_hash
+            )
 
     def grant_approval(self, approval_id: str, approver: str) -> Approval:
         approver = _approver(approver)
@@ -741,6 +759,15 @@ class SQLiteStateStore:
 
     def get_approval(self, approval_id: str) -> ApprovalRecord | None:
         return self._read_approval(self._connection(), approval_id)
+
+    def approvals_for(self, action_hash: str) -> tuple[ApprovalRecord, ...]:
+        connection = self._connection()
+        rows = connection.execute(
+            "SELECT approval_id FROM approvals WHERE action_hash=? ORDER BY rowid",
+            (action_hash,),
+        ).fetchall()
+        found = (self._read_approval(connection, row["approval_id"]) for row in rows)
+        return tuple(record for record in found if record is not None)
 
     def grant_approval(self, approval_id: str, approver: str) -> Approval:
         approver = _approver(approver)

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -942,6 +942,7 @@ def test_an_empty_CTRLRUN_CONFIG_is_refused(workspace, monkeypatch):
 
 
 def test_the_cli_offers_exactly_the_commands_the_spec_freezes():
+    """SPEC-v0.1 §8, plus what SPEC-v0.2 §11 adds. `gateway` arrives with item 6."""
     assert set(main.commands) == {
         "init",
         "demo",
@@ -950,6 +951,7 @@ def test_the_cli_offers_exactly_the_commands_the_spec_freezes():
         "receipts",
         "effects",
         "resolve",
+        "inspect",
     }
 
 

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -222,16 +222,23 @@ def test_the_action_id_is_matched_exactly_never_as_a_prefix(refund, remote, stor
 
 
 def test_the_receipt_is_null_for_an_action_still_awaiting_a_human(control, store):
-    """§5, and v0.1 §6.1: a suspended action is not terminal, so it has no receipt yet."""
+    """§5, and v0.1 §6.1: a suspended action is not terminal, so it has no receipt yet.
+
+    Null because *this* action has none. Another action commits first and writes one, so a
+    lookup that returned any receipt rather than this action's would be caught here.
+    """
 
     @protect("stripe.refund", effect="refund:{payment_id}", control=control)
     def refund(payment_id: str, amount: int) -> str:
         return "re_1"
 
+    with context(agent="refund-agent"):
+        refund(payment_id="txn_committed", amount=200)
     with context(agent="refund-agent"), pytest.raises(ApprovalRequired):
         refund(payment_id="txn_2", amount=2000)
 
-    action_id = store.events()[0].action_id
+    assert store.receipts(), "another action must hold a receipt for this to prove anything"
+    action_id = store.events()[-1].action_id
     document = json.loads(_ok(_cli("inspect", action_id, "--json")).stdout)
 
     assert document["receipt"] is None
@@ -244,13 +251,25 @@ def test_the_receipt_is_null_for_an_action_still_awaiting_a_human(control, store
 
 
 def test_the_effect_is_null_for_an_action_with_no_effect_key(control, store):
-    @protect("stripe.refund", control=control)
-    def refund(payment_id: str, amount: int) -> str:
+    """Null because *this* action has none — not because the store happens to be empty.
+
+    A keyed action runs first, so a lookup that fell back to any record rather than to this
+    action's would find one and be caught here.
+    """
+
+    @protect("stripe.refund", effect="refund:{payment_id}", control=control)
+    def keyed(payment_id: str, amount: int) -> str:
         return "re_1"
 
-    with context(agent="refund-agent"):
-        refund(payment_id="txn_1", amount=200)
+    @protect("stripe.refund", control=control)
+    def keyless(payment_id: str, amount: int) -> str:
+        return "re_2"
 
+    with context(agent="refund-agent"):
+        keyed(payment_id="txn_1", amount=200)
+        keyless(payment_id="txn_2", amount=200)
+
+    assert store.list_effects(), "the store must hold an effect record for this to prove anything"
     action_id = store.receipts()[-1].action_id
     document = json.loads(_ok(_cli("inspect", action_id, "--json")).stdout)
 
@@ -312,6 +331,27 @@ def test_the_human_output_shows_who_resolved_an_ambiguous_effect(refund, remote,
 
     assert "EFFECT_RESOLVED" in output
     assert "resolved_by=human" in output
+
+
+def test_the_human_output_of_a_suspended_action_comes_from_its_approval_request(control, store):
+    """An action awaiting a human has no receipt, and an Event carries neither its name nor
+    its arguments. The approval request holds the whole Action (v0.1 §4.1), and that is the
+    only reason this header can be rendered at all."""
+
+    @protect("stripe.refund", effect="refund:{payment_id}", control=control)
+    def refund(payment_id: str, amount: int) -> str:
+        return "re_1"
+
+    with context(agent="refund-agent", user="alice"), pytest.raises(ApprovalRequired):
+        refund(payment_id="txn_2", amount=2000)
+
+    action_id = store.events()[0].action_id
+    output = _ok(_cli("inspect", action_id)).stdout
+
+    assert "stripe.refund" in output.splitlines()[0]
+    assert "principal   refund-agent (user: alice)" in output
+    assert '"payment_id": "txn_2"' in output
+    assert "receipt     -  (awaiting a human)" in output
 
 
 def test_the_human_output_shows_the_approval_and_who_answered(control, store):

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1,0 +1,364 @@
+"""`ctrlrun inspect <action_id>`. Build-list item 5; SPEC-v0.2 §5, acceptance test T18.
+
+One action's whole history in one place: what was proposed, what the policy said, which
+approval was involved, what happened to the effect, and what the receipt records. The
+evidence already holds all of it, in four places; this is the command that joins them.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from ctrlrun import (
+    AmbiguousEffect,
+    ApprovalRequired,
+    Control,
+    Policy,
+    SQLiteStateStore,
+    context,
+    protect,
+    with_approval,
+)
+from ctrlrun.cli.main import main
+from ctrlrun.receipt import JSONLEventSink
+
+POLICY = """
+schema: ctrlrun.policy/v1
+actions:
+  stripe.refund:
+    rules:
+      - when: { amount_lte: 500 }
+        decision: allow
+      - when: { amount_lte: 5000 }
+        decision: approve
+      - decision: deny
+"""
+
+INSPECTION_SCHEMA = "ctrlrun.inspection/v1"
+
+
+class Remote:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.lose = False
+
+    def refund(self, payment_id: str) -> str:
+        self.calls += 1
+        if self.lose:
+            raise TimeoutError("no response from api.stripe.com after 30s")
+        return f"re_{payment_id}"
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    (tmp_path / "ctrlrun.yaml").write_text(POLICY, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("CTRLRUN_CONFIG", raising=False)
+    monkeypatch.delenv("CTRLRUN_STATE", raising=False)
+    return tmp_path
+
+
+@pytest.fixture
+def store(workspace):
+    store = SQLiteStateStore(workspace / ".ctrlrun" / "state.db")
+    yield store
+    store.close()
+
+
+@pytest.fixture
+def control(workspace, store):
+    return Control(
+        Policy.from_file(workspace / "ctrlrun.yaml"),
+        store,
+        sinks=[JSONLEventSink(workspace / ".ctrlrun")],
+    )
+
+
+@pytest.fixture
+def remote():
+    return Remote()
+
+
+@pytest.fixture
+def refund(control, remote):
+    @protect("stripe.refund", effect="refund:{payment_id}", control=control)
+    def refund(payment_id: str, amount: int) -> str:
+        return remote.refund(payment_id)
+
+    return refund
+
+
+def _cli(*args):
+    return CliRunner().invoke(main, list(args))
+
+
+def _ok(result):
+    assert result.exit_code == 0, f"{result.output}\n{result.exception!r}"
+    return result
+
+
+def _lost_response(refund, remote, store):
+    """T1's scenario: the remote commits and the response goes missing."""
+    remote.lose = True
+    with context(agent="refund-agent", user="alice"), pytest.raises(TimeoutError):
+        refund(payment_id="txn_1", amount=200)
+    return store.receipts()[-1].action_id
+
+
+# --- T18: the JSON document ------------------------------------------------------------
+
+
+def test_T18_inspect_json_emits_the_inspection_schema(refund, remote, store):
+    action_id = _lost_response(refund, remote, store)
+
+    document = json.loads(_ok(_cli("inspect", action_id, "--json")).stdout)
+
+    assert document["schema"] == INSPECTION_SCHEMA
+    assert document["action_id"] == action_id
+
+
+def test_T18_inspect_json_carries_the_receipt(refund, remote, store):
+    action_id = _lost_response(refund, remote, store)
+
+    document = json.loads(_ok(_cli("inspect", action_id, "--json")).stdout)
+
+    assert document["receipt"]["receipt_id"] == store.receipts()[-1].receipt_id
+    assert document["receipt"]["result"] == "ambiguous"
+
+
+def test_T18_inspect_json_carries_the_effect_record(refund, remote, store):
+    action_id = _lost_response(refund, remote, store)
+
+    document = json.loads(_ok(_cli("inspect", action_id, "--json")).stdout)
+
+    assert document["effect"]["effect_key"] == "refund:txn_1"
+    assert document["effect"]["state"] == "ambiguous"
+    assert document["effect"]["attempt"] == 1
+
+
+def test_T18_inspect_json_carries_the_events_in_event_id_order(refund, remote, store):
+    action_id = _lost_response(refund, remote, store)
+
+    document = json.loads(_ok(_cli("inspect", action_id, "--json")).stdout)
+
+    ids = [event["event_id"] for event in document["events"]]
+    assert ids == sorted(ids)
+    assert [event["type"] for event in document["events"]] == [
+        "ACTION_PROPOSED",
+        "POLICY_EVALUATED",
+        "EFFECT_RESERVED",
+        "EXECUTION_STARTED",
+        "EXECUTION_AMBIGUOUS",
+    ]
+
+
+def test_T18_inspect_json_carries_every_approval_for_the_action_hash(control, store):
+    """§5 — every approval carrying this hash, not only the consumed one: an invalidated or
+    expired request is part of the history."""
+
+    @protect("stripe.refund", effect="refund:{payment_id}", control=control)
+    def refund(payment_id: str, amount: int) -> str:
+        return "re_1"
+
+    with context(agent="refund-agent"), pytest.raises(ApprovalRequired) as first:
+        refund(payment_id="txn_2", amount=2000)
+    with context(agent="refund-agent"), pytest.raises(ApprovalRequired) as second:
+        refund(payment_id="txn_2", amount=2000)
+
+    _ok(_cli("approve", second.value.request_id))
+    with context(agent="refund-agent"), with_approval(second.value.request_id):
+        refund(payment_id="txn_2", amount=2000)
+
+    action_id = store.receipts()[-1].action_id
+    document = json.loads(_ok(_cli("inspect", action_id, "--json")).stdout)
+
+    ids = {approval["approval_id"] for approval in document["approvals"]}
+    assert ids == {first.value.request_id, second.value.request_id}
+    statuses = {approval["approval_id"]: approval["status"] for approval in document["approvals"]}
+    assert statuses[second.value.request_id] == "consumed"
+    assert statuses[first.value.request_id] == "pending"
+
+
+def test_T18_every_enum_renders_by_value(refund, remote, store):
+    action_id = _lost_response(refund, remote, store)
+
+    raw = _ok(_cli("inspect", action_id, "--json")).stdout
+
+    assert "EffectState." not in raw
+    assert "ReceiptResult." not in raw
+    assert "Decision." not in raw
+    assert "ApprovalStatus." not in raw
+    assert "EventType." not in raw
+
+
+def test_T18_an_unknown_action_id_exits_non_zero_with_empty_stdout(store, workspace):
+    result = _cli("inspect", "act_nothing", "--json")
+
+    assert result.exit_code != 0
+    assert result.stdout == ""
+    assert "act_nothing" in result.stderr
+
+
+def test_T18_an_unknown_action_id_is_non_zero_in_human_form_too(store, workspace):
+    result = _cli("inspect", "act_nothing")
+
+    assert result.exit_code != 0
+    assert result.stdout == ""
+
+
+# --- §5: the matching rule, and the two nullable fields --------------------------------
+
+
+def test_the_action_id_is_matched_exactly_never_as_a_prefix(refund, remote, store):
+    action_id = _lost_response(refund, remote, store)
+
+    result = _cli("inspect", action_id[:12], "--json")
+
+    assert result.exit_code != 0
+    assert result.stdout == ""
+
+
+def test_the_receipt_is_null_for_an_action_still_awaiting_a_human(control, store):
+    """§5, and v0.1 §6.1: a suspended action is not terminal, so it has no receipt yet."""
+
+    @protect("stripe.refund", effect="refund:{payment_id}", control=control)
+    def refund(payment_id: str, amount: int) -> str:
+        return "re_1"
+
+    with context(agent="refund-agent"), pytest.raises(ApprovalRequired):
+        refund(payment_id="txn_2", amount=2000)
+
+    action_id = store.events()[0].action_id
+    document = json.loads(_ok(_cli("inspect", action_id, "--json")).stdout)
+
+    assert document["receipt"] is None
+    assert document["approvals"][0]["status"] == "pending"
+    assert [event["type"] for event in document["events"]] == [
+        "ACTION_PROPOSED",
+        "POLICY_EVALUATED",
+        "APPROVAL_REQUESTED",
+    ]
+
+
+def test_the_effect_is_null_for_an_action_with_no_effect_key(control, store):
+    @protect("stripe.refund", control=control)
+    def refund(payment_id: str, amount: int) -> str:
+        return "re_1"
+
+    with context(agent="refund-agent"):
+        refund(payment_id="txn_1", amount=200)
+
+    action_id = store.receipts()[-1].action_id
+    document = json.loads(_ok(_cli("inspect", action_id, "--json")).stdout)
+
+    assert document["effect"] is None
+    assert document["receipt"]["effect_key"] is None
+
+
+def test_the_json_is_one_object_on_stdout(refund, remote, store):
+    """A script reads this; one object, parseable whole, and nothing else printed."""
+    action_id = _lost_response(refund, remote, store)
+
+    stdout = _ok(_cli("inspect", action_id, "--json")).stdout
+
+    assert isinstance(json.loads(stdout), dict)
+
+
+# --- §5: the human rendering -----------------------------------------------------------
+
+
+def test_the_human_output_leads_with_the_action_id_and_name(refund, remote, store):
+    action_id = _lost_response(refund, remote, store)
+
+    output = _ok(_cli("inspect", action_id)).stdout
+
+    assert output.splitlines()[0].startswith(action_id)
+    assert "stripe.refund" in output.splitlines()[0]
+
+
+def test_the_human_output_shows_the_header_fields_the_spec_names(refund, remote, store):
+    action_id = _lost_response(refund, remote, store)
+
+    output = _ok(_cli("inspect", action_id)).stdout
+
+    assert "principal   refund-agent (user: alice)" in output
+    assert "environment production" in output
+    assert "decision    allow" in output
+    assert "effect      refund:txn_1  ambiguous  attempt 1" in output
+    assert "receipt     ctr_" in output
+    assert '"payment_id": "txn_1"' in output
+
+
+def test_the_human_output_lists_every_event_with_its_id_and_timestamp(refund, remote, store):
+    action_id = _lost_response(refund, remote, store)
+
+    output = _ok(_cli("inspect", action_id)).stdout
+
+    for event in store.events():
+        assert f"{event.event_id}" in output
+        assert str(event.type) in output
+    assert "EXECUTION_AMBIGUOUS" in output
+
+
+def test_the_human_output_shows_who_resolved_an_ambiguous_effect(refund, remote, store):
+    """SPEC-v0.2 §2.2 — `ctrlrun inspect` MUST show `resolved_by`."""
+    action_id = _lost_response(refund, remote, store)
+    _ok(_cli("resolve", "refund:txn_1", "--failed"))
+
+    output = _ok(_cli("inspect", action_id)).stdout
+
+    assert "EFFECT_RESOLVED" in output
+    assert "resolved_by=human" in output
+
+
+def test_the_human_output_shows_the_approval_and_who_answered(control, store):
+    @protect("stripe.refund", effect="refund:{payment_id}", control=control)
+    def refund(payment_id: str, amount: int) -> str:
+        return "re_1"
+
+    with context(agent="refund-agent"), pytest.raises(ApprovalRequired) as pending:
+        refund(payment_id="txn_2", amount=2000)
+    _ok(_cli("approve", pending.value.request_id))
+    with context(agent="refund-agent"), with_approval(pending.value.request_id):
+        refund(payment_id="txn_2", amount=2000)
+
+    action_id = store.receipts()[-1].action_id
+    output = _ok(_cli("inspect", action_id)).stdout
+
+    assert pending.value.request_id in output
+    assert "cli:local" in output
+    assert "consumed" in output
+
+
+def test_a_blocked_retry_inspects_as_its_own_action(refund, remote, store):
+    """Each attempt is a distinct action (v0.1 §5.3), so each has its own history."""
+    _lost_response(refund, remote, store)
+    remote.lose = False
+    with context(agent="refund-agent"), pytest.raises(AmbiguousEffect):
+        refund(payment_id="txn_1", amount=200)
+
+    first, second = (receipt.action_id for receipt in store.receipts())
+    assert first != second
+
+    document = json.loads(_ok(_cli("inspect", second, "--json")).stdout)
+    assert document["receipt"]["result"] == "blocked"
+    assert document["effect"]["state"] == "ambiguous"
+    assert [event["type"] for event in document["events"]] == [
+        "ACTION_PROPOSED",
+        "POLICY_EVALUATED",
+        "EFFECT_RESERVATION_REFUSED",
+    ]
+
+
+def test_inspect_reads_the_store_the_env_var_names(refund, remote, store, tmp_path, monkeypatch):
+    """Every CLI command works on the store an agent is using (v0.1 §8)."""
+    action_id = _lost_response(refund, remote, store)
+    monkeypatch.setenv("CTRLRUN_STATE", str(tmp_path / "elsewhere.db"))
+
+    result = _cli("inspect", action_id, "--json")
+
+    assert result.exit_code != 0
+    assert result.stdout == ""


### PR DESCRIPTION
Build-list item 5. SPEC-v0.2 §5, acceptance test T18.

One action's whole history in one place. The evidence already held all of it — receipt, effect record, approvals, events — in four places that had to be joined by hand.

```
act_52eccc7fc51512b73a54e93217ca34c6  stripe.refund

principal   refund-agent (user: alice)
resource    payment:txn_8231
environment production
arguments   {"amount": 2000, "currency": "EUR", "payment_id": "txn_8231"}
decision    allow  (rule[0])
effect      refund:txn_8231  ambiguous  attempt 1
receipt     ctr_7cc862f2e54afb0b941f0af63e9c7bd9  ambiguous

    1  2026-09-03T17:10:48.357Z  ACTION_PROPOSED       action_hash=sha256:fdfe5539…
    2  2026-09-03T17:10:48.357Z  POLICY_EVALUATED      decision=allow reason=rule[0]
    3  2026-09-03T17:10:48.358Z  EFFECT_RESERVED       attempt=1 lease_expires_at=…
    4  2026-09-03T17:10:48.358Z  EXECUTION_STARTED
    5  2026-09-03T17:10:48.358Z  EXECUTION_AMBIGUOUS   error=TimeoutError: no response…
```

`--json` emits one `ctrlrun.inspection/v1` object with `receipt`, `effect`, `approvals` and `events`, every enum by value. `receipt` is null for an action still awaiting a human, `effect` for one with no effect key. The human form shows `EFFECT_RESOLVED`'s `resolved_by`, which §2.2 requires of it.

`action_id` is matched **exactly** — no prefixes, no globs, as v0.1 §3.1 matches an action name. An unknown one exits non-zero with a message on stderr and **nothing on stdout**, so a script cannot mistake "no such action" for "an action with no events".

## Two design points

**`StateStore.approvals_for(action_hash)` is new.** §5 wants *every* approval carrying the hash, not only the one this action consumed — an invalidated, expired or denied request is part of the history, and after item 6 a denial can come from a different `action_id` with the same hash. It goes on `StateStore`, **not** on `ApprovalStore`, which is deliberately the slice an approval provider depends on: a provider answers one request and has no business enumerating them. Recorded in SPEC-v0.2 §11.

**A suspended action can be inspected at all only because of the approval request.** It has no receipt (v0.1 §6.1), and an `Event` carries neither the action's name nor its arguments — but `ApprovalRequest` stores the whole `Action` (v0.1 §4.1). `Receipt.action` and `Action.name` are the same field under different names, so `_Proposal` normalizes the two sources rather than duck-typing them at the call site. My first attempt *did* duck-type it, typed `Any`, and mypy could not see the `AttributeError`.

## Mutation table — §5, and a harness bug that mattered more

| # | Rule | Result |
|---|---|---|
| M1–M3 | unknown id: non-zero, empty stdout, exact match | red |
| M4 | the document declares `ctrlrun.inspection/v1` | red |
| M5–M8 | receipt, effect, events; events in `event_id` order | red |
| M9–M10 | *every* approval for the hash, matched on the hash | red |
| M11 | enums render by value | **equivalent mutant** |
| M12 | `receipt` is this action's, not any receipt | red |
| M13 | `effect` is this action's, not any record | red |
| M14 | `resolved_by` is shown (§2.2) | red |
| M15–M17 | the human header, incl. a suspended action's | red |

**The harness was lying.** M4 reported green; applied by hand it went red. A same-length edit (`v1`→`v2`) written and run inside one mtime second leaves a stale `.pyc`, and Python serves it — the mutation never reached the interpreter. Every harness now clears `src/**/__pycache__` before each run. **A false green in a mutation table is worse than no table**, because it reads as evidence a check is load-bearing when nothing exercised it.

I re-ran the §1.1, §2, §3 and §4 tables with the fix: all still fully red, so nothing was hidden there. Only greens could ever be affected — a stale `.pyc` cannot turn a passing check red.

**M11 is genuinely equivalent, not a gap.** `EffectState` is a `StrEnum`, so `json.dumps` emits `"ambiguous"` with or without the `str()` call. The `str()` stays as defence against a future non-`StrEnum` enum; no test can distinguish the two, and pretending otherwise would be the same false-green problem in a different costume.

**M12 and M13 were real gaps, and the same one twice**: `receipt` and `effect` could have been read from *any* record in the store rather than this action's, and both tests stayed green because the store held nothing else. Each now runs a second action that produces exactly the record a sloppy lookup would wrongly return.

## Verification

887 tests pass (867 → 887), `mypy --strict src/`, `ruff check` and `ruff format --check` clean. Every SPEC-v0.1 §7 acceptance test still passes. `inspect` joins the frozen CLI surface, and the test that pins that surface is updated.