### PR TITLE
build: stop the formatter rewriting the specs, and give CI one entry point

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,17 +26,10 @@ jobs:
           # touch it, in a subprocess, whether or not it happens to be installed here.
           pip install -e ".[dev,gateway,otel,identity]"
 
-      - name: pytest
-        run: pytest
-
-      - name: mypy
-        run: mypy --strict src
-
-      - name: ruff
-        run: ruff check
-
-      - name: ruff format
-        run: ruff format --check
+      # One script, called here and by a developer before pushing, so the two cannot
+      # diverge. `test_ci_runs_the_check_script` fails if this step stops calling it.
+      - name: check
+        run: ./scripts/check.sh
 
   # The definition of done says the demo runs with no network and the README quick start
   # works verbatim. Both were only ever checked by hand, which is how a README stops being

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,19 @@ reconstruct:
 
 ### Fixed
 
+- **`ruff format` reformatted Python code blocks inside the specs; `ruff check` never looked
+  at them.** Whether a spec's examples were rewritten therefore turned on whether they happened
+  to parse: `SPEC-v0.1.md` and `SPEC-v0.2.md` keep their aligned comments only because theirs
+  carry placeholders like `<generated>`, and `SPEC-v0.3.md`'s parse, so a CI check that had
+  never fired before went red on them and the alignment was flattened to make it green.
+
+  A specification's code blocks are illustration rather than code — they elide, they annotate,
+  they line comments up so a reader can compare down the column — and the formatter has no way
+  to know that. `[tool.ruff.format] exclude` now tells it, `force-exclude` makes the exclusion
+  mean the same thing however ruff is invoked, and SPEC-v0.3's alignment is restored.
+  `test_the_formatter_leaves_markdown_alone` keeps it that way, with a control test that fails
+  if the probe it relies on is not actually unformatted.
+
 - **The gateway compared mirrored header values by re-parsing them, and Python's parser is
   lenient.** `Mcp-Param-{Name}` validation ran the header through `int()`, so a body carrying
   `amount: 2000` was certified as agreeing with headers spelling it `2_000`, `+2000`, `02000`,

--- a/docs/SPEC-v0.3.md
+++ b/docs/SPEC-v0.3.md
@@ -292,16 +292,15 @@ invention, not as an implementation of anything.
 renamed.
 
 ```python
-_NO_CLAIMS: Final = MappingProxyType({})  # shared; a dataclass default must be immutable
-
+_NO_CLAIMS: Final = MappingProxyType({})             # shared; a dataclass default must be immutable
 
 @dataclass(frozen=True)
 class Principal:
-    agent: str  # required, e.g. "refund-agent"
-    user: str | None = None  # human on whose behalf, if any
-    claims: Mapping[str, str | int | bool] = _NO_CLAIMS  # verified, from the provider (§3)
-    issuer: str | None = None  # who verified it, e.g. a JWT `iss`
-    expires_at: datetime | None = None  # when the credential stops being valid
+    agent: str                                       # required, e.g. "refund-agent"
+    user: str | None = None                          # human on whose behalf, if any
+    claims: Mapping[str, str | int | bool] = _NO_CLAIMS   # verified, from the provider (§3)
+    issuer: str | None = None                        # who verified it, e.g. a JWT `iss`
+    expires_at: datetime | None = None               # when the credential stops being valid
 ```
 
 `Principal` stays `frozen=True` and stays **unhashable**, as it is today: `Mapping` is not
@@ -2401,7 +2400,7 @@ from .identity import (
     HeaderIdentityProvider,
 )
 from .authority import Authority, Grant, Subject, Delegation, AuthorityResult
-from .policy import Condition, parse_conditions  # promoted; see below
+from .policy import Condition, parse_conditions       # promoted; see below
 from .state import DelegationRecord
 from .errors import AuthorityDenied, AuthorityEscalation, IdentityError
 # lazily importable, not re-exported at package import:
@@ -2484,13 +2483,9 @@ with `-41001`'s `data` shape, and `v0.2 §6.10`'s `DENY` row narrowed to policy 
 Errors:
 
 ```python
-class IdentityError(CTRLRunError): ...  # a credential was offered and rejected
-
-
-class AuthorityDenied(ActionDenied): ...  # reason: §4.3; grant_id, delegation_id
-
-
-class AuthorityEscalation(CTRLRunError): ...  # reason: §5.3; a delegation that may not exist
+class IdentityError(CTRLRunError): ...           # a credential was offered and rejected
+class AuthorityDenied(ActionDenied): ...         # reason: §4.3; grant_id, delegation_id
+class AuthorityEscalation(CTRLRunError): ...     # reason: §5.3; a delegation that may not exist
 ```
 
 `AuthorityDenied` subclasses `ActionDenied`: an authority denial *is* the action being denied, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,21 @@ ignore_missing_imports = true
 line-length = 100
 target-version = "py311"
 src = ["src", "tests"]
+# So an exclusion means the same thing however ruff is invoked. Without this, a path named
+# explicitly on the command line skips the exclude list, and `ruff format docs/SPEC-v0.3.md`
+# would reformat what `ruff format` leaves alone — the same surprise in a smaller box.
+force-exclude = true
+
+[tool.ruff.format]
+# The formatter reads Python code blocks inside Markdown; the linter does not (`ruff check`
+# on a `.md` reports "No Python files found"). That asymmetry is a trap: whether a spec's
+# examples get reformatted depends on whether they happen to parse, so SPEC-v0.1 and v0.2
+# keep their aligned comments only because theirs carry placeholders like `<generated>`, and
+# SPEC-v0.3 lost its alignment to a check that had never fired before. A specification's code
+# blocks are illustration, not code — they elide, they annotate, they line comments up to be
+# read — and the formatter has no way to know that. So it leaves Markdown alone, and the two
+# tools now agree on what a `.md` file is.
+exclude = ["*.md"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "B", "ANN", "SIM", "RUF"]

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Everything CI's `check` job runs, in one place, cheapest first.
+#
+# CI calls this file rather than naming the tools itself, so "it passed locally" and "it
+# passed in CI" cannot come to mean different things. They did once: `ruff format` reads
+# Python code blocks inside Markdown and `ruff check` does not, so a spec whose blocks
+# happened to parse went red on a check that had never fired before, found by CI rather than
+# by the person who wrote it. The formatter now leaves Markdown alone; this file is what
+# keeps the next such asymmetry from being discovered the same way.
+#
+# `test_ci_runs_the_check_script` fails if CI stops calling it.
+#
+# Cheapest first, so a formatting slip costs a second rather than a full test run. The tools
+# run through `python -m`, so they come from the same environment as the `ctrlrun` they are
+# checking. Set PYTHON to pick a different interpreter.
+set -eu
+
+PYTHON="${PYTHON:-python3}"
+
+run() {
+    printf '\n=== %s ===\n' "$*"
+    "$PYTHON" -m "$@"
+}
+
+run ruff format --check
+run ruff check
+run mypy --strict src
+run pytest
+
+printf '\nall checks passed\n'

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -17,6 +17,7 @@ import tomllib
 from pathlib import Path
 
 import pytest
+import yaml
 
 from ctrlrun import MissingDependency
 
@@ -95,6 +96,73 @@ def test_the_otel_extra_declares_the_api_sdk_and_exporter():
     assert "opentelemetry-api" in declared
     assert "opentelemetry-sdk" in declared
     assert "otlp" in declared
+
+
+_UNFORMATTED_BLOCK = """A specification, whose code blocks are illustration rather than code.
+
+```python
+@dataclass(frozen=True)
+class Principal:
+    agent: str                     # aligned, because a reader compares these down the column
+    user: str | None = None        # and the alignment is the point
+```
+"""
+
+
+def _ruff_format_check(path):
+    return subprocess.run(
+        [sys.executable, "-m", "ruff", "format", "--check", "--no-cache", str(path)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def test_the_formatter_leaves_markdown_alone():
+    """`ruff format` reads Python code blocks inside Markdown and `ruff check` does not, so
+    whether a spec's examples get reformatted turns on whether they happen to parse. SPEC-v0.1
+    and v0.2 keep their aligned comments only because theirs carry unparseable placeholders;
+    SPEC-v0.3's parse, and a CI check that had never fired before went red on them.
+
+    A specification's blocks elide and annotate and line comments up to be read. The formatter
+    cannot know that, so `[tool.ruff.format] exclude` tells it, and this test is what stops the
+    exclusion being dropped by someone who does not meet the trap until CI does.
+    """
+    spec = REPO_ROOT / "docs" / "_formatter_probe.md"
+    spec.write_text(_UNFORMATTED_BLOCK, encoding="utf-8")
+    try:
+        assert _ruff_format_check(spec).returncode == 0, "the formatter reformatted a .md file"
+    finally:
+        spec.unlink()
+
+
+def test_the_formatter_would_have_reformatted_that_block_as_python():
+    """The control for the test above. Without it, a `ruff` that had stopped working, or a
+    block that was already formatted, would pass it — a negative test against something the
+    environment already prevents proves nothing (SPEC-v0.2's mutation notes)."""
+    module = REPO_ROOT / "_formatter_probe.py"
+    module.write_text(_UNFORMATTED_BLOCK.split("```python\n")[1].split("```")[0], encoding="utf-8")
+    try:
+        assert _ruff_format_check(module).returncode != 0, (
+            "the probe is already formatted, so the .md assertion proves nothing"
+        )
+    finally:
+        module.unlink()
+
+
+def test_ci_runs_the_check_script():
+    """`scripts/check.sh` is what CI's `check` job runs, so "it passed locally" and "it passed
+    in CI" cannot come to mean different things. If a step here goes back to naming the tools
+    inline, the two ends can drift again — which is how the Markdown surprise reached `main`."""
+    workflow = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text())
+    steps = workflow["jobs"]["check"]["steps"]
+    commands = " ".join(step.get("run", "") for step in steps)
+
+    assert "scripts/check.sh" in commands
+    for tool in ("pytest", "mypy", "ruff"):
+        assert f"\n{tool}" not in commands and not commands.strip().startswith(tool), (
+            f"CI's check job invokes {tool} directly; it should go through scripts/check.sh"
+        )
 
 
 def test_core_declares_only_pyyaml_and_click():

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -11,6 +11,7 @@ in-process it would pass or fail on whatever pytest happened to import first.
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 import tomllib
@@ -98,27 +99,39 @@ def test_the_otel_extra_declares_the_api_sdk_and_exporter():
     assert "otlp" in declared
 
 
-_UNFORMATTED_BLOCK = """A specification, whose code blocks are illustration rather than code.
-
-```python
-@dataclass(frozen=True)
+#: A spec-shaped code block: valid Python, and deliberately not what the formatter would write.
+_ALIGNED_BLOCK = """@dataclass(frozen=True)
 class Principal:
-    agent: str                     # aligned, because a reader compares these down the column
+    agent: str                     # aligned, so a reader can compare down the column
     user: str | None = None        # and the alignment is the point
-```
 """
 
+_SPEC_PAGE = (
+    "A specification, whose code blocks are illustration rather than code.\n\n"
+    "```python\n" + _ALIGNED_BLOCK + "```\n"
+)
 
-def _ruff_format_check(path):
+
+def _ruff_format_check(path: Path) -> int:
+    """`ruff format --check` under this repository's configuration, on one file."""
     return subprocess.run(
-        [sys.executable, "-m", "ruff", "format", "--check", "--no-cache", str(path)],
+        [
+            sys.executable,
+            "-m",
+            "ruff",
+            "format",
+            "--check",
+            "--no-cache",
+            "--config",
+            str(REPO_ROOT / "pyproject.toml"),
+            str(path),
+        ],
         capture_output=True,
         text=True,
-        cwd=REPO_ROOT,
-    )
+    ).returncode
 
 
-def test_the_formatter_leaves_markdown_alone():
+def test_the_formatter_leaves_markdown_alone(tmp_path):
     """`ruff format` reads Python code blocks inside Markdown and `ruff check` does not, so
     whether a spec's examples get reformatted turns on whether they happen to parse. SPEC-v0.1
     and v0.2 keep their aligned comments only because theirs carry unparseable placeholders;
@@ -128,39 +141,41 @@ def test_the_formatter_leaves_markdown_alone():
     cannot know that, so `[tool.ruff.format] exclude` tells it, and this test is what stops the
     exclusion being dropped by someone who does not meet the trap until CI does.
     """
-    spec = REPO_ROOT / "docs" / "_formatter_probe.md"
-    spec.write_text(_UNFORMATTED_BLOCK, encoding="utf-8")
-    try:
-        assert _ruff_format_check(spec).returncode == 0, "the formatter reformatted a .md file"
-    finally:
-        spec.unlink()
+    page = tmp_path / "SPEC-probe.md"
+    page.write_text(_SPEC_PAGE, encoding="utf-8")
+
+    assert _ruff_format_check(page) == 0, "the formatter wants to rewrite a Markdown file"
 
 
-def test_the_formatter_would_have_reformatted_that_block_as_python():
-    """The control for the test above. Without it, a `ruff` that had stopped working, or a
-    block that was already formatted, would pass it — a negative test against something the
-    environment already prevents proves nothing (SPEC-v0.2's mutation notes)."""
-    module = REPO_ROOT / "_formatter_probe.py"
-    module.write_text(_UNFORMATTED_BLOCK.split("```python\n")[1].split("```")[0], encoding="utf-8")
-    try:
-        assert _ruff_format_check(module).returncode != 0, (
-            "the probe is already formatted, so the .md assertion proves nothing"
-        )
-    finally:
-        module.unlink()
+def test_the_formatter_would_have_reformatted_that_block_as_python(tmp_path):
+    """The control for the test above. Without it a `ruff` that had stopped working — or a
+    block that was already formatted — would pass that test while proving nothing, which is a
+    negative test against something the environment already prevents."""
+    module = tmp_path / "probe.py"
+    module.write_text(_ALIGNED_BLOCK, encoding="utf-8")
+
+    assert _ruff_format_check(module) != 0, (
+        "the probe is already formatted, so the Markdown assertion proves nothing"
+    )
 
 
 def test_ci_runs_the_check_script():
     """`scripts/check.sh` is what CI's `check` job runs, so "it passed locally" and "it passed
-    in CI" cannot come to mean different things. If a step here goes back to naming the tools
-    inline, the two ends can drift again — which is how the Markdown surprise reached `main`."""
-    workflow = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text())
-    steps = workflow["jobs"]["check"]["steps"]
+    in CI" cannot come to mean different things. If a step goes back to naming the tools inline
+    the two ends can drift again, which is how the Markdown surprise reached `main`.
+
+    Skipped outside a checkout: `MANIFEST.in` prunes `.github`, so an sdist carries no workflow
+    to read and a packager building from one has no CI wiring to check.
+    """
+    workflow = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+    if not workflow.exists():
+        pytest.skip("no repository checkout")
+    steps = yaml.safe_load(workflow.read_text())["jobs"]["check"]["steps"]
     commands = " ".join(step.get("run", "") for step in steps)
 
     assert "scripts/check.sh" in commands
     for tool in ("pytest", "mypy", "ruff"):
-        assert f"\n{tool}" not in commands and not commands.strip().startswith(tool), (
+        assert not re.search(rf"(^|\s){tool}\s", commands), (
             f"CI's check job invokes {tool} directly; it should go through scripts/check.sh"
         )
 


### PR DESCRIPTION
`ruff format` reads Python code blocks inside Markdown. `ruff check` does not —
`ruff check docs/SPEC-v0.3.md` reports *"No Python files found"*.

So whether a specification's examples get rewritten turns on **whether they happen to parse**.
`SPEC-v0.1.md` and `SPEC-v0.2.md` keep their aligned comments only because theirs carry
unparseable placeholders (`action_id: str = <generated>`); `SPEC-v0.3.md`'s parse, so a check
that had never fired before went red on it — and the alignment was flattened to make it green:

```diff
-    agent: str                     # required, e.g. "refund-agent"
-    user: str | None = None        # human on whose behalf, if any
+    agent: str  # required, e.g. "refund-agent"
+    user: str | None = None  # human on whose behalf, if any
```

That is the wrong direction. A spec's code blocks are **illustration, not code**. They elide,
they annotate, and they line comments up so a reader can compare down the column — which is
exactly what a code formatter removes. And the inconsistency is worse than either choice on its
own: two specs aligned, one not, decided by luck.

## The fix

- `[tool.ruff.format] exclude = ["*.md"]` — the formatter leaves Markdown alone, so it and the
  linter now agree on what a `.md` file is.
- `force-exclude = true` — so an exclusion means the same thing however ruff is invoked. Without
  it, `ruff format docs/SPEC-v0.3.md` would still rewrite what bare `ruff format` leaves alone:
  the same surprise in a smaller box.
- SPEC-v0.3's alignment is restored by reversing the commit that took it.

**`test_the_formatter_leaves_markdown_alone`** pins it, because a config line nobody tests is a
config line somebody deletes. It writes a deliberately unformatted block into a `.md` and
asserts the formatter leaves it. A companion test writes *the same block* as a `.py` and asserts
the formatter does want to rewrite it — so the first is not passing because ruff stopped working
or because the probe was formatted all along.

## Secondary: one entry point for the checks

You may want to drop this half; it is a separate concern in the same incident.

The Markdown surprise was found by CI rather than by the person who wrote it, because running
`ruff check` locally was not running what CI ran. `scripts/check.sh` is now what CI's `check`
job executes — `ruff format --check`, `ruff check`, `mypy --strict src`, `pytest`, cheapest
first — so "it passed locally" and "it passed in CI" cannot come to mean different things.
`test_ci_runs_the_check_script` fails if a step goes back to naming the tools inline.

The tools run through `python -m`, so they come from the same environment as the `ctrlrun` they
are checking rather than whatever is first on `PATH`.

## Mutation table

| Mutation | Result | Restored |
|---|---|---|
| `exclude = ["*.md"]` → `exclude = []` | `test_the_formatter_leaves_markdown_alone` **failed** — and the control still passed, so the probe was genuinely unformatted | both pass |
| CI step calls `ruff`/`pytest` inline instead of the script | `test_ci_runs_the_check_script` **failed** | passes |

## Checks

`./scripts/check.sh` — 1290 passed (3 new), `mypy --strict` clean, both ruff checks clean.
