### PR TITLE
item 6a: the StateStore half the gateway stands on

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,14 @@ dev = [
 ]
 # SPEC-v0.2 §1: `pip install ctrlrun` must not grow. Anything needing an HTTP server or a
 # third-party SDK lands here, lazily imported, with `MissingDependency` when it is absent.
-# Declared empty until the item that needs them lands: item 5 adds the gateway's HTTP client,
-# item 7 the OpenTelemetry API, SDK and OTLP/HTTP exporter.
-gateway = []
+#
+# The gateway's only dependency is an HTTP client (§6.11): the listening side is stdlib
+# `http.server`, and what an ASGI stack would add is a second server, not a capability.
+# What is needed is a connect/write/read exception taxonomy precise enough to feed §6.8's
+# first row — a gateway that could not tell "never connected" from "no reply" would have to
+# call everything AMBIGUOUS, which is safe and useless.
+gateway = ["httpx>=0.27"]
+# Item 8 adds the OpenTelemetry API, SDK and OTLP/HTTP exporter.
 otel = []
 
 [tool.setuptools.packages.find]

--- a/src/ctrlrun/__init__.py
+++ b/src/ctrlrun/__init__.py
@@ -23,6 +23,7 @@ from .errors import (
     DuplicateEffect,
     EffectKeyError,
     InvalidArgument,
+    MissingDependency,
     NotExecuted,
     PolicyError,
 )
@@ -53,6 +54,7 @@ __all__ = [
     "InvalidArgument",
     "JSONLEventSink",
     "LocalApprovalProvider",
+    "MissingDependency",
     "NotExecuted",
     "Policy",
     "PolicyError",

--- a/src/ctrlrun/effect.py
+++ b/src/ctrlrun/effect.py
@@ -314,3 +314,87 @@ def _rendered(name: str, value: object, template: str, error: type[CTRLRunError]
         f"{template!r}: '{{{name}}}' is {type(value).__name__}; a placeholder must resolve "
         "to a non-empty string or an int"
     )
+
+
+def plan_lease_extension(
+    record: EffectRecord | None,
+    effect_key: str,
+    action_id: str,
+    until: datetime,
+    now: datetime,
+) -> EffectRecord:
+    """The record an accepted `extend_lease` writes, or the refusal it raises (§6.9.4).
+
+    v0.1 §5.3 ended "there is no setting that releases an expired reservation, and none that
+    extends a lease already granted." SPEC-v0.2 §6.9.4 amends the second clause only, and
+    narrowly: an extension is accepted for an `EXECUTING` record held by this `action_id`
+    whose lease **has not already expired**, and for nothing else.
+
+    That last condition is the whole of the safety argument. A record whose lease has lapsed
+    may already have been declared `AMBIGUOUS` by another attempt (v0.1 §5.4), and extending
+    it would resurrect a reservation someone else has moved on from — reintroducing exactly
+    the double execution the lease exists to prevent.
+
+    Pure, like `plan_reservation`: both stores decide here and then only write, so the
+    in-memory double cannot drift into permitting what SQLite refuses.
+    """
+    if until.tzinfo is None or until.tzinfo.utcoffset(until) is None:
+        raise InvalidArgument(f"extend_lease(until=...) must be timezone-aware, got {until!r}")
+    if not action_id:
+        raise InvalidArgument("action_id must be a non-empty string")
+
+    if record is None:
+        # SPEC: §6.9.4 — the spec names two refusals and does not enumerate this one. There
+        # is no record to extend and no evidence of what happened, which is what
+        # `AmbiguousEffect` says; it writes nothing, so nothing is widened by saying it.
+        raise AmbiguousEffect(
+            f"effect {effect_key!r} has no record to extend", effect_key=effect_key
+        )
+    if record.state is EffectState.COMMITTED:
+        raise DuplicateEffect(
+            f"effect {effect_key!r} was already committed by {record.action_id}",
+            state=COMMITTED_EFFECT,
+            effect_key=effect_key,
+        )
+    if record.state is EffectState.AMBIGUOUS:
+        raise AmbiguousEffect(
+            f"effect {effect_key!r} has an unknown outcome from {record.action_id} and "
+            f"cannot be extended; resolve it with 'ctrlrun resolve {effect_key}'",
+            effect_key=effect_key,
+            action_id=record.action_id,
+        )
+    if record.state is EffectState.FAILED:
+        # SPEC: §6.9.4 — a FAILED record is not this attempt's to extend either. Refusing
+        # with `AmbiguousEffect` costs nothing: the call writes no record, so FAILED stays
+        # FAILED and stays retryable (v0.1 §5.4).
+        raise AmbiguousEffect(
+            f"effect {effect_key!r} is {record.state} and holds no lease to extend",
+            effect_key=effect_key,
+            action_id=record.action_id,
+        )
+    if not record.lease_is_live(now):
+        raise AmbiguousEffect(
+            f"effect {effect_key!r} was left {record.state} by {record.action_id} and its "
+            f"lease expired; it is not extendable by anything (SPEC-v0.2 §6.9.4)",
+            effect_key=effect_key,
+            action_id=record.action_id,
+        )
+    if record.state is not EffectState.EXECUTING or record.action_id != action_id:
+        raise DuplicateEffect(
+            f"effect {effect_key!r} is {record.state} under {record.action_id}",
+            state=IN_PROGRESS_EFFECT,
+            effect_key=effect_key,
+        )
+    if until <= now:
+        raise InvalidArgument(
+            f"extend_lease(until={until!r}) is not in the future; a lease that has already "
+            "expired reserves nothing (v0.1 §5.3 E3)"
+        )
+    if record.lease_expires_at is not None and until < record.lease_expires_at:
+        # `extend_lease`, not `set_lease`: moving expiry closer is a release of reservation
+        # by another name, and v0.1 §5.3's first clause is untouched by §6.9.4.
+        raise InvalidArgument(
+            f"extend_lease(until={until!r}) would shorten the lease on {effect_key!r}, "
+            f"which expires at {record.lease_expires_at!r}"
+        )
+    return replace(record, lease_expires_at=until, updated_at=now)

--- a/src/ctrlrun/effect.py
+++ b/src/ctrlrun/effect.py
@@ -342,6 +342,15 @@ def plan_lease_extension(
         raise InvalidArgument(f"extend_lease(until=...) must be timezone-aware, got {until!r}")
     if not action_id:
         raise InvalidArgument("action_id must be a non-empty string")
+    if until <= now:
+        # Argument validation, and it belongs above the record checks: a live lease always
+        # expires after `now`, so a past `until` is also a shortening, and behind the
+        # no-shortening rule this guard would never run. Two defences that can only fire
+        # together are one defence and a comment.
+        raise InvalidArgument(
+            f"extend_lease(until={until!r}) is not in the future; a lease that has already "
+            "expired reserves nothing (v0.1 §5.3 E3)"
+        )
 
     if record is None:
         # SPEC: §6.9.4 — the spec names two refusals and does not enumerate this one. There
@@ -356,39 +365,30 @@ def plan_lease_extension(
             state=COMMITTED_EFFECT,
             effect_key=effect_key,
         )
-    if record.state is EffectState.AMBIGUOUS:
-        raise AmbiguousEffect(
-            f"effect {effect_key!r} has an unknown outcome from {record.action_id} and "
-            f"cannot be extended; resolve it with 'ctrlrun resolve {effect_key}'",
-            effect_key=effect_key,
-            action_id=record.action_id,
-        )
-    if record.state is EffectState.FAILED:
-        # SPEC: §6.9.4 — a FAILED record is not this attempt's to extend either. Refusing
-        # with `AmbiguousEffect` costs nothing: the call writes no record, so FAILED stays
-        # FAILED and stays retryable (v0.1 §5.4).
-        raise AmbiguousEffect(
-            f"effect {effect_key!r} is {record.state} and holds no lease to extend",
-            effect_key=effect_key,
-            action_id=record.action_id,
-        )
-    if not record.lease_is_live(now):
-        raise AmbiguousEffect(
-            f"effect {effect_key!r} was left {record.state} by {record.action_id} and its "
-            f"lease expired; it is not extendable by anything (SPEC-v0.2 §6.9.4)",
-            effect_key=effect_key,
-            action_id=record.action_id,
-        )
-    if record.state is not EffectState.EXECUTING or record.action_id != action_id:
+    if record.lease_is_live(now) and (
+        record.state is not EffectState.EXECUTING or record.action_id != action_id
+    ):
+        # Someone is holding this key right now, and it is not this attempt — or it is, but
+        # it has not begun executing, so there is no round trip to extend across.
         raise DuplicateEffect(
             f"effect {effect_key!r} is {record.state} under {record.action_id}",
             state=IN_PROGRESS_EFFECT,
             effect_key=effect_key,
         )
-    if until <= now:
-        raise InvalidArgument(
-            f"extend_lease(until={until!r}) is not in the future; a lease that has already "
-            "expired reserves nothing (v0.1 §5.3 E3)"
+    if not (record.state is EffectState.EXECUTING and record.lease_is_live(now)):
+        # One branch, not three. `AMBIGUOUS`, `FAILED` and a lapsed lease all refuse with
+        # the same exception and write nothing, so separate guards for each would be one
+        # defence wearing three hats — indistinguishable to a caller and to a test. The
+        # message names the state instead.
+        #
+        # The lapsed-lease case is the one that carries the safety argument: another attempt
+        # may already have declared this record `AMBIGUOUS` (v0.1 §5.4), and extending it
+        # would resurrect a reservation someone else has moved on from.
+        raise AmbiguousEffect(
+            f"effect {effect_key!r} is {record.state} under {record.action_id} with no live "
+            f"lease; it is not extendable by anything (SPEC-v0.2 §6.9.4)",
+            effect_key=effect_key,
+            action_id=record.action_id,
         )
     if record.lease_expires_at is not None and until < record.lease_expires_at:
         # `extend_lease`, not `set_lease`: moving expiry closer is a release of reservation

--- a/src/ctrlrun/errors.py
+++ b/src/ctrlrun/errors.py
@@ -112,3 +112,20 @@ class NotExecuted(CTRLRunError):
     This is the *only* exception that maps to `FAILED` and therefore permits a retry.
     Every other exception is an `AMBIGUOUS` outcome.
     """
+
+
+class MissingDependency(CTRLRunError):
+    """An optional extra is not installed (SPEC-v0.2 §1.1, §11).
+
+    Never `ImportError` or `ModuleNotFoundError`: an operator reads those as a broken
+    package rather than as an option they did not select. The message names the module that
+    is missing and the command that installs it.
+    """
+
+    def __init__(self, module: str, extra: str) -> None:
+        super().__init__(
+            f"{module!r} is not installed; it ships in the {extra!r} extra: "
+            f"pip install 'ctrlrun[{extra}]'"
+        )
+        self.module = module
+        self.extra = extra

--- a/src/ctrlrun/gateway/__init__.py
+++ b/src/ctrlrun/gateway/__init__.py
@@ -1,0 +1,49 @@
+"""The MCP gateway. Build-list item 6; SPEC-v0.2 §6. Ships in `ctrlrun[gateway]`.
+
+Nothing here is imported by `import ctrlrun` (SPEC-v0.2 §1.1): the package is reachable only
+by naming it, and the HTTP client it needs is resolved at call time, so a core install that
+never runs a gateway never pays for one — and never fails at import to say so.
+
+The listening side is stdlib `http.server` (§6.11). The extra's only dependency is an HTTP
+client with a connect/write/read exception taxonomy precise enough to feed §6.8's first row:
+"the connection was never established" is the one claim in that table that asserts
+non-execution, and it is only provable if no request byte can have been written.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+from typing import Final, NoReturn
+
+from ..errors import MissingDependency
+
+#: The extra's HTTP client, imported by name so a missing one is a `MissingDependency`
+#: rather than a `ModuleNotFoundError` from halfway down an import chain.
+_HTTP_CLIENT: Final = "httpx"
+
+#: The extra that carries it, for the install command in the error.
+_EXTRA: Final = "gateway"
+
+__all__ = ["serve"]
+
+
+def http_client() -> ModuleType:
+    """The HTTP client the gateway forwards with, or `MissingDependency` (SPEC-v0.2 §1.1)."""
+    try:
+        return importlib.import_module(_HTTP_CLIENT)
+    except ImportError as exc:
+        raise MissingDependency(_HTTP_CLIENT, _EXTRA) from exc
+
+
+def serve(*, upstream: str, alias: str, **options: object) -> NoReturn:
+    """Run a gateway in front of one upstream MCP server (SPEC-v0.2 §6.1).
+
+    The dependency check happens first and unconditionally, so an operator who has not
+    installed the extra learns it from one clear line rather than from a stack trace.
+    """
+    http_client()
+    raise NotImplementedError(
+        "the gateway's request handling arrives with build-list items 6b-6d; "
+        "this release ships the StateStore half it stands on (SPEC-v0.2 §6.9.4, §6.10)"
+    )

--- a/src/ctrlrun/state.py
+++ b/src/ctrlrun/state.py
@@ -20,7 +20,7 @@ import logging
 import os
 import sqlite3
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -45,6 +45,7 @@ from .effect import (
     EffectState,
     Reservation,
     ReservationPlan,
+    plan_lease_extension,
     plan_reservation,
 )
 from .errors import AmbiguousEffect, DuplicateEffect, InvalidArgument
@@ -346,6 +347,27 @@ class StateStore(ApprovalStore, Protocol):
         """Every effect record, oldest first, optionally narrowed to one state."""
         ...
 
+    def extend_lease(self, effect_key: str, action_id: str, until: datetime) -> None:
+        """Extend a live `EXECUTING` reservation this action holds (SPEC-v0.2 §6.9.4).
+
+        Atomic, and refused unless all of: the record is `EXECUTING`, its `action_id` is the
+        caller's, and its lease **has not already expired**. An expired lease is extendable
+        by nothing, and an expired reservation is still released by nobody.
+        """
+        ...
+
+    def find_granted_approval(self, action_hash: str) -> Approval | None:
+        """The newest granted, unexpired approval for this hash, or `None` (§6.10)."""
+        ...
+
+    def find_denied_request(self, action_hash: str) -> ApprovalRequest | None:
+        """The newest unexpired *denied* request for this hash, or `None` (§6.10).
+
+        "No" is an answer, and re-asking is not free: without this the gateway would send a
+        human a fresh notification every time an agent resent a call it disliked.
+        """
+        ...
+
     def approvals_for(self, action_hash: str) -> tuple[ApprovalRecord, ...]:
         """Every approval record carrying `action_hash`, oldest first (SPEC-v0.2 §5).
 
@@ -438,6 +460,18 @@ class InMemoryStateStore:
             return tuple(
                 record for record in self._approvals.values() if record.action_hash == action_hash
             )
+
+    def find_granted_approval(self, action_hash: str) -> Approval | None:
+        now = self._clock()
+        with self._lock:
+            records = list(self._approvals.values())
+        return _newest_granted(records, action_hash, now)
+
+    def find_denied_request(self, action_hash: str) -> ApprovalRequest | None:
+        now = self._clock()
+        with self._lock:
+            records = list(self._approvals.values())
+        return _newest_denied(records, action_hash, now)
 
     def grant_approval(self, approval_id: str, approver: str) -> Approval:
         approver = _approver(approver)
@@ -584,6 +618,13 @@ class InMemoryStateStore:
             resolved = _resolved(record, state, resolver, self._clock())
             self._effects[effect_key] = resolved
             return resolved
+
+    def extend_lease(self, effect_key: str, action_id: str, until: datetime) -> None:
+        with self._lock:
+            extended = plan_lease_extension(
+                self._effects.get(effect_key), effect_key, action_id, until, self._clock()
+            )
+            self._effects[effect_key] = extended
 
     def get_effect(self, effect_key: str) -> EffectRecord | None:
         with self._lock:
@@ -759,6 +800,12 @@ class SQLiteStateStore:
 
     def get_approval(self, approval_id: str) -> ApprovalRecord | None:
         return self._read_approval(self._connection(), approval_id)
+
+    def find_granted_approval(self, action_hash: str) -> Approval | None:
+        return _newest_granted(self.approvals_for(action_hash), action_hash, self._clock())
+
+    def find_denied_request(self, action_hash: str) -> ApprovalRequest | None:
+        return _newest_denied(self.approvals_for(action_hash), action_hash, self._clock())
 
     def approvals_for(self, action_hash: str) -> tuple[ApprovalRecord, ...]:
         connection = self._connection()
@@ -1018,6 +1065,23 @@ class SQLiteStateStore:
     def mark_ambiguous(self, effect_key: str, action_id: str, error: str) -> None:
         self._transition(effect_key, action_id, EffectState.AMBIGUOUS, _UNFINISHED, error=error)
 
+    def extend_lease(self, effect_key: str, action_id: str, until: datetime) -> None:
+        connection = self._connection()
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            extended = plan_lease_extension(
+                self._read_effect(connection, effect_key),
+                effect_key,
+                action_id,
+                until,
+                self._clock(),
+            )
+            self._write_effect(connection, extended)
+        except BaseException:
+            self._unwind(connection)
+            raise
+        connection.commit()
+
     def resolve_effect(self, effect_key: str, state: EffectState, resolver: str) -> EffectRecord:
         resolver = _approver(resolver)
         connection = self._connection()
@@ -1140,3 +1204,53 @@ def _required_action(action_id: str | None) -> str:
     if not action_id:
         raise InvalidArgument("reserving an effect needs the action_id reserving it")
     return action_id
+
+
+def _newest_granted(
+    records: Iterable[ApprovalRecord], action_hash: str, now: datetime
+) -> Approval | None:
+    """The newest granted, unexpired approval for `action_hash` (SPEC-v0.2 §6.10).
+
+    Matching on the hash rather than on a presented request id is safe for the reason v0.1
+    §4.2 A1 exists: the hash covers the principal, the arguments, the resource and the
+    environment, so an approval can only match an identical action from the same principal —
+    which is the same action. It is still single-use, and still consumed atomically with the
+    reservation, which is where that guarantee actually lives.
+    """
+    granted = [
+        record
+        for record in records
+        if record.action_hash == action_hash
+        and record.status is ApprovalStatus.GRANTED
+        and record.expires_at > now
+    ]
+    if not granted:
+        return None
+    # `reversed`, because `max` returns the *first* maximal element and `records` arrives
+    # oldest-first: two approvals granted in the same clock tick tie, and the later-stored
+    # one is the newer of them.
+    newest: ApprovalRecord = max(
+        reversed(list(granted)), key=lambda record: record.granted_at or record.request.created_at
+    )
+    return newest.as_approval()
+
+
+def _newest_denied(
+    records: Iterable[ApprovalRecord], action_hash: str, now: datetime
+) -> ApprovalRequest | None:
+    """The newest unexpired denied request for `action_hash` (SPEC-v0.2 §6.10).
+
+    A denial holds for the life of the request that carried it; once that expires, asking
+    again is legitimate.
+    """
+    denied = [
+        record
+        for record in records
+        if record.action_hash == action_hash
+        and record.status is ApprovalStatus.DENIED
+        and record.expires_at > now
+    ]
+    if not denied:
+        return None
+    newest: ApprovalRecord = max(reversed(denied), key=lambda record: record.request.created_at)
+    return newest.request

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,0 +1,326 @@
+"""What the gateway needs from the StateStore. Build-list item 6a; SPEC-v0.2 §6.9.4, §6.10.
+
+The gateway itself is items 6b-6d. This is the kernel half it stands on, built first and on
+its own because it is the part that touches transactions: a lease extension and two
+hash-keyed approval lookups. T26b is the acceptance test, and the row that matters in it is
+the last one — an `EXECUTING` record whose lease has *already* expired is not extendable by
+anything, because another attempt may already have declared it `AMBIGUOUS`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from ctrlrun import (
+    Action,
+    AmbiguousEffect,
+    ApprovalRequest,
+    CTRLRunError,
+    DuplicateEffect,
+    EffectState,
+    InvalidArgument,
+    Principal,
+    SQLiteStateStore,
+)
+from ctrlrun.approval import DEFAULT_APPROVAL_TTL, ApprovalStatus
+from ctrlrun.effect import COMMITTED_EFFECT, IN_PROGRESS_EFFECT
+
+KEY = "refund:txn_1"
+MINE = "act_mine"
+THEIRS = "act_theirs"
+LEASE = timedelta(minutes=5)
+
+
+@pytest.fixture
+def sqlite_store(tmp_path, fake_clock):
+    """T26b is explicit that this runs against a real SQLite store, not the double."""
+    store = SQLiteStateStore(tmp_path / "state.db", clock=fake_clock)
+    yield store
+    store.close()
+
+
+def _executing(store, action_id: str = MINE) -> None:
+    store.reserve_effect(KEY, action_id, LEASE)
+    store.begin_execution(KEY, action_id)
+
+
+def _until(fake_clock, minutes: int = 10) -> datetime:
+    return fake_clock.now + timedelta(minutes=minutes)
+
+
+# --- T26b: extend_lease refuses what it must -------------------------------------------
+
+
+def test_T26b_extend_lease_succeeds_for_an_executing_record_this_action_holds(
+    sqlite_store, fake_clock
+):
+    _executing(sqlite_store)
+    until = _until(fake_clock)
+
+    sqlite_store.extend_lease(KEY, MINE, until)
+
+    record = sqlite_store.get_effect(KEY)
+    assert record.lease_expires_at == until
+    assert record.state is EffectState.EXECUTING
+    assert record.lease_is_live(fake_clock.now + timedelta(minutes=9))
+
+
+def test_T26b_an_extended_lease_keeps_the_record_alive_past_the_original(sqlite_store, fake_clock):
+    """The point of the call: a round trip that outlasts the lease it started under."""
+    _executing(sqlite_store)
+    sqlite_store.extend_lease(KEY, MINE, _until(fake_clock, 10))
+    fake_clock.advance(timedelta(minutes=7))
+
+    assert sqlite_store.get_effect(KEY).lease_is_live(fake_clock.now)
+
+
+def test_T26b_extend_lease_refuses_a_reserved_record(sqlite_store, fake_clock):
+    sqlite_store.reserve_effect(KEY, MINE, LEASE)
+
+    with pytest.raises(CTRLRunError):
+        sqlite_store.extend_lease(KEY, MINE, _until(fake_clock))
+
+    assert sqlite_store.get_effect(KEY).state is EffectState.RESERVED
+
+
+def test_T26b_extend_lease_refuses_a_committed_record(sqlite_store, fake_clock):
+    _executing(sqlite_store)
+    sqlite_store.commit_effect(KEY, MINE, "re_1")
+
+    with pytest.raises(DuplicateEffect) as refused:
+        sqlite_store.extend_lease(KEY, MINE, _until(fake_clock))
+
+    assert refused.value.state == COMMITTED_EFFECT
+
+
+def test_T26b_extend_lease_refuses_a_failed_record(sqlite_store, fake_clock):
+    _executing(sqlite_store)
+    sqlite_store.fail_effect(KEY, MINE, "rejected before any side effect")
+
+    with pytest.raises(CTRLRunError):
+        sqlite_store.extend_lease(KEY, MINE, _until(fake_clock))
+
+    # Refused without mutating: FAILED still permits a retry (v0.1 §5.4).
+    assert sqlite_store.get_effect(KEY).state is EffectState.FAILED
+
+
+def test_T26b_extend_lease_refuses_an_ambiguous_record(sqlite_store, fake_clock):
+    _executing(sqlite_store)
+    sqlite_store.mark_ambiguous(KEY, MINE, "response lost")
+
+    with pytest.raises(AmbiguousEffect):
+        sqlite_store.extend_lease(KEY, MINE, _until(fake_clock))
+
+    assert sqlite_store.get_effect(KEY).state is EffectState.AMBIGUOUS
+
+
+def test_T26b_extend_lease_refuses_a_different_action_id(sqlite_store, fake_clock):
+    _executing(sqlite_store, THEIRS)
+
+    with pytest.raises(DuplicateEffect) as refused:
+        sqlite_store.extend_lease(KEY, MINE, _until(fake_clock))
+
+    assert refused.value.state == IN_PROGRESS_EFFECT
+    assert sqlite_store.get_effect(KEY).action_id == THEIRS
+
+
+def test_T26b_extend_lease_refuses_a_lease_that_already_expired(sqlite_store, fake_clock):
+    """The row that carries the whole safety argument (SPEC-v0.2 §6.9.4).
+
+    A record whose lease has lapsed may already have been declared `AMBIGUOUS` by another
+    attempt, and extending it would resurrect a reservation someone else has moved on from —
+    reintroducing exactly the double execution the lease exists to prevent. Deterministic:
+    the clock is advanced, never slept on.
+    """
+    _executing(sqlite_store)
+    fake_clock.advance(LEASE + timedelta(seconds=1))
+
+    with pytest.raises(AmbiguousEffect):
+        sqlite_store.extend_lease(KEY, MINE, _until(fake_clock))
+
+    assert sqlite_store.get_effect(KEY).state is EffectState.EXECUTING
+    assert not sqlite_store.get_effect(KEY).lease_is_live(fake_clock.now)
+
+
+def test_T26b_an_expired_lease_stays_unextendable_after_another_attempt_ambiguates_it(
+    sqlite_store, fake_clock
+):
+    """The sequence §6.9.4 is defending against, run in order."""
+    _executing(sqlite_store)
+    fake_clock.advance(LEASE + timedelta(seconds=1))
+    with pytest.raises(AmbiguousEffect):
+        sqlite_store.reserve_effect(KEY, THEIRS, LEASE)  # declares it AMBIGUOUS (v0.1 §5.4)
+
+    assert sqlite_store.get_effect(KEY).state is EffectState.AMBIGUOUS
+    with pytest.raises(AmbiguousEffect):
+        sqlite_store.extend_lease(KEY, MINE, _until(fake_clock))
+
+
+def test_T26b_extend_lease_refuses_a_key_no_record_exists_for(sqlite_store, fake_clock):
+    with pytest.raises(CTRLRunError):
+        sqlite_store.extend_lease("refund:nothing", MINE, _until(fake_clock))
+
+
+def test_T26b_extend_lease_refuses_an_until_in_the_past(sqlite_store, fake_clock):
+    """A lease that has already expired reserves nothing (v0.1 §5.3 E3)."""
+    _executing(sqlite_store)
+
+    with pytest.raises(InvalidArgument):
+        sqlite_store.extend_lease(KEY, MINE, fake_clock.now - timedelta(seconds=1))
+
+    assert sqlite_store.get_effect(KEY).lease_is_live(fake_clock.now)
+
+
+def test_T26b_extend_lease_refuses_a_naive_datetime(sqlite_store):
+    _executing(sqlite_store)
+
+    with pytest.raises(InvalidArgument):
+        sqlite_store.extend_lease(KEY, MINE, datetime(2099, 1, 1))
+
+
+def test_T26b_extend_lease_never_shortens_a_lease(sqlite_store, fake_clock):
+    """`extend_lease`, not `set_lease`: v0.1 §5.3's first clause is untouched, and moving
+    expiry closer is a release of reservation by another name."""
+    _executing(sqlite_store)
+    original = sqlite_store.get_effect(KEY).lease_expires_at
+
+    with pytest.raises(InvalidArgument):
+        sqlite_store.extend_lease(KEY, MINE, original - timedelta(minutes=1))
+
+    assert sqlite_store.get_effect(KEY).lease_expires_at == original
+
+
+def test_extend_lease_holds_for_the_in_memory_store_too(state_store, fake_clock):
+    """A double that permits what SQLite refuses invalidates every test that uses it."""
+    state_store.reserve_effect(KEY, MINE, LEASE)
+    state_store.begin_execution(KEY, MINE)
+    state_store.extend_lease(KEY, MINE, _until(fake_clock))
+
+    assert state_store.get_effect(KEY).lease_expires_at == _until(fake_clock)
+    state_store.mark_ambiguous(KEY, MINE, "lost")
+    with pytest.raises(AmbiguousEffect):
+        state_store.extend_lease(KEY, MINE, _until(fake_clock, 20))
+
+
+# --- §6.10: the two hash-keyed approval lookups ----------------------------------------
+
+
+def _request(store, request_id: str, action: Action, clock, ttl=DEFAULT_APPROVAL_TTL):
+    request = ApprovalRequest(
+        request_id=request_id,
+        action_hash=action.action_hash,
+        action=action,
+        created_at=clock.now,
+        expires_at=clock.now + ttl,
+    )
+    store.put_approval_request(request)
+    return request
+
+
+def _action(amount: int = 2000) -> Action:
+    return Action(
+        name="mcp.acme.refund",
+        arguments={"payment_id": "txn_1", "amount": amount},
+        principal=Principal(agent="refund-agent"),
+    )
+
+
+def test_find_granted_approval_returns_the_newest_granted_one(state_store, fake_clock):
+    action = _action()
+    _request(state_store, "apr_1", action, fake_clock)
+    state_store.grant_approval("apr_1", "human:ops")
+    fake_clock.advance(timedelta(minutes=1))
+    _request(state_store, "apr_2", action, fake_clock)
+    state_store.grant_approval("apr_2", "human:ops")
+
+    found = state_store.find_granted_approval(action.action_hash)
+
+    assert found is not None
+    assert found.approval_id == "apr_2"
+
+
+def test_find_granted_approval_breaks_a_tie_toward_the_later_record(state_store, fake_clock):
+    """Two grants in one clock tick tie on `granted_at`; the later-stored one is newer."""
+    action = _action()
+    _request(state_store, "apr_1", action, fake_clock)
+    _request(state_store, "apr_2", action, fake_clock)
+    state_store.grant_approval("apr_1", "human:ops")
+    state_store.grant_approval("apr_2", "human:ops")
+
+    assert state_store.find_granted_approval(action.action_hash).approval_id == "apr_2"
+
+
+def test_find_granted_approval_ignores_a_pending_one(state_store, fake_clock):
+    action = _action()
+    _request(state_store, "apr_1", action, fake_clock)
+
+    assert state_store.find_granted_approval(action.action_hash) is None
+
+
+def test_find_granted_approval_ignores_a_consumed_one(state_store, fake_clock):
+    action = _action()
+    _request(state_store, "apr_1", action, fake_clock)
+    state_store.grant_approval("apr_1", "human:ops")
+    state_store.consume_approval("apr_1", action.action_hash)
+
+    assert state_store.find_granted_approval(action.action_hash) is None
+
+
+def test_find_granted_approval_ignores_an_expired_one(state_store, fake_clock):
+    action = _action()
+    _request(state_store, "apr_1", action, fake_clock, ttl=timedelta(minutes=5))
+    state_store.grant_approval("apr_1", "human:ops")
+    fake_clock.advance(timedelta(minutes=6))
+
+    assert state_store.find_granted_approval(action.action_hash) is None
+
+
+def test_find_granted_approval_ignores_another_actions_hash(state_store, fake_clock):
+    action = _action()
+    _request(state_store, "apr_1", action, fake_clock)
+    state_store.grant_approval("apr_1", "human:ops")
+
+    assert state_store.find_granted_approval(_action(amount=9999).action_hash) is None
+
+
+def test_find_denied_request_returns_an_unexpired_denial(state_store, fake_clock):
+    """§6.10 — "no" is an answer, and re-asking is not free."""
+    action = _action()
+    _request(state_store, "apr_1", action, fake_clock)
+    state_store.deny_approval("apr_1", "human:ops")
+
+    found = state_store.find_denied_request(action.action_hash)
+
+    assert found is not None
+    assert found.request_id == "apr_1"
+
+
+def test_find_denied_request_ignores_an_expired_denial(state_store, fake_clock):
+    """A denial holds for the life of the request that carried it; after that, asking
+    again is legitimate (§6.10)."""
+    action = _action()
+    _request(state_store, "apr_1", action, fake_clock, ttl=timedelta(minutes=5))
+    state_store.deny_approval("apr_1", "human:ops")
+    fake_clock.advance(timedelta(minutes=6))
+
+    assert state_store.find_denied_request(action.action_hash) is None
+
+
+def test_find_denied_request_ignores_a_granted_one(state_store, fake_clock):
+    action = _action()
+    _request(state_store, "apr_1", action, fake_clock)
+    state_store.grant_approval("apr_1", "human:ops")
+
+    assert state_store.find_denied_request(action.action_hash) is None
+
+
+def test_the_two_lookups_agree_with_the_record_the_store_holds(state_store, fake_clock):
+    action = _action()
+    _request(state_store, "apr_1", action, fake_clock)
+    state_store.deny_approval("apr_1", "human:ops")
+
+    assert state_store.get_approval("apr_1").status is ApprovalStatus.DENIED
+    assert state_store.find_granted_approval(action.action_hash) is None
+    assert state_store.find_denied_request(action.action_hash).request_id == "apr_1"

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -79,9 +79,10 @@ def test_T26b_an_extended_lease_keeps_the_record_alive_past_the_original(sqlite_
 def test_T26b_extend_lease_refuses_a_reserved_record(sqlite_store, fake_clock):
     sqlite_store.reserve_effect(KEY, MINE, LEASE)
 
-    with pytest.raises(CTRLRunError):
+    with pytest.raises(DuplicateEffect) as refused:
         sqlite_store.extend_lease(KEY, MINE, _until(fake_clock))
 
+    assert refused.value.state == IN_PROGRESS_EFFECT
     assert sqlite_store.get_effect(KEY).state is EffectState.RESERVED
 
 
@@ -99,9 +100,10 @@ def test_T26b_extend_lease_refuses_a_failed_record(sqlite_store, fake_clock):
     _executing(sqlite_store)
     sqlite_store.fail_effect(KEY, MINE, "rejected before any side effect")
 
-    with pytest.raises(CTRLRunError):
+    with pytest.raises(AmbiguousEffect) as refused:
         sqlite_store.extend_lease(KEY, MINE, _until(fake_clock))
 
+    assert "failed" in str(refused.value)
     # Refused without mutating: FAILED still permits a retry (v0.1 §5.4).
     assert sqlite_store.get_effect(KEY).state is EffectState.FAILED
 
@@ -110,9 +112,10 @@ def test_T26b_extend_lease_refuses_an_ambiguous_record(sqlite_store, fake_clock)
     _executing(sqlite_store)
     sqlite_store.mark_ambiguous(KEY, MINE, "response lost")
 
-    with pytest.raises(AmbiguousEffect):
+    with pytest.raises(AmbiguousEffect) as refused:
         sqlite_store.extend_lease(KEY, MINE, _until(fake_clock))
 
+    assert "ambiguous" in str(refused.value)
     assert sqlite_store.get_effect(KEY).state is EffectState.AMBIGUOUS
 
 
@@ -171,6 +174,23 @@ def test_T26b_extend_lease_refuses_an_until_in_the_past(sqlite_store, fake_clock
         sqlite_store.extend_lease(KEY, MINE, fake_clock.now - timedelta(seconds=1))
 
     assert sqlite_store.get_effect(KEY).lease_is_live(fake_clock.now)
+
+
+def test_T26b_a_past_until_is_refused_before_the_record_is_even_read(sqlite_store, fake_clock):
+    """The two refusals are separated deliberately (SPEC-v0.2 §6.9.4).
+
+    A live lease always expires after `now`, so a past `until` is also a shortening — behind
+    the no-shortening rule this check could never fire, and two defences that can only fire
+    together are one defence and a comment. Validating the argument first makes each
+    independently reachable, and this is the window where only the first one can apply:
+    there is no record, so there is no lease to shorten.
+    """
+    with pytest.raises(InvalidArgument):
+        sqlite_store.extend_lease("refund:nothing", MINE, fake_clock.now - timedelta(seconds=1))
+
+    # The same call with a future `until` gets the record refusal instead, not this one.
+    with pytest.raises(AmbiguousEffect):
+        sqlite_store.extend_lease("refund:nothing", MINE, _until(fake_clock))
 
 
 def test_T26b_extend_lease_refuses_a_naive_datetime(sqlite_store):

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,113 @@
+"""The dependency rule. Build-list item 6a; SPEC-v0.2 §1.1, and the first half of T30.
+
+`pip install ctrlrun` must not grow. An extra's module imports lazily, and a missing extra
+raises `MissingDependency` naming the install command — never `ImportError`, which reads to
+an operator as a broken package rather than an unselected option.
+
+T30's own assertion, that a **subprocess** running `import ctrlrun` pulls in no module from
+an extra, lands with item 8 when there is a second extra to check. The subprocess matters:
+in-process it would pass or fail on whatever pytest happened to import first.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from ctrlrun import MissingDependency
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: SPEC-v0.2 §1.1 — what `pip install ctrlrun` is allowed to pull in, and nothing else.
+CORE_DEPENDENCIES = {"pyyaml", "click"}
+
+
+def _pyproject() -> dict:
+    path = REPO_ROOT / "pyproject.toml"
+    if not path.exists():  # installed without the source tree
+        pytest.skip("no repository checkout")
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def test_core_declares_only_pyyaml_and_click():
+    declared = {
+        name.split("[")[0].split(">")[0].split("=")[0].strip().lower()
+        for name in _pyproject()["project"]["dependencies"]
+    }
+
+    assert declared == CORE_DEPENDENCIES
+
+
+def test_the_gateway_extra_declares_its_http_client():
+    """§6.11 — the extra's only dependency is an HTTP client, and the listening side is
+    stdlib `http.server`. An ASGI stack here would be a second server in the package."""
+    extras = _pyproject()["project"]["optional-dependencies"]
+
+    assert extras["gateway"], "the gateway extra must declare its HTTP client"
+    assert not any("uvicorn" in name or "starlette" in name for name in extras["gateway"])
+
+
+def test_an_extra_is_never_in_core_dependencies():
+    project = _pyproject()["project"]
+    core = {
+        name.split("[")[0].split(">")[0].split("=")[0].strip() for name in project["dependencies"]
+    }
+    for extra, names in project["optional-dependencies"].items():
+        if extra == "dev":
+            continue
+        for name in names:
+            assert name.split("[")[0].split(">")[0].split("=")[0].strip() not in core
+
+
+def test_importing_ctrlrun_does_not_import_the_gateway_extra():
+    """A subprocess, because in-process this would pass on whatever pytest imported first."""
+    finished = subprocess.run(
+        [sys.executable, "-c", "import ctrlrun, sys; print('httpx' in sys.modules)"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert finished.stdout.strip() == "False"
+
+
+def test_importing_ctrlrun_does_not_import_the_gateway_package():
+    finished = subprocess.run(
+        [sys.executable, "-c", "import ctrlrun, sys; print('ctrlrun.gateway' in sys.modules)"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert finished.stdout.strip() == "False"
+
+
+def test_a_missing_extra_raises_MissingDependency_naming_the_install_command(monkeypatch):
+    """Never `ImportError` or `ModuleNotFoundError` (§1.1): an operator reads those as a
+    broken package rather than as an option they did not select."""
+    import ctrlrun.gateway as gateway
+
+    monkeypatch.setattr(gateway, "_HTTP_CLIENT", "no_such_module_at_all")
+
+    with pytest.raises(MissingDependency) as raised:
+        gateway.serve(upstream="http://localhost:8000", alias="acme")
+
+    assert "pip install 'ctrlrun[gateway]'" in str(raised.value)
+    assert not isinstance(raised.value, ImportError)
+
+
+def test_MissingDependency_is_a_ctrlrun_error():
+    from ctrlrun import CTRLRunError
+
+    assert issubclass(MissingDependency, CTRLRunError)
+
+
+def test_MissingDependency_names_the_extra_and_the_command():
+    error = MissingDependency("httpx", "gateway")
+
+    assert "httpx" in str(error)
+    assert "pip install 'ctrlrun[gateway]'" in str(error)


### PR DESCRIPTION
First of four stages for item 6. SPEC-v0.2 §6.9.4 and §6.10, acceptance test T26b.

§6 is ~600 lines of spec and 10 acceptance tests — roughly 4× everything shipped so far. This stage is the part that touches transactions, built first and on its own so it gets reviewed without HTTP plumbing on top of it. **No request handling yet**; `serve()` raises `NotImplementedError` after checking its dependency.

Remaining stages: **6b** `mcp.py`/`outcome.py` (T20, T24 — §6.8's table as pure functions), **6c** `server.py` (T19, T21, T22, T23, T25), **6d** elicitation + legacy passthrough (T26, T30b).

## `extend_lease` (§6.9.4)

v0.1 §5.3 ended *"there is no setting that releases an expired reservation, and none that extends a lease already granted."* This amends the **second clause only**, and narrowly: an extension is accepted for an `EXECUTING` record held by this `action_id` whose lease **has not already expired**, and for nothing else.

That last condition is the whole safety argument. A record whose lease lapsed may already have been declared `AMBIGUOUS` by another attempt (v0.1 §5.4), and extending it would resurrect a reservation someone else has moved on from — reintroducing exactly the double execution the lease exists to prevent.

The first clause is untouched. Nothing releases an expired reservation, and `extend_lease` is not `set_lease`: moving expiry *closer* is refused too.

The decision is a pure function in `effect.py` beside `plan_reservation`, so both stores decide with it and then only write — the in-memory double cannot drift into permitting what SQLite refuses.

## `find_granted_approval` / `find_denied_request` (§6.10)

Matching on the hash rather than a presented request id is safe for the reason v0.1 §4.2 A1 exists: the hash covers the principal, arguments, resource and environment, so an approval can only match an identical action from the same principal — which is the same action. Single use is still enforced at consumption, which is where that guarantee actually lives.

"Newest" breaks ties toward the later-stored record: two grants in one clock tick tie on `granted_at`, and `max` returns the *first* maximal element from an oldest-first sequence.

## The extra

`MissingDependency`, and a `ctrlrun.gateway` package that resolves its HTTP client **at call time**. A core install that never runs a gateway never pays for one, and never fails at import to say so.

The extra declares `httpx` and nothing else. §6.11 is explicit that the listening side is stdlib `http.server` — what an ASGI stack would add is a second server, not a capability. `tests/test_packaging.py` pins the rule: core declares only `pyyaml` and `click`, no extra leaks into it, and a **subprocess** importing `ctrlrun` pulls in neither `httpx` nor `ctrlrun.gateway`.

No spec change this time — `extend_lease`, `find_granted_approval` and `find_denied_request` were already frozen in §11.

## Mutation table — 24 mutations, all red

| # | Rule | Result |
|---|---|---|
| M1–M3 | expired lease unextendable; only the holder; only `EXECUTING` | red |
| M4–M6 | `COMMITTED` refuses as duplicate; no-live-lease refuses; the message names the state | red |
| M7–M11 | missing record, past `until`, no shortening, tz-aware, the write happens | red |
| M12 | the in-memory store refuses exactly what SQLite refuses | red |
| M13–M16 | `find_granted_approval`: status, expiry, hash, newest | red |
| M17–M18 | `find_denied_request`: expiry, status | red |
| M19–M21 | `MissingDependency` not `ImportError`; checked first; names the command | red |
| M22–M24 | the extra is never core; not an ASGI stack; `import ctrlrun` stays clean | red |

**Three of them started green, and it was the same defect three times.** `until <= now`, the `AMBIGUOUS` branch and the `FAILED` branch were each unreachable behind a later check that refused *identically*:

- a live lease always expires after `now`, so a past `until` was always also a shortening — the no-shortening rule got there first;
- `AMBIGUOUS`, `FAILED` and a lapsed lease all raised `AmbiguousEffect` and wrote nothing, so the three guards were one behaviour with three messages.

`until <= now` is argument validation and now runs above the record checks, where the no-record case makes it independently reachable. The other two collapse into one branch that names the state it found. **Three guards that can only fire together are one guard and two comments** — and a mutation table is how you find out which you have.

The harness also had two bugs I fixed: ambiguous anchor strings mutated `plan_reservation` instead of `plan_lease_extension` (the same `if record.state is …` lines appear in both), and the stale-`.pyc` issue from item 5's review. Both produced false greens.

## Verification

931 tests pass (887 → 931), `mypy --strict src/`, `ruff check` and `ruff format --check` clean. The built wheel carries `ctrlrun/gateway/` and declares `httpx>=0.27; extra == "gateway"` with core still at `pyyaml`, `click`.