### PR TITLE
spec: the environment belongs to the deployment, not to the call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ shipped, and the only thing in the tree today is the contract.
 
 ### Changed
 
+- **Four edits claimed by the previous change were never in the file.** A batch that wrote only
+  at the end discarded every successful replacement before the one that raised, and only the
+  failing one was re-run — so `authority_unreadable` was referenced by §4.6, three rows of §9 and
+  T77d while §4.3's closed reason set never defined it; the precedence order was never reordered;
+  the `pyyaml>=6.0` rationale was missing from §4.2; and `authority_grant` still had no route into
+  evidence. A later edit then deleted §4.2's `environments` paragraph believing it a duplicate,
+  when it was the only copy. All five are restored, and the tooling now writes after each edit so
+  a later failure cannot undo an earlier success.
 - **BREAKING: `context(environment=...)` is removed; `Control` takes `environment=` instead.**
   v0.3 makes the environment an authorization input — a grant may scope to
   `environments: ["staging"]` — and a dimension the subject sets is not one. On the decorator path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ shipped, and the only thing in the tree today is the contract.
 
 ### Changed
 
+- **BREAKING: `context(environment=...)` is removed; `Control` takes `environment=` instead.**
+  v0.3 makes the environment an authorization input — a grant may scope to
+  `environments: ["staging"]` — and a dimension the subject sets is not one. On the decorator path
+  the value came from the agent's own call site, so a grant scoped to staging was a real
+  restriction through the gateway and decoration in-process.
+
+  It is now set once per `Control`, from its `environment=` argument, else
+  `$CTRLRUN_ENVIRONMENT`, else the policy document's top-level `environment:`, else
+  `"production"`. The gateway's `--environment` and the ACS hook's configuration are unchanged —
+  they were already this rule. A deployment that ran several environments from one process runs
+  one `Control` each. `SPEC-v0.1.md` §8's frozen signature is amended in the same change, as the
+  rule for a frozen name requires.
+
 - **`docs/SPEC-v0.3.md` amended against an independent review of §4 and §5.** The contract was
   read by two reviewers who had not written it, and they found two authorization holes the
   author's own pass had missed.

--- a/docs/SPEC-v0.1.md
+++ b/docs/SPEC-v0.1.md
@@ -517,7 +517,10 @@ protect(name: str, *, effect: str | None = None, resource: str | None = None,
         wait: bool = False, lease: timedelta | None = None,
         control: Control | None = None) -> Callable
 
-context(agent: str, user: str | None = None, environment: str | None = None) -> ContextManager
+context(agent: str, user: str | None = None) -> ContextManager
+# `environment` was a parameter here until v0.3. SPEC-v0.3 §2.5 removed it: the environment
+# became an authorization input, and a dimension the subject sets is not one. It is set once
+# on the Control instead.
 with_approval(request_id: str) -> ContextManager
 
 Control.from_file(path=None) -> Control

--- a/docs/SPEC-v0.1.md
+++ b/docs/SPEC-v0.1.md
@@ -526,7 +526,11 @@ with_approval(request_id: str) -> ContextManager
 Control.from_file(path=None) -> Control
 Control(policy: Policy, store: StateStore, approvals: ApprovalProvider | None = None, *,
         clock=..., approval_ttl: timedelta = timedelta(minutes=15),
-        lease: timedelta = timedelta(minutes=5))
+        lease: timedelta = timedelta(minutes=5),
+        environment: str | None = None)
+# `environment` was added in v0.3 when it became an authorization input; SPEC-v0.3 §2.5 has
+# the four sources it resolves from. `Control.from_file()` passes none, so it reaches ranks
+# 2 to 4 -- the env var, the document, then "production".
 Control.evaluate(action: Action) -> Evaluation   # decision + reason, no side effects
 Control.execute(action: Action, executor: Callable[[], Any], effect_key: str | None,
                 *, lease: timedelta | None = None) -> Receipt

--- a/docs/SPEC-v0.3.md
+++ b/docs/SPEC-v0.3.md
@@ -426,6 +426,47 @@ places make opposite trade-offs deliberately.
 The `ctrlrun inspect` and OTel changes above ship with **build-list item 1**, alongside the
 `Principal` fields they display; `ctrlrun.inspection/v1` becomes `v2` there (§12.2).
 
+### 2.5 The environment belongs to the deployment, not to the call
+
+`Action.environment` is an authorization input in v0.3: §4.2 lets a grant scope to
+`environments: ["staging"]`, and §4.3 makes it one of the four things a grant must match on. So it
+comes under the rule §3.2 applies to the principal — **the subject never sets the environment it
+is authorized in** — and v0.1's arrangement, where `context(environment=...)` took it from the
+agent's own call site, cannot survive that.
+
+**`context(environment=...)` is removed.** `context()` takes `agent` and `user` and nothing else.
+The environment is set once, on the `Control`, and every Action inherits it:
+
+```python
+Control(..., environment: str | None = None)
+```
+
+resolved at construction, in this order, and fixed for the life of the object:
+
+1. the `environment=` argument, where one was passed;
+2. `$CTRLRUN_ENVIRONMENT`, where it is set — set but empty is `InvalidArgument`, as
+   `CTRLRUN_CONFIG` and `CTRLRUN_STATE` are (`v0.1 §3.4`, `§8`): a configured-but-blank
+   deployment name is a misconfiguration, and falling back would put actions in an environment
+   nobody chose;
+3. the policy document's top-level `environment:` key (§12.1);
+4. `"production"`.
+
+The gateway keeps `--environment` and the ACS hook keeps its own configuration (§8.4); both are
+this rule already, which is why they needed no change. What changes is that the decorator path now
+agrees with them, so the sentence holds on **every** entry point of §4.3.1 rather than on two of
+three.
+
+This is a **breaking change to a frozen name** (`v0.1 §8`), and it is worth what it costs. An
+authorization dimension the subject can set is not an authorization dimension; keeping the
+parameter would have meant a specification that spends a paragraph explaining when
+`environments:` is real and when it is decoration. A deployment that ran different environments
+from one process — the case the parameter served — runs one `Control` each, which is what "the
+environment is a property of the deployment" means in code.
+
+`ctrlrun.example.yaml` and the sector templates gain no `environment:` key: `"production"` is the
+fail-closed default, and a starting-point policy that named a non-production environment would be
+a starting point that switched a guarantee off.
+
 ---
 
 ## 3. `IdentityProvider`
@@ -853,20 +894,6 @@ think of — the wildcard outcome §5.4's `subject` row forbids, reached in N re
 Requiring an expiry makes §5.4's `expires_at` row bound every descendant in time by construction,
 so an unexpiring delegation minted at runtime becomes unrepresentable. It is one line in the
 document and it is the only dimension that bounds a chain the operator has stopped watching.
-
-**`environments` is an authorization dimension, and v0.3 does not authenticate it.** This is
-stated rather than implied, because the rest of §4 rests on the opposite property for the
-principal. `Action.environment` has three sources: `context(environment=...)`, which is a free
-string from the agent's own call site; `AcsControlHook`, which §8.4 now takes from configuration
-rather than the envelope; and the gateway's `--environment`, which is the operator's. Only the last
-two are worth anything to an authorization decision.
-
-So a grant scoped `environments: ["staging"]` is a real restriction **only where the environment is
-set by something the agent does not control**. In-process, under `@protect` and `context()`, it is
-not: the same code that proposes the action names the environment it is proposed in. An operator
-who needs environment scoping enforced runs the gateway, or supplies the environment from their own
-trusted configuration. `docs/THREAT_MODEL.md` carries this beside the delegator (§5.7) and the
-approver (`v0.1 §4.1`), which are unauthenticated for the same kind of reason. §13 records it.
 
 **Subject matching addresses `agent` and `user`, and nothing else.** Not claims, not the issuer.
 Both fields are part of the action's canonical form (`v0.1 §2.2`), so an authority decision is
@@ -2213,6 +2240,9 @@ is individually configurable**, and there is no flag that makes any single one o
 | A pattern outside §4.4's grammar | `PolicyError` at load | |
 | `mode:` anywhere but the top level of the policy document | `PolicyError` at load | |
 | `mode:` not exactly `observe` or `enforce` | `PolicyError` at load | |
+| `$CTRLRUN_ENVIRONMENT` set but empty | `InvalidArgument`; never a fallback to the default (§2.5) | |
+| `environment:` present and not a non-empty string | `PolicyError` at load | |
+| `context(environment=...)` | `TypeError` — the parameter is gone (§2.5) | |
 | `authority:` or `mode:` in a `v1`/`v2` document | `PolicyError` at load, naming the key and `ctrlrun.policy/v3` | |
 | `actions:` or `mode:` in an `--authority` document | `PolicyError` at load, naming the file and the key | |
 | Gateway: `--principal-from-client-info` | exit non-zero, naming `--principal-header` | |
@@ -2293,6 +2323,16 @@ provider-raises row asserts `IdentityError`, that the executor's call count is 0
 receipt was written — three behaviours, because asserting only the exception class cannot tell a
 refusal from a refusal that already ran the action.
 
+#### T65d — The environment comes from the deployment, not the call
+`context(environment="staging")` raises `TypeError`: the parameter is gone (§2.5), and asserting
+the removal by signature rather than by behaviour is what stops it being quietly reinstated.
+Resolution order is parametrized against a fake environment and a fake document: the
+`Control(environment=...)` argument wins; else `$CTRLRUN_ENVIRONMENT`; else the document's
+`environment:`; else `"production"`. `$CTRLRUN_ENVIRONMENT` set but empty raises `InvalidArgument`
+rather than falling through — asserted, because falling through is the failure that puts actions
+in an environment nobody chose. Every `Action` built under one `Control` carries the same
+environment whatever the calling code does.
+
 #### T65b — `--principal-from-client-info` is gone
 `ctrlrun gateway --principal-from-client-info ...` exits non-zero, and stderr names
 `--principal-header`. The gateway does not start; no socket is bound.
@@ -2326,6 +2366,16 @@ has one → passes; `agent: "*"` against a dotted agent name; a `subject.agent` 
 against a name sharing only the prefix → denied. Each asserts the reason, so deleting the
 `user is not None` check fails a test rather than silently letting an agent inherit a human's
 grant.
+
+#### T67c — A grant scoped to another environment does not match
+A grant with `environments: ["staging"]`, an action that matches it on subject, name and resource
+in every respect, and a `Control` constructed `environment="production"`. Then
+`AuthorityDenied(reason="no_authority")` — by reason — and the executor never ran. The same grant
+under a `Control` constructed `environment="staging"` passes, which is the control: without it an
+implementation that matched no environment at all would satisfy the first half.
+
+The point of the pair is that **no calling code participates**. There is no argument the protected
+function can pass, and no `context()` parameter, that changes which of the two outcomes it gets.
 
 #### T68 — A matching grant passes to policy
 Subject, action, resource and environment all match and the constraints hold. Then
@@ -2692,7 +2742,10 @@ class Principal:                       # extended, v0.1 §2.1
     expires_at: datetime | None = None
 
 Control(..., identity: IdentityProvider | None = None,
-             authority: Authority | None = None)
+             authority: Authority | None = None,
+             environment: str | None = None)          # §2.5
+
+context(agent: str, user: str | None = None)          # `environment` REMOVED — §2.5
 Control.authority -> Authority | None
 Control.delegate(parent_id: str, grant: Grant, *, by: Principal) -> Delegation
 Control.revoke(delegation_id: str, *, by: str | None = None) -> None
@@ -2744,6 +2797,11 @@ deleted from the document cannot be found by walking downward from the ids that 
 - `RESERVED_ARGUMENTS` gains `claims`, `issuer` and `expires_at` (§4.5) — a **breaking** change
   for a protected function taking an argument by one of those names, in documents of every
   schema version (§12.1).
+- **`context(environment=...)` is removed** and `Control` gains `environment=` (§2.5). A
+  **breaking** change to a name `v0.1 §8` froze, made because an authorization dimension the
+  subject can set is not one. `$CTRLRUN_ENVIRONMENT` and the document's top-level `environment:`
+  are the other two sources. `v0.1 §8`'s signature is amended in the same item, as the rule for a
+  frozen name requires.
 
 **Removed.** `ctrlrun gateway --principal-from-client-info`, and the
 `GatewayConfig.principal_from_client_info` field behind it (§8.1).
@@ -2833,8 +2891,10 @@ it on `v3` would leave the same name meaning two things in two files — which i
 and `Control` cannot be constructed until the argument is renamed. The load error says so. T74b
 asserts it against a `v1` document, so the breakage is a tested decision rather than a surprise.
 
-The top-level key set grows to `schema`, `actions`, `mode`, `authority`, and stays closed. An
-`--authority` document has its own, smaller closed set (§8.3).
+The top-level key set grows to `schema`, `actions`, `mode`, `authority` and `environment`, and
+stays closed. `environment:` MUST be a non-empty string; it is the third of §2.5's four sources
+and needs `ctrlrun.policy/v3` like the other two new keys. An `--authority` document has its own,
+smaller closed set (§8.3).
 
 `ctrlrun init` keeps writing `v1`: the smallest working policy is still the right starting point,
 and adding authority means changing the schema line, which is a visible act of opting in.
@@ -2897,10 +2957,6 @@ Everything in `v0.1 §9` and `v0.2 §12` that v0.3 does not deliver, and specifi
   (§5.7, §7).
 - **Authenticating the delegator.** `ctrlrun delegate --as` is an assertion, recorded as one
   (§5.7) — the same position `v0.1 §4.1` takes on the approver, who is also still unauthenticated.
-- **Authenticating the environment.** `environments:` scopes a grant, and in-process the
-  environment is whatever `context()` said (§4.2). It is a real restriction only where something
-  the agent does not control supplies it, which in v0.3 means the gateway or the ACS hook's own
-  configuration.
 - **Sweeping a subtree of delegations.** `ctrlrun revoke` takes one id and v0.3 lists none, so the
   answer to a chain of unknown width is `delegable: false` on the root grant plus a restart
   (§5.6).

--- a/docs/SPEC-v0.3.md
+++ b/docs/SPEC-v0.3.md
@@ -373,6 +373,14 @@ never be honoured must not spend a human's attention.
 that requires every principal to carry an expiry enforces that in its provider, which is the
 component that knows what it verified.
 
+**`Control.evaluate` cannot do any of that**, because §11 requires it to write nothing. So for
+that one entry point the expiry check is a decision rather than a refusal: it returns
+`Evaluation(Decision.DENY, "principal_expired")`, appends no event and writes no receipt. Stated
+because §4.3.1 subjects `evaluate` to the same ordered checks as the rest, and a check defined
+only as side effects would otherwise have no meaning on the one path that may not have them — and
+because §8.3 sends the gateway's approval pre-check through `evaluate`, so the three plausible
+readings give three different gateway behaviours.
+
 `IdentityError`, not `ActionDenied`: an agent loop's `except ActionDenied` is written to handle
 a policy saying no, and a credential that stopped being valid is not that. This is the same
 distinction `v0.1 §5.1` draws for `EffectKeyError`.
@@ -390,12 +398,11 @@ implementer:
 |---|---|---|
 | Committing, failing or marking ambiguous an outcome | **not refused** | The effect has already happened at the remote. Refusing the write would strand a real-world effect in `AMBIGUOUS` for a clock reason, which is the one mistake `v0.1 §5.5` exists to prevent |
 | Extending a lease (`v0.2 §6.9.4`) | **refused** | An extension is a request to keep holding authority the credential no longer carries. Refusing lets the lease lapse, and a lapsed lease is `AMBIGUOUS` (`v0.1 §5.3 E3`) — the safe state, reached by the ordinary path |
-| `Control.resume` (`v0.2 §6.9`) | **evaluated and recorded, not re-decided** | Exactly what `v0.2 §6.9.2` chose for policy on the same leg, for the same reason: the reservation is held and the remote may already be acting on it |
+| `Control.resume` (`v0.2 §6.9`) | **not re-evaluated** | The receipt carries `principal.expires_at` (§2.4) whether or not a check ran, so a check here would change nothing a reader or a test could see. §5.6.1's resume row is different, and does re-evaluate, because the combined decision it records *is* observable |
 
 A refused lease extension appends `ACTION_DENIED` with `data.reason = "principal_expired"` and
 raises `IdentityError`; it does not move the effect record, which the expiring lease will do on
-its own. The resumed leg records the expiry in its receipt (`decision_reason` stays whatever the
-resumption reached) and appends `ACTION_DENIED` for nothing — there is nothing to deny.
+its own.
 
 ### 2.4 Where claims appear
 
@@ -447,14 +454,32 @@ resolved at construction, in this order, and fixed for the life of the object:
 2. `$CTRLRUN_ENVIRONMENT`, where it is set — set but empty is `InvalidArgument`, as
    `CTRLRUN_CONFIG` and `CTRLRUN_STATE` are (`v0.1 §3.4`, `§8`): a configured-but-blank
    deployment name is a misconfiguration, and falling back would put actions in an environment
-   nobody chose;
+   nobody chose. The check runs **whenever the variable is present**, including when rank 1
+   supplied the value — a blank deployment name is a misconfiguration whether or not something
+   else happened to win, and short-circuiting past it would make the refusal depend on how the
+   `Control` was constructed. `Control(environment="")` is `InvalidArgument` at construction for
+   the same reason;
 3. the policy document's top-level `environment:` key (§12.1);
 4. `"production"`.
 
-The gateway keeps `--environment` and the ACS hook keeps its own configuration (§8.4); both are
-this rule already, which is why they needed no change. What changes is that the decorator path now
-agrees with them, so the sentence holds on **every** entry point of §4.3.1 rather than on two of
-three.
+**`Control.execute` refuses an `Action` whose `environment` is not its own.** `Action(...)` is
+public and `Control.execute(action, ...)` is frozen API, so a caller can hand over an Action
+carrying any environment it likes; without this check §4.3.1's second row is a hole straight
+through the rule above, and `Action` is frozen so the environment cannot be re-stamped. The
+refusal is `InvalidArgument` — a wiring bug, not a policy saying no — and unlike the
+principal-disagreement check §3.1 declines to add, it breaks almost nothing: both sides default to
+`"production"`, so only a caller that deliberately set a different one is affected, and that is
+the caller this is for.
+
+The gateway takes `--environment` and the ACS hook its own configuration (§8.4). The gateway was
+already this rule. The ACS hook was **not** — it reads `params.metadata.environment` off the
+inbound envelope today — and §8.4 is the amendment that stops it. That amendment ships with
+build-list item 5 while authority ships with item 2, so **`AcsControlHook` MUST refuse to be
+constructed against a `Control` holding an `Authority` from item 2 onward**, not from item 5.
+Between those two items the hook is otherwise an entry point where the caller supplies both the
+principal and the environment while authority enforces on both. With the decorator path and the direct-execute
+path both settled, the sentence holds on **every** row of §4.3.1's table rather than on some of
+them.
 
 This is a **breaking change to a frozen name** (`v0.1 §8`), and it is worth what it costs. An
 authorization dimension the subject can set is not an authorization dimension; keeping the
@@ -462,6 +487,24 @@ parameter would have meant a specification that spends a paragraph explaining wh
 `environments:` is real and when it is decoration. A deployment that ran different environments
 from one process — the case the parameter served — runs one `Control` each, which is what "the
 environment is a property of the deployment" means in code.
+
+**A rehydrated Action is checked the same way.** `Control.resume` takes its Action from the store
+(`v0.2 §6.9`), so it carries the environment of the `Control` that proposed it. Resuming it on a
+`Control` with a different one is refused — `InvalidArgument`, as above — because §5.6.1 makes the
+resumed leg re-evaluate authority for its receipt and extend a lease, and evaluating a staging
+action's authority inside a production deployment is the fail-open this section exists to close. A
+continuation is a store-wide token, so without the check the mismatch is reachable by design
+rather than by accident.
+
+**Two `Control`s in different environments MUST NOT share a store.** This is the corollary of
+"runs one `Control` each", and it needs saying because `Control.from_file()` puts the store beside
+the policy (`v0.1 §8`), so two Controls built from one `ctrlrun.yaml` share one by default. Effect
+keys carry no environment — `v0.1 §5.1`'s template sees arguments and `{resource}`, nothing else —
+so a staging `refund:txn_1` reserves the key a production refund of the same transaction needs,
+and the production action is refused as a duplicate, or blocked by a staging `AMBIGUOUS` record
+only a human can clear. Give each environment its own `CTRLRUN_STATE`. v0.2 had the same
+collision; what is new is that §2.5 tells an operator to run several Controls, so it must also
+tell them this.
 
 `ctrlrun.example.yaml` and the sector templates gain no `environment:` key: `"production"` is the
 fail-closed default, and a starting-point policy that named a non-production environment would be
@@ -493,8 +536,9 @@ Control(..., identity: IdentityProvider | None = None)
 `resolve` is called once per action, before the `Action` is constructed — it has to be, since
 an Action cannot exist without a principal (`v0.1 §2.1`).
 
-**Where it runs, and where it does not.** There are exactly two places that build an `Action`,
-and they are the two that resolve: `@protect`'s wrapper, and the gateway. `Control.execute` and
+**Where it runs, and where it does not.** Three places build an `Action`, and they are the three
+that resolve: `@protect`'s wrapper, the gateway, and `ctrlrun.acs`'s request hook (§8.4). §4.3.1's
+table is the enumeration; this paragraph is about what follows from it. `Control.execute` and
 `Control.evaluate` take an already-constructed `Action` (`v0.1 §8`, unchanged), so a caller that
 builds an `Action` by hand and passes it to `Control.execute` supplies its own `Principal` and
 the provider never runs.
@@ -508,9 +552,10 @@ is — has no such path, because the gateway builds the Action and the client ne
 `Control.execute`: it would be a check against the wrong threat, and it would break every
 existing caller that builds Actions for tests and tools.
 
-**The environment**, when a provider answers and no `context()` is active, is `"production"` —
-`v0.1 §2.1`'s default — for both `IdentityContext.environment` and the `Action`. The gateway
-supplies `--environment` instead (`v0.2 §6.5`).
+**The environment** is not this section's to decide: it comes from the `Control`, the gateway or
+the ACS hook, per §2.5, and `IdentityContext.environment` carries whichever of those applies. It
+is never `v0.1 §2.1`'s dataclass default reached by falling through, and it never depends on
+whether a `context()` is active — `context()` no longer carries one.
 
 `IdentityContext.headers` is a mapping with **lowercased** header names, because HTTP header
 names are case-insensitive and a provider that had to guess the casing would be a provider that
@@ -895,6 +940,14 @@ Requiring an expiry makes §5.4's `expires_at` row bound every descendant in tim
 so an unexpiring delegation minted at runtime becomes unrepresentable. It is one line in the
 document and it is the only dimension that bounds a chain the operator has stopped watching.
 
+**`environments` is a real restriction on every path**, because §2.5 takes the value away from
+the caller: it is set once on the `Control`, from its argument, `$CTRLRUN_ENVIRONMENT`, the
+document, or `"production"`, and the gateway and the ACS hook take it from their own
+configuration. A grant scoped `environments: ["staging"]` therefore means what it looks like it
+means, wherever the action is proposed from. It is matched by exact string, not by pattern (§4.4),
+because an environment name is a short closed list and a glob over it buys nothing but a way to
+typo `prod*` into matching `production-canary`.
+
 **Subject matching addresses `agent` and `user`, and nothing else.** Not claims, not the issuer.
 Both fields are part of the action's canonical form (`v0.1 §2.2`), so an authority decision is
 stable under the token rotation §2.2 describes; a claim is not. Matching a grant on a claim is
@@ -908,11 +961,25 @@ parses an unquoted `2026-12-31T23:59:59Z` into a `datetime` and an unquoted
 accepted on input and both must be rejected when they carry no offset. The comparison is
 `now > expires_at → expired`; a grant is valid up to and including its expiry instant.
 
+That rule needs a floor under the YAML parser, and v0.3 adds one: **`pyyaml>=6.0`** in
+`dependencies`, where the core requirement was previously unpinned. PyYAML 6 returns an
+offset-aware `datetime` for a timestamp carrying one; PyYAML 5 subtracts the offset and returns a
+naive value, which would reject §4.1's own example at load and make §5.2's "retaining the offset it
+was written with" impossible to honour. The failure is closed rather than open — nothing loads —
+but a headline example that fails on a permitted dependency version is a defect in the dependency
+declaration, not in the example.
+
 ### 4.3 Evaluation, and where it sits
 
 An action **passes authority** iff at least one grant matches on **all four** of subject, action
 name, resource and environment, has **all** its constraints hold, is **unexpired**, and — if it
-is a delegation — has a chain that is still valid under §5.
+is a delegation — has a chain that is still valid under §5, **and** no delegation record reached
+during the evaluation was unreadable (§4.6).
+
+The last clause belongs in the definition rather than in a remark three subsections later,
+because this sentence is where an implementer writes the loop. Without it the `iff` is satisfied
+by a broad root grant while a corrupted narrow delegation sits unread beside it — precisely the
+fail-open §4.6 describes.
 
 Authority is evaluated **before** policy. Two reasons, and the second is the load-bearing one:
 
@@ -945,8 +1012,19 @@ simply not on anybody's list. So the list is here, and it is normative.
 
 Every path below either proposes an action or creates authority. Each is subject to the same
 fail-closed checks in the same order — **principal validity and expiry, then authority, then
-policy** — and each MUST resolve its principal from an `IdentityProvider` where one is configured
-(§3.1), never from a value the caller supplied alongside the request.
+policy**.
+
+The **environment** obeys §2.5 on every row without exception: it comes from the `Control`, the
+gateway or the ACS hook, and a mismatched one is refused even where the caller built the Action.
+
+The **principal** obeys the same rule on every row whose *Resolves identity* cell says yes — it
+comes from an `IdentityProvider`, never from a value supplied alongside the request. The rows that
+say no are the stated exceptions, each argued where it lives rather than here: a directly-built
+`Action` is inside the process trust boundary (§3.1), a resumed leg carries the principal of the
+action it is resuming (§5.6.1), and `Control.delegate` takes `by` as an argument that §5.3 rule 4
+checks against the parent's subject but does not authenticate — `--as` is an assertion, recorded
+as one (§5.7, §13). An unqualified MUST above a table containing its own exceptions would teach an
+implementer that delegation is authenticated.
 
 | Entry point | Builds an `Action` | Resolves identity | Evaluates authority |
 |---|---|---|---|
@@ -978,15 +1056,18 @@ rather than passing one.
 | Reason | Meaning |
 |---|---|
 | `authority_grant` | **Passed.** A grant matched; `AuthorityResult.grant_id` names which |
+| `authority_unreadable` | A stored delegation could not be read, parsed or walked (§4.6, §5.5) |
 | `no_authority` | No grant matched subject, action, resource and environment |
 | `authority_constraint` | A grant matched the shape, but a constraint did not hold |
 | `authority_expired` | Every grant that matched the shape had passed its own `expires_at` |
 | `authority_escalation` | A delegated grant is no longer contained in its chain, or an ancestor has expired or is missing (§5.6) |
 | `authority_revoked` | A delegation in the chain has been revoked (§5.7) |
 
-`authority_grant` exists because a *passing* result also needs a reason: §4.6 records the axis
-that produced the decision, and there was otherwise no value to record for the cell where
-authority is the one that spoke. `decision_reason` **never** holds a grant id — a grant may
+`authority_grant` is what a *passing* result carries in `AuthorityResult.reason`, and it reaches
+evidence as `AUTHORITY_RESOLVED.data.reason` (§7). It has to reach evidence somewhere: §4.6 sends
+both passing cells' `decision_reason` to the policy axis, so without that event field the value
+would live only in memory, be asserted by no test, and be exactly the check-nothing-exercises this
+document keeps refusing to ship. T68 asserts it by name. `decision_reason` **never** holds a grant id — a grant may
 legally be named `no_authority`, and evidence that could be spoofed by naming a grant is not
 evidence. The id travels in `AuthorityResult.grant_id` and in `AUTHORITY_RESOLVED.data.grant_id`.
 
@@ -995,8 +1076,8 @@ way — expired *and* excluded by a constraint. Evaluation MUST collect every re
 for rather than short-circuiting on the first, and then report, across all grants, the first
 reason present in this fixed order:
 
-`authority_escalation` → `authority_revoked` → `authority_constraint` → `authority_expired` →
-`no_authority`
+`authority_unreadable` → `authority_escalation` → `authority_revoked` → `authority_expired` →
+`authority_constraint` → `no_authority`
 
 Fixed and collected rather than short-circuited, so the evidence for one configuration does not
 depend on the order grants appear in the document or the order an implementation happens to
@@ -1126,8 +1207,8 @@ three configurations nothing can tell apart, which reads as coverage and exercis
 pins the trace that makes them indistinguishable.
 
 `# SPEC:` the item-2 brief asks T70 to "parametrize the 3×3". With a grant carrying no decision
-(§4.2) authority is binary and the table is 2×3, so T70 parametrizes six cells and asserts the
-recorded reason in each. The brief's third row was the grant-level `decision:` this document
+(§4.2) authority is binary and the table is 2×3 — and its bottom row collapses to one case, so
+T70 parametrizes four and asserts the recorded reason in each. The brief's third row was the grant-level `decision:` this document
 removed, and the reasoning is in §4.2.
 
 **`decision_reason`** names the axis that produced the decision: an authority reason from §4.3
@@ -1242,7 +1323,12 @@ enough that every pair is decidable" holds only for grammar-valid input, and §5
 relation is undefined on a segment like `a**`. `Control.delegate` takes a `Grant` built in Python,
 so without a constructor that refuses, §5.3 rule 6 would be discharging a proof about a value
 nothing checked. A `constraints` key that disagrees with its own `Condition` is the sharpest case:
-containment would compare one thing and §5.2 would store another. `Control.delegate` is public API and takes a `Grant` built in Python, not YAML;
+containment would compare one thing and §5.2 would store another.
+
+`Subject`'s own refusal carries a different argument, and it is why the two are separate checks:
+without it a holder of a narrow grant could mint a child addressed to *every principal in the
+deployment*, widening the population rather than the powers. "Any agent" is spelled
+`Subject(agent="*")`, which is greppable — and §5.4 forbids it in a delegation regardless. `Control.delegate` is public API and takes a `Grant` built in Python, not YAML;
 without this a holder of a narrow grant could mint a child addressed to every principal in the
 deployment — widening the population rather than the powers. "Any agent" is spelled
 `Subject(agent="*")`, which is greppable — and §5.4 forbids it in a *delegation* regardless.
@@ -1858,7 +1944,7 @@ prevents. It is in the table because a reader will look for it.
 - **`would_have.blocked_reason`** is `null` when the action would have run unimpeded, and
   otherwise names what would have stopped it: `approval_required`, `duplicate`, `in_progress`,
   `ambiguous`, `approval_mismatch`, `principal_expired`, `unknown_action`, `no_matching_rule`, or
-  one of §4.3's five **deny** reasons — never `authority_grant`, which records a pass. It is separate from `decision` because "the policy said allow
+  one of §4.3's six **deny** reasons — never `authority_grant`, which records a pass. It is separate from `decision` because "the policy said allow
   and the effect was already committed" is a real and common answer, and a single field could not
   hold both halves.
 
@@ -2171,6 +2257,14 @@ multi-tenant deployment, a different alert.
 **Startup output.** The gateway already prints every action in its policy with no `effect:`
 (`v0.2 §3.2`). It now also prints, in the same startup block:
 
+- the environment in force and where it came from, because the gateway resolves it once and
+  stamps every Action with it. `--environment` defaults to **unset**, not to `"production"`: it is
+  passed to `Control(environment=...)` as §2.5's rank 1 where given, and where it is not, the
+  Control resolves ranks 2 to 4 as it would in-process. A flag defaulting to `"production"` would
+  silently outrank `$CTRLRUN_ENVIRONMENT`, so an operator who set the variable to `staging` would
+  get a gateway stamping `production` on every action and matching the wrong grants — the
+  fail-open direction. The gateway builds its Actions from the `Control`'s environment, never from
+  a second copy of its own;
 - the identity provider in force, by name, and for `HeaderIdentityProvider` the header it trusts
   and the one-line warning of §3.3;
 - whether an `authority:` section is loaded and how many grants it holds — or, when there is none,
@@ -2296,9 +2390,11 @@ happened.
 #### T61b — An expiry that falls mid-action
 Parametrized over §2.3.1: a principal that expires after `EXECUTION_STARTED` still commits (the
 record reaches `COMMITTED`, no exception); a lease extension under the same expired principal is
-refused with `IdentityError` and the record is left for the lapsing lease to move; a
-`Control.resume` under it records the expiry and does not re-decide, and the resumed leg produces a
-receipt.
+refused with `IdentityError` and the record is left for the lapsing lease to move; and a
+`Control.resume` under it is **not** re-evaluated for expiry — asserted by the resumed leg
+producing a receipt that carries `principal.expires_at` and appends no `ACTION_DENIED`, since a
+check whose only effect is a field the receipt already carries is one no test can tell from its
+absence.
 
 #### T62 — A provider returning `None` with no context is `no_principal`
 `ActionDenied(reason="no_principal")`, a warning naming the action on the `ctrlrun` logger, and the


### PR DESCRIPTION
v0.3 makes the environment an authorization input — a grant may scope to
`environments: ["staging"]`, and §4.3 makes it one of the four things a grant matches on. On the
decorator path the value came from `context(environment=...)`: the agent's own call site.

So the same dimension was a real restriction through the gateway and **decoration in-process**,
and §4.2 had grown a paragraph explaining when it was which. An authorization dimension the
subject can set is not one.

## The change

The environment is set once on the `Control` and every `Action` inherits it:

1. `Control(environment=...)`
2. `$CTRLRUN_ENVIRONMENT` — set but empty is `InvalidArgument`, as `CTRLRUN_CONFIG` and
   `CTRLRUN_STATE` are; falling back would put actions in an environment nobody chose
3. the policy document's top-level `environment:` (new in `ctrlrun.policy/v3`)
4. `"production"`

`context(environment=...)` is **removed**. The gateway's `--environment` and the ACS hook's
configuration are unchanged — they were already this rule, which is why they needed no amendment.
What changes is that the decorator path now agrees with them, so §4.3.1's sentence holds on
**every** entry point rather than two of three, and §4.2's "only real sometimes" paragraph is
deleted.

This is a **breaking change to a name `SPEC-v0.1.md` §8 froze**, so §8's signature is amended in
the same change, as the rule for a frozen name requires. A deployment that ran several
environments from one process runs one `Control` each — which is what "the environment is a
property of the deployment" means in code. §13's *"Authenticating the environment"* line is
deleted rather than reworded: it is no longer true.

## Caught while checking

A **full duplicate** of the old paragraph was still sitting in §4.2, contradicting the new §2.5
outright — an earlier edit had matched only the first of two copies. A grep for the removed
parameter found it. Without that check this PR would have shipped a spec that said the environment
both is and is not authenticated, four hundred lines apart.

## Tests

- **T65d** — `context(environment=...)` raises `TypeError`, asserted by signature so it cannot be
  quietly reinstated; the four-source resolution order parametrized, including the set-but-empty
  refusal, since falling through is the failure that puts actions in an environment nobody chose.
- **T67c** — a staging-scoped grant refused under a production `Control`, paired with the same
  grant passing under a staging one. The second is the control: without it, an implementation
  that matched no environment at all would satisfy the first half. The point of the pair is that
  **no calling code participates** — there is no argument and no `context()` parameter that
  changes which outcome it gets.

## Checks

`./scripts/check.sh` — 1290 passed, `mypy --strict` clean, both ruff checks clean.
