### PR TITLE
item 2: the authority: section, grants and evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,31 @@ shipped, and the only thing in the tree today is the contract.
 
 ### Added
 
+- **The `authority:` section: grants, patterns and evaluation** (build-list item 2,
+  SPEC-v0.3 §4). A second axis, and it is **opt-in and then fail-closed**: a document with no
+  `authority:` key behaves exactly as v0.2, and the moment one exists every principal needs a
+  grant — including for actions the policy allows outright, including reads, including actions
+  with no effect key. There is no `default: allow` and no flag that makes a missing grant
+  permissive. `Authority`, `Grant`, `Subject` and `AuthorityResult` are public;
+  `Control(authority=...)` takes one, and `Control.from_file` reads it from the same document.
+- **Authority is evaluated before policy, and the two combine as the stricter of the pair.**
+  A denial there appends `AUTHORITY_DENIED` and **never** `POLICY_EVALUATED`, so it cannot
+  leave a pending approval request behind for an action that could never run. Neither axis
+  loosens the other: authority cannot make a denied action allowed, and policy cannot make an
+  unauthorized one permitted. **A grant carries no `decision:`** — how much autonomy an action
+  has stays the same for every principal, and what differs is whether they may propose it at
+  all.
+- **A pattern grammar small enough that containment is decidable** (§4.4, §5.5): a literal, a
+  `prefix*` that cannot cross a separator, and a final `**` whose preceding segments are all
+  literals. `stripe.*` matches `stripe.refund` and not `stripe.refund.partial`; there is no
+  `?`, no character class, and no short spelling for "everything" — granting the whole surface
+  of a system is spelled `**`, one token, greppable, and impossible to write by accident.
+- **Two new event types and one new error.** `AUTHORITY_RESOLVED` is appended for *every*
+  action that passes authority, not only a delegated one, so a deployment with a permissive
+  grant is distinguishable from one with no section at all. `AuthorityDenied` subclasses
+  `ActionDenied` — an authority denial *is* the action being denied — and carries a reason from
+  §4.3's closed set, never a grant id: a grant may legally be named `no_authority`, and
+  evidence that can be spoofed by naming a grant is not evidence.
 - **Extended `Principal`, `IdentityProvider`, and the two core providers** (build-list item 1,
   SPEC-v0.3 §2, §3). `Principal` gains `claims`, `issuer` and `expires_at`, validated the way
   arguments are — no `float`, no containers, a timezone-aware expiry — and **none of the three
@@ -39,6 +64,27 @@ shipped, and the only thing in the tree today is the contract.
 
 ### Changed
 
+- **BREAKING: a condition naming `claims`, `issuer` or `expires_at` is refused at load**, in a
+  document of *every* schema version (§4.5, §12.1). The reservation lives in the condition-key
+  splitter, which runs for every condition in every document, and gating it on `v3` would leave
+  the same name meaning two things in two files. A `v1` policy whose protected function takes an
+  argument called `claims` stops loading until the argument is renamed; the load error says so.
+- **`Control.evaluate` returns the combined decision**, not the policy axis alone. Its signature
+  and `Evaluation`'s two fields are unchanged, and it still writes nothing — it would simply
+  stop answering "what will happen to this action" if it reported one axis while `Control.execute`
+  acted on both.
+- **`Control.resume` records the authority axis on its receipt** (§5.6.1). Evaluated and
+  recorded, not re-decided: the reservation is held and the remote may already be acting on it.
+  A lease extension is the other way round — refused where authority no longer covers the
+  action, so the lease lapses and the record becomes `AMBIGUOUS` by the ordinary path.
+- **`AcsControlHook` refuses a `Control` that holds an `Authority`** (§8.4). It reads
+  `params.metadata.agent_id` off the inbound envelope, and an authorization decision may not be
+  made against a principal the caller asserted — the same sentence that removed
+  `--principal-from-client-info`. It gains an `identity` provider of its own with item 5.
+- **`policy._Condition` is now `policy.Condition`, and `policy.parse_conditions` is public.**
+  A grant's `constraints:` is in exactly a rule's `when:` syntax and is parsed by the same code:
+  a second condition evaluator would be a second place for `True` to start comparing equal to
+  `1`. The top-level policy key set gains `authority`, which needs `ctrlrun.policy/v3`.
 - **BREAKING: `context(environment=...)` is removed** — already recorded below, and item 1 is
   where it happens. `Control(environment=...)` replaces it.
 - **BREAKING: `ctrlrun gateway --principal-from-client-info` is removed.** It exits non-zero

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,6 +136,8 @@ Pragmas: `journal_mode=WAL`, `busy_timeout=5000`, `synchronous=NORMAL`.
 |---|---|---|
 | `action.py` | model, canonicalization, hash | policy, storage |
 | `policy.py` | YAML → rules → Decision; `effect:`/`resource:` templates | approvals, effect *state* |
+| `identity.py` | `IdentityProvider`, `IdentityContext`, static and header providers | policy, authority, storage |
+| `authority.py` | `Grant`, `Subject`, `Authority`, matching, containment, delegation planning | approvals, effect state, executors, sinks |
 | `approval.py` | request/grant/consume, providers | executors |
 | `effect.py` | key templating, state enum, transition rules | SQLite |
 | `state.py` | `StateStore` protocol + SQLite/in-memory impls | policy, decorator, sinks |
@@ -151,12 +153,27 @@ itself. A gateway that owned the reservation would be a second module composing 
 and a second implementation of SPEC-v0.1 §5.5's asymmetry, which is the one rule in this
 codebase that must not drift.
 
+The same holds for authority (v0.3). `authority.py` reads the store through the `StateStore`
+protocol and **writes nothing and appends nothing**: `Authority.evaluate` returns a result and
+`plan_delegation` returns the record it *would* write, and `Control` performs every write and
+fans every event out to the sinks. An `Authority` that wrote for itself would be a second module
+composing storage and evidence, and it would leave the highest-privilege operations in the
+release as the only ones invisible to the export path (SPEC-v0.3 §4.8).
+
 One exception, added in v0.2 and worth stating rather than discovering: `policy.py` imports the
 template grammar (`template_placeholders`) from `effect.py`, because SPEC-v0.2 §3.1 requires an
 `effect:` / `resource:` template to be validated when the policy loads and the grammar is
 security-critical enough that a second copy of it is worse than the import. Policy still knows
 nothing of effect state — no records, no transitions, no reservations — and `effect.py` does not
 import `policy.py`, so there is no cycle.
+
+v0.3 makes the same exception once more, for the same reason: `authority.py` imports the
+condition parser and evaluator (`Condition`, `parse_conditions`) from `policy.py`, because a
+grant's `constraints:` is in exactly a rule's `when:` syntax and the two axes MUST share one
+evaluator (SPEC-v0.3 §4.5). A second condition evaluator would be a second place for `True` to
+start comparing equal to `1`. `policy.py` does not import `authority.py`, so there is no cycle,
+and policy still cannot see a principal: `agent_eq` and every other reserved name are still
+refused at load (§4.7).
 
 ## 7. What changes after v0.1 (and what doesn't)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,13 @@ ctrlrun = ["py.typed"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    # SPEC-v0.3 §4.1 / T66: a test that legitimately builds an `authority:` section, and
+    # may therefore append one of the five §7 event types. `tests/conftest.py` fails any
+    # unmarked test that appends one, which is what "no `authority:` section behaves
+    # exactly as v0.2" means mechanically inside one pytest process.
+    "authority: builds an `authority:` section (SPEC-v0.3 §4.1)",
+]
 
 [tool.mypy]
 python_version = "3.11"

--- a/src/ctrlrun/__init__.py
+++ b/src/ctrlrun/__init__.py
@@ -11,6 +11,7 @@ from .approval import (
     LocalApprovalProvider,
     ScriptedApprovalProvider,
 )
+from .authority import Authority, AuthorityResult, Grant, Subject
 from .control import Control, context, protect, with_approval
 from .effect import EffectRecord, EffectState, ReconcileOutcome
 from .errors import (
@@ -19,6 +20,8 @@ from .errors import (
     ApprovalMismatch,
     ApprovalRequired,
     ApprovalTimeout,
+    AuthorityDenied,
+    AuthorityEscalation,
     CTRLRunError,
     DuplicateEffect,
     EffectKeyError,
@@ -35,7 +38,7 @@ from .identity import (
     IdentityProvider,
     StaticIdentityProvider,
 )
-from .policy import Decision, Policy
+from .policy import Condition, Decision, Policy, parse_conditions
 from .receipt import Event, EventSink, JSONLEventSink, Receipt
 from .state import InMemoryStateStore, SQLiteStateStore, StateStore
 from .webhook import WebhookApprovalProvider
@@ -50,7 +53,12 @@ __all__ = [
     "ApprovalRequest",
     "ApprovalRequired",
     "ApprovalTimeout",
+    "Authority",
+    "AuthorityDenied",
+    "AuthorityEscalation",
+    "AuthorityResult",
     "CTRLRunError",
+    "Condition",
     "Control",
     "Decision",
     "DuplicateEffect",
@@ -59,6 +67,7 @@ __all__ = [
     "EffectState",
     "Event",
     "EventSink",
+    "Grant",
     "HeaderIdentityProvider",
     "IdentityContext",
     "IdentityError",
@@ -78,11 +87,13 @@ __all__ = [
     "ScriptedApprovalProvider",
     "StateStore",
     "StaticIdentityProvider",
+    "Subject",
     "Suspended",
     "WebhookApprovalProvider",
     "action_hash",
     "canonicalize",
     "context",
+    "parse_conditions",
     "protect",
     "with_approval",
 ]

--- a/src/ctrlrun/acs.py
+++ b/src/ctrlrun/acs.py
@@ -87,6 +87,22 @@ class AcsControlHook:
         approver_id: str = "cli:local",
         ask_timeout_seconds: int = DEFAULT_ASK_TIMEOUT_SECONDS,
     ) -> None:
+        if control.authority is not None:
+            # SPEC-v0.3 §8.4 — this hook reads `params.metadata.agent_id` straight off the
+            # inbound envelope, and §4 makes the principal an authorization input. A
+            # self-reported name cannot be one, which is the same sentence that removes the
+            # gateway's `--principal-from-client-info` (§8.1); leaving the ACS hook alone would
+            # make that removal a gesture. §8.4 requires the hook to take an
+            # `identity: IdentityProvider` of its own, which lands with build-list item 5 — so
+            # until then it has none, and an `Authority` cannot be enforced against a principal
+            # nobody verified. Refused at construction rather than per call: a deployment finds
+            # out at startup.
+            raise InvalidArgument(
+                "AcsControlHook needs an `identity` provider for a Control that holds an "
+                "Authority, and does not take one before build-list item 5. This hook reads "
+                "params.metadata.agent_id off the envelope, and an authorization decision may "
+                "not be made against a principal the caller asserted (SPEC-v0.3 §8.4)"
+            )
         self._control = control
         self._prefix = prefix
         self._approver_id = approver_id

--- a/src/ctrlrun/authority.py
+++ b/src/ctrlrun/authority.py
@@ -1,0 +1,703 @@
+"""Grants, patterns, containment and evaluation. Build-list item 2; SPEC-v0.3 §4.
+
+Authority is the second axis. Policy answers *how much autonomy does this action have*, and
+has never been able to see who is asking (`v0.1 §3.2` refuses `agent_eq` at load, and still
+does). Authority answers *may this principal propose it at all*, and sees nothing else: a
+grant carries no `decision:`, so how much autonomy an action has is the same for every
+principal (§4.2, §4.7).
+
+Three rules shape every function below.
+
+**Opt-in, then fail-closed** (§4.1). A document with no `authority:` key produces no
+`Authority` at all — `_optional_from_yaml` returns `None` and `Control` behaves exactly as
+v0.2. A document with one governs every action, and no matching grant is `DENY`.
+
+**The grammar is small on purpose** (§4.4). `fnmatch` would make `contains` — the relation
+build-list item 3's attenuation rests on — an approximation rather than a decision. So: a
+literal, a `prefix*` that cannot cross a separator, and a final `**` whose preceding segments
+are all literals. Nothing else parses.
+
+**This module is pure.** It reads a `StateStore` and never writes to one, and it appends no
+event. `Control` does both (§4.8), which is what keeps `ARCHITECTURE.md` §6's single composer
+single.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+from types import MappingProxyType
+from typing import Any, Final
+
+import yaml
+
+from .action import Action, Principal
+from .errors import InvalidArgument, PolicyError
+from .policy import SUPPORTED_SCHEMAS, Condition, parse_conditions, require_v3
+from .state import StateStore
+
+#: SPEC-v0.3 §4.4 — an action name is dotted (`v0.1 §2.1`) and a resource is `type:id`.
+ACTION_SEPARATOR: Final = "."
+RESOURCE_SEPARATOR: Final = ":"
+
+#: The only spelling for "everything", and one token long so a review can grep for it.
+DEEP_WILDCARD: Final = "**"
+
+#: SPEC-v0.3 §4.3 — the closed set of reasons, and the one a *passing* result carries.
+AUTHORITY_GRANT: Final = "authority_grant"
+AUTHORITY_UNREADABLE: Final = "authority_unreadable"
+AUTHORITY_ESCALATION: Final = "authority_escalation"
+AUTHORITY_REVOKED: Final = "authority_revoked"
+AUTHORITY_EXPIRED: Final = "authority_expired"
+AUTHORITY_CONSTRAINT: Final = "authority_constraint"
+NO_AUTHORITY: Final = "no_authority"
+
+#: §4.3 — fixed rather than short-circuited, so the evidence for one configuration does not
+#: depend on the order grants appear in the document. `authority_expired` outranks
+#: `authority_constraint` deliberately: expiry is a property of the grant and a failed
+#: constraint a property of the call, and the reason should name what will still be wrong
+#: after the caller changes the request.
+REASON_PRECEDENCE: Final = (
+    AUTHORITY_UNREADABLE,
+    AUTHORITY_ESCALATION,
+    AUTHORITY_REVOKED,
+    AUTHORITY_EXPIRED,
+    AUTHORITY_CONSTRAINT,
+    NO_AUTHORITY,
+)
+
+#: SPEC-v0.3 §5.5 — a root grant is depth 0, a delegation of it depth 1. `0` is valid and
+#: means no delegation may be created at all.
+DEFAULT_MAX_DELEGATION_DEPTH: Final = 3
+
+#: §4.2 — a delegation names its parent by id, so two grants answering to one name is an
+#: ambiguity nobody can resolve later.
+_GRANT_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+#: §5.2 mints delegation ids in this namespace, and one namespace addresses both kinds.
+DELEGATION_ID_PREFIX: Final = "dlg_"
+
+_AUTHORITY_KEY: Final = "authority"
+_AUTHORITY_KEYS: Final = frozenset({"max_delegation_depth", "grants"})
+_GRANT_KEYS: Final = frozenset(
+    {
+        "id",
+        "subject",
+        "actions",
+        "resources",
+        "constraints",
+        "environments",
+        "expires_at",
+        "delegable",
+    }
+)
+_SUBJECT_KEYS: Final = frozenset({"agent", "user"})
+
+#: §4.8 — `standalone=False` tolerates the keys the policy loader owns; `standalone=True` is
+#: §8.3's `--authority` document, whose key set is closed at exactly `schema` and `authority`.
+_POLICY_OWNED_KEYS: Final = frozenset({"schema", "actions", "mode", "environment"})
+_STANDALONE_KEYS: Final = frozenset({"schema", _AUTHORITY_KEY})
+
+#: A grant with no constraints. Shared, because it is immutable — handed out through a
+#: `default_factory` for the reason `action.NO_CLAIMS` is (Python 3.11 refuses any unhashable
+#: dataclass default, `mappingproxy` included).
+NO_CONSTRAINTS: Final[Mapping[str, Condition]] = MappingProxyType({})
+
+
+def _type_name(value: object) -> str:
+    return type(value).__name__
+
+
+# --- patterns (SPEC-v0.3 §4.4) ---------------------------------------------------------
+
+
+def _segments(pattern: str, separator: str | None) -> tuple[str, ...]:
+    return (pattern,) if separator is None else tuple(pattern.split(separator))
+
+
+def validate_pattern(pattern: object, *, separator: str | None, where: str) -> str:
+    """Refuse anything outside §4.4's grammar, and return the pattern.
+
+    `separator=None` is a subject pattern: one segment, no separator, and therefore no deep
+    wildcard — `agent: "**"` would give "any agent" a spelling a review grep for `"*"` misses
+    (§4.2).
+    """
+    if not isinstance(pattern, str) or not pattern:
+        raise InvalidArgument(f"{where}: a pattern must be a non-empty string, got {pattern!r}")
+    segments = _segments(pattern, separator)
+    last = len(segments) - 1
+    for index, segment in enumerate(segments):
+        if not segment:
+            raise InvalidArgument(
+                f"{where}: {pattern!r} has an empty segment; a pattern is a non-empty sequence "
+                f"of segments joined by {separator!r}"
+            )
+        if "?" in segment or "[" in segment or "]" in segment:
+            raise InvalidArgument(
+                f"{where}: {pattern!r} is not a pattern; there is no '?' and there are no "
+                "character classes. A pattern is a literal, a trailing '*', or a final '**'"
+            )
+        if segment == DEEP_WILDCARD:
+            if separator is None:
+                raise InvalidArgument(
+                    f"{where}: {pattern!r} may not carry a deep wildcard; a subject has no "
+                    "separator, so '**' means nothing there that '*' does not. Write '*'"
+                )
+            if index != last:
+                raise InvalidArgument(f"{where}: {pattern!r} may use '**' only as its last segment")
+            for earlier in segments[:index]:
+                if "*" in earlier:
+                    raise InvalidArgument(
+                        f"{where}: {pattern!r} puts a wildcard before a '**'; every segment "
+                        "before a deep wildcard must be a literal, so containment is decided "
+                        "by comparison rather than by reasoning about two kinds of wildcard"
+                    )
+            continue
+        stars = segment.count("*")
+        if stars > 1 or (stars == 1 and not segment.endswith("*")):
+            raise InvalidArgument(
+                f"{where}: {pattern!r} has a segment {segment!r} that is neither a literal nor "
+                "a literal followed by one trailing '*'. There is no leading or infix '*', and "
+                "'**' is never part of a larger segment"
+            )
+    return pattern
+
+
+def matches(pattern: str, value: str, *, separator: str | None) -> bool:
+    """Does `value` match `pattern`? Segment-wise, case-sensitive, no normalization (§4.4)."""
+    parts = _segments(pattern, separator)
+    actual = _segments(value, separator)
+    if parts[-1] == DEEP_WILDCARD:
+        prefix = parts[:-1]
+        return len(actual) > len(prefix) and actual[: len(prefix)] == prefix
+    if len(parts) != len(actual):
+        return False
+    return all(_segment_matches(part, item) for part, item in zip(parts, actual, strict=True))
+
+
+def _segment_matches(pattern: str, value: str) -> bool:
+    if pattern.endswith("*"):
+        return value.startswith(pattern[:-1])
+    return pattern == value
+
+
+def contains(parent: str, child: str, *, separator: str | None) -> bool:
+    """Is every value matching `child` also matched by `parent`? (SPEC-v0.3 §5.5.)
+
+    A different relation from `matches`, with counterintuitive clauses — `Q.**` does not
+    contain `Q` — and an implementation of it as `fnmatch` or `startswith` passes an
+    evaluation test while breaking attenuation. `**` counts as one segment everywhere below,
+    which is what makes every well-formed pattern contain itself.
+    """
+    outer = _segments(parent, separator)
+    inner = _segments(child, separator)
+    if outer == (DEEP_WILDCARD,):
+        return True
+    if outer[-1] == DEEP_WILDCARD:
+        prefix = outer[:-1]
+        return len(inner) > len(prefix) and inner[: len(prefix)] == prefix
+    if inner[-1] == DEEP_WILDCARD or len(inner) != len(outer):
+        return False
+    return all(_segment_contains(out, item) for out, item in zip(outer, inner, strict=True))
+
+
+def _segment_contains(parent: str, child: str) -> bool:
+    parent_wild = parent.endswith("*")
+    child_wild = child.endswith("*")
+    if not parent_wild:
+        # literal ⊆ literal iff equal; a prefix wildcard is never inside a literal.
+        return not child_wild and parent == child
+    return child[: -1 if child_wild else None].startswith(parent[:-1])
+
+
+# --- the model (SPEC-v0.3 §4.8) --------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Subject:
+    """Who a grant is addressed to: an agent pattern, a user pattern, or both (§4.2).
+
+    Both `None` is refused. Without that, a holder of a narrow grant could mint a child
+    addressed to every principal in the deployment — widening the population rather than the
+    powers. "Any agent" is spelled `Subject(agent="*")`, which is greppable.
+    """
+
+    agent: str | None = None
+    user: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.agent is None and self.user is None:
+            raise InvalidArgument(
+                "a subject must declare at least one of 'agent' and 'user'; a subject matching "
+                "every principal is one nobody means to write by accident (SPEC-v0.3 §4.2)"
+            )
+        if self.agent is not None:
+            validate_pattern(self.agent, separator=None, where="subject.agent")
+        if self.user is not None:
+            validate_pattern(self.user, separator=None, where="subject.user")
+
+    def matches(self, principal: Principal) -> bool:
+        """§4.2 — a grant scoped to a human is not satisfied by an agent acting alone."""
+        if self.agent is not None and not matches(self.agent, principal.agent, separator=None):
+            return False
+        if self.user is not None:
+            if principal.user is None:
+                return False
+            if not matches(self.user, principal.user, separator=None):
+                return False
+        return True
+
+
+@dataclass(frozen=True)
+class Grant:
+    """One permission: this subject may propose these actions, under these limits (§4.2).
+
+    `__post_init__` validates everything the YAML loader validates, so the constructor refuses
+    exactly what the loader refuses. That is not decoration: `Control.delegate` takes a `Grant`
+    built in Python, and §5.5's segment relation is undefined on a segment like `a**`, so
+    without it item 3's containment check would be discharging a proof about a value nothing
+    validated.
+    """
+
+    id: str
+    subject: Subject
+    actions: tuple[str, ...] = ()
+    resources: tuple[str, ...] | None = None
+    constraints: Mapping[str, Condition] = field(default_factory=lambda: NO_CONSTRAINTS)
+    environments: tuple[str, ...] | None = None
+    expires_at: datetime | None = None
+    delegable: bool = False
+
+    def __post_init__(self) -> None:
+        # An empty id is legal only on the `Control.delegate` path and only until the call
+        # returns (§4.2); a `dlg_`-prefixed one is what §5.2 mints and what a delegation
+        # record is parsed back into, so the model accepts it and the loader refuses it.
+        if self.id and not _GRANT_ID.match(self.id):
+            raise InvalidArgument(f"grant id {self.id!r} must match {_GRANT_ID.pattern}")
+        object.__setattr__(self, "actions", tuple(self.actions))
+        if not self.actions:
+            raise InvalidArgument(f"grant {self.id!r}: 'actions' must be a non-empty list")
+        for pattern in self.actions:
+            validate_pattern(pattern, separator=ACTION_SEPARATOR, where=f"grant {self.id!r} action")
+        if self.resources is not None:
+            object.__setattr__(self, "resources", tuple(self.resources))
+            if not self.resources:
+                raise InvalidArgument(
+                    f"grant {self.id!r}: 'resources' must be a non-empty list, or absent — "
+                    "an absent 'resources' is what grants any resource (SPEC-v0.3 §4.2)"
+                )
+            for pattern in self.resources:
+                validate_pattern(
+                    pattern, separator=RESOURCE_SEPARATOR, where=f"grant {self.id!r} resource"
+                )
+        if self.environments is not None:
+            object.__setattr__(self, "environments", tuple(self.environments))
+            if not self.environments:
+                raise InvalidArgument(
+                    f"grant {self.id!r}: 'environments' must be a non-empty list, or absent"
+                )
+            for name in self.environments:
+                if not isinstance(name, str) or not name:
+                    raise InvalidArgument(
+                        f"grant {self.id!r}: an environment must be a non-empty string, "
+                        f"got {name!r}"
+                    )
+        for key, condition in self.constraints.items():
+            if not isinstance(condition, Condition):
+                raise InvalidArgument(
+                    f"grant {self.id!r}: constraint {key!r} must be a policy.Condition, "
+                    f"got {_type_name(condition)}"
+                )
+            if key != f"{condition.argument}_{condition.op}" or key != condition.key:
+                # The sharpest case of all: containment would compare one thing and §5.2 would
+                # store another.
+                raise InvalidArgument(
+                    f"grant {self.id!r}: constraint key {key!r} disagrees with the condition it "
+                    f"holds ({condition.argument!r}, {condition.op!r})"
+                )
+        object.__setattr__(self, "constraints", MappingProxyType(dict(self.constraints)))
+        if self.expires_at is not None and self.expires_at.tzinfo is None:
+            raise InvalidArgument(
+                f"grant {self.id!r}: 'expires_at' must carry an offset; an expiry in an "
+                "unstated timezone cannot be checked (SPEC-v0.3 §4.2)"
+            )
+        if self.delegable and self.expires_at is None:
+            # Nothing else bounds the *population* a delegable grant can reach: creation is
+            # non-idempotent and nothing caps children per parent, so a compromised holder can
+            # mint one full-width child per agent name it can think of. An expiry makes §5.4's
+            # `expires_at` row bound every descendant in time by construction.
+            raise InvalidArgument(
+                f"grant {self.id!r}: a grant with 'delegable: true' must declare 'expires_at' "
+                "(SPEC-v0.3 §4.2)"
+            )
+
+    def is_expired(self, now: datetime) -> bool:
+        """`now > expires_at`; a grant is valid up to and including its expiry instant."""
+        return self.expires_at is not None and now > self.expires_at
+
+    def matches_shape(self, action: Action) -> bool:
+        """Subject, action name, resource and environment — all four, or no match (§4.3)."""
+        if not self.subject.matches(action.principal):
+            return False
+        if not any(
+            matches(pattern, action.name, separator=ACTION_SEPARATOR) for pattern in self.actions
+        ):
+            return False
+        if self.resources is not None:
+            # §4.4 — an action whose resource is None does not match a grant that declares
+            # `resources:`. To grant an action that carries no resource, omit the key.
+            if action.resource is None:
+                return False
+            if not any(
+                matches(pattern, action.resource, separator=RESOURCE_SEPARATOR)
+                for pattern in self.resources
+            ):
+                return False
+        # §4.2 — matched by exact string, not by pattern: an environment name is a short
+        # closed list, and a glob over it buys nothing but a way to typo `prod*` into
+        # matching `production-canary`.
+        return self.environments is None or action.environment in self.environments
+
+    def constraints_hold(self, action: Action) -> bool:
+        """All constraints, ANDed. An absent argument makes one false and logs (§4.5)."""
+        arguments = action.canonical_arguments
+        return all(
+            condition.matches(action.name, arguments) for condition in self.constraints.values()
+        )
+
+
+@dataclass(frozen=True)
+class AuthorityResult:
+    """What the authority axis decided, and which grant it decided on (§4.8)."""
+
+    passed: bool
+    reason: str
+    grant_id: str | None = None
+    delegation_id: str | None = None
+    depth: int = 0
+
+
+class Authority:
+    """The `authority:` section, loaded and evaluable (SPEC-v0.3 §4).
+
+    Pure: `evaluate` reads the store to resolve delegations and writes nothing to it, appends
+    no event, and has no other side effect. `Control` performs every write (§4.8).
+    """
+
+    def __init__(
+        self,
+        grants: Mapping[str, Grant],
+        *,
+        max_delegation_depth: int = DEFAULT_MAX_DELEGATION_DEPTH,
+        source: str = "<string>",
+    ) -> None:
+        if max_delegation_depth < 0:
+            raise InvalidArgument("max_delegation_depth must be a non-negative int")
+        self._grants = MappingProxyType(dict(grants))
+        self._max_delegation_depth = max_delegation_depth
+        self._source = source
+
+    @property
+    def grants(self) -> Mapping[str, Grant]:
+        return self._grants
+
+    @property
+    def max_delegation_depth(self) -> int:
+        return self._max_delegation_depth
+
+    @property
+    def source(self) -> str:
+        return self._source
+
+    @classmethod
+    def from_yaml(
+        cls, text: str, *, source: str = "<string>", standalone: bool = False
+    ) -> Authority:
+        """Parse an `authority:` section. A document with none is a `PolicyError` (§4.8).
+
+        `standalone=True` is §8.3's `--authority` document, whose top-level key set is closed
+        at exactly `schema` and `authority`; `standalone=False` is the combined `ctrlrun.yaml`,
+        where the policy loader owns `actions:` and `mode:` and this one ignores them. One
+        constructor cannot enforce both, so it is told which.
+
+        Deciding that a document *has* no section is `Control`'s job, not this one's: a loader
+        that invented an empty `Authority` would deny every action in a v0.2 configuration
+        (§4.1).
+        """
+        authority = _optional_from_yaml(text, source=source, standalone=standalone)
+        if authority is None:
+            raise PolicyError(
+                f"{source}: no 'authority:' section. A document loaded as authority must carry "
+                "one; a section that governs every action must state what it permits"
+            )
+        return authority
+
+    def evaluate(self, action: Action, *, now: datetime, store: StateStore) -> AuthorityResult:
+        """Does any grant cover this action? (SPEC-v0.3 §4.3.)
+
+        Passes iff at least one grant matches subject, action name, resource and environment,
+        has all its constraints hold, and is unexpired. Every reason a grant failed for is
+        collected rather than short-circuited, and the reported one is the first in §4.3's
+        fixed precedence order — so the evidence for one configuration does not depend on the
+        order grants appear in the document.
+
+        `store` is required and unused while every grant is a root grant: build-list item 3
+        walks a delegation's chain through it on every evaluation, and an optional store would
+        give an implementation a fail-open reading in which a revoked delegation stays valid.
+        """
+        passed: list[str] = []
+        failed: dict[str, list[str]] = {}
+        for grant_id, grant in self._grants.items():
+            if not grant.matches_shape(action):
+                continue
+            reasons: list[str] = []
+            if grant.is_expired(now):
+                reasons.append(AUTHORITY_EXPIRED)
+            if not grant.constraints_hold(action):
+                reasons.append(AUTHORITY_CONSTRAINT)
+            if reasons:
+                for reason in reasons:
+                    failed.setdefault(reason, []).append(grant_id)
+            else:
+                passed.append(grant_id)
+        if passed:
+            # §4.6 — holding two permissions is never worse than holding one, and the grant
+            # named is a property of the set rather than of the document.
+            return AuthorityResult(True, AUTHORITY_GRANT, grant_id=min(passed))
+        for reason in REASON_PRECEDENCE:
+            if reason in failed:
+                return AuthorityResult(False, reason, grant_id=min(failed[reason]))
+        return AuthorityResult(False, NO_AUTHORITY)
+
+
+# --- loading (SPEC-v0.3 §4.1, §4.2) ----------------------------------------------------
+
+
+def _optional_from_yaml(
+    text: str, *, source: str = "<string>", standalone: bool = False
+) -> Authority | None:
+    """The `authority:` section of this document, or `None` where it has none.
+
+    `# SPEC:` §11 freezes `Authority.from_yaml`, which answers a document that *has* a section.
+    "No section at all" is a different answer and the one §4.1's opt-in rule turns on, so the
+    reader that can give it is private to the package: `Control.from_file` calls it, and a
+    public name for it would be an addition to a frozen surface.
+    """
+    try:
+        document = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise PolicyError(f"{source}: not valid YAML: {exc}") from exc
+    if not isinstance(document, Mapping):
+        raise PolicyError(
+            f"{source}: an authority document must be a mapping, got {_type_name(document)}"
+        )
+    schema = document.get("schema")
+    if schema not in SUPPORTED_SCHEMAS:
+        raise PolicyError(
+            f"{source}: unknown policy schema {schema!r}, expected one of "
+            f"{', '.join(repr(known) for known in SUPPORTED_SCHEMAS)}"
+        )
+    if standalone:
+        for owned in sorted(_POLICY_OWNED_KEYS - _STANDALONE_KEYS):
+            if owned in document:
+                raise PolicyError(
+                    f"{source}: an authority document carries 'schema' and 'authority' and "
+                    f"nothing else; {owned!r} belongs in the policy file. Two sources for one "
+                    "key is an ambiguity nobody can resolve later (SPEC-v0.3 §8.3)"
+                )
+        _reject_unknown_keys(document, _STANDALONE_KEYS, f"{source}: top level")
+    if _AUTHORITY_KEY not in document:
+        return None
+    # §12.1 — the schema string is the only thing standing between a reader that enforces
+    # authority and one that ignores the section and runs every action unchecked. Checked here
+    # as well as in `Policy`, because §8.3's `--authority` document is never read by the
+    # policy loader at all.
+    require_v3(document, str(schema), source)
+    return _from_section(document[_AUTHORITY_KEY], source)
+
+
+def _from_section(section: object, source: str) -> Authority:
+    where = f"{source}: authority"
+    if not isinstance(section, Mapping):
+        raise PolicyError(
+            f"{where}: must be a mapping with a 'grants' key, got {_type_name(section)}"
+        )
+    _reject_unknown_keys(section, _AUTHORITY_KEYS, where)
+    depth = section.get("max_delegation_depth", DEFAULT_MAX_DELEGATION_DEPTH)
+    if not isinstance(depth, int) or isinstance(depth, bool) or depth < 0:
+        raise PolicyError(
+            f"{where}: 'max_delegation_depth' must be a non-negative int, got {depth!r}"
+        )
+    entries = section.get("grants")
+    if not isinstance(entries, list):
+        # §4.1 — inferring "nothing" from a missing key would make a truncated edit look
+        # deliberate. An empty list is valid and denies every action; an absent one is not.
+        raise PolicyError(
+            f"{where}: 'grants' must be a list, got {_type_name(entries)}. A section that "
+            "governs every action must state what it permits, so 'grants' is required — write "
+            "'grants: []' to permit nothing"
+        )
+    grants: dict[str, Grant] = {}
+    for index, entry in enumerate(entries):
+        grant = _parse_grant(entry, f"{where} grants[{index}]")
+        if grant.id in grants:
+            raise PolicyError(
+                f"{where} grants[{index}]: duplicate grant id {grant.id!r}; a delegation names "
+                "its parent by id, and two grants answering to one name is an ambiguity nobody "
+                "can resolve later"
+            )
+        grants[grant.id] = grant
+    return Authority(grants, max_delegation_depth=depth, source=source)
+
+
+def _parse_grant(entry: object, where: str) -> Grant:
+    if not isinstance(entry, Mapping):
+        raise PolicyError(f"{where}: a grant must be a mapping, got {_type_name(entry)}")
+    _reject_unknown_keys(entry, _GRANT_KEYS, where)
+    grant_id = entry.get("id")
+    if not isinstance(grant_id, str) or not grant_id:
+        raise PolicyError(f"{where}: 'id' must be a non-empty string, got {grant_id!r}")
+    if grant_id.startswith(DELEGATION_ID_PREFIX):
+        raise PolicyError(
+            f"{where}: a grant id may not begin {DELEGATION_ID_PREFIX!r}; that namespace is "
+            "minted for delegations (SPEC-v0.3 §5.2), and one namespace addresses both kinds"
+        )
+    delegable = entry.get("delegable", False)
+    if not isinstance(delegable, bool):
+        raise PolicyError(f"{where}: 'delegable' must be true or false, got {delegable!r}")
+
+    try:
+        return Grant(
+            id=grant_id,
+            subject=_parse_subject(entry.get("subject"), where),
+            actions=_parse_patterns(entry.get("actions"), "actions", where),
+            resources=(
+                _parse_patterns(entry["resources"], "resources", where)
+                if "resources" in entry
+                else None
+            ),
+            constraints=_parse_constraints(entry, where),
+            environments=(
+                _parse_environments(entry["environments"], where)
+                if "environments" in entry
+                else None
+            ),
+            expires_at=_parse_expires_at(entry, where),
+            delegable=delegable,
+        )
+    except InvalidArgument as exc:
+        # The model refuses what the loader refuses (§4.8), so the loader delegates the
+        # grammar to it rather than keeping a second copy that can drift.
+        raise PolicyError(f"{where}: {exc}") from exc
+
+
+def _parse_subject(value: object, where: str) -> Subject:
+    if not isinstance(value, Mapping):
+        raise PolicyError(
+            f"{where}: 'subject' must be a mapping with 'agent' and/or 'user', "
+            f"got {_type_name(value)}"
+        )
+    _reject_unknown_keys(value, _SUBJECT_KEYS, f"{where}: subject")
+    for key in sorted(_SUBJECT_KEYS):
+        if key in value and not isinstance(value[key], str):
+            raise PolicyError(
+                f"{where}: subject: {key!r} must be a pattern string, got {_type_name(value[key])}"
+            )
+    try:
+        return Subject(agent=value.get("agent"), user=value.get("user"))
+    except InvalidArgument as exc:
+        raise PolicyError(f"{where}: subject: {exc}") from exc
+
+
+def _parse_patterns(value: object, key: str, where: str) -> tuple[str, ...]:
+    """A present key must be a list. An *absent* one is what §4.2 makes optional — a key
+    written with no value is a truncated edit, and reading it as "any resource" would widen
+    the grant in the direction §4.1 exists to refuse."""
+    if not isinstance(value, list):
+        raise PolicyError(
+            f"{where}: {key!r} must be a non-empty list of patterns, got {_type_name(value)}"
+        )
+    for pattern in value:
+        if not isinstance(pattern, str):
+            raise PolicyError(f"{where}: {key!r}: a pattern must be a string, got {pattern!r}")
+    return tuple(value)
+
+
+def _parse_environments(value: object, where: str) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise PolicyError(
+            f"{where}: 'environments' must be a non-empty list of names, got {_type_name(value)}"
+        )
+    return tuple(value)
+
+
+def _parse_constraints(entry: Mapping[Any, Any], where: str) -> Mapping[str, Condition]:
+    if "constraints" not in entry:
+        return NO_CONSTRAINTS
+    value = entry["constraints"]
+    # §4.5 — as `when: {}` is. An empty mapping is a truncated edit, and "no constraints" is
+    # already spelled by leaving the key out.
+    if not isinstance(value, Mapping) or not value:
+        raise PolicyError(
+            f"{where}: 'constraints' must be a non-empty mapping of conditions, or absent, "
+            f"got {_type_name(value)}"
+        )
+    return parse_conditions(value, where=f"{where}: constraints")
+
+
+def _parse_expires_at(entry: Mapping[Any, Any], where: str) -> datetime | None:
+    if "expires_at" not in entry:
+        return None
+    value = entry["expires_at"]
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value)
+        except ValueError as exc:
+            raise PolicyError(
+                f"{where}: 'expires_at' must be an ISO-8601 timestamp with an offset, got {value!r}"
+            ) from exc
+    if not isinstance(value, datetime):
+        raise PolicyError(
+            f"{where}: 'expires_at' must be an ISO-8601 timestamp with an offset, "
+            f"got {_type_name(value)}"
+        )
+    # A naive timestamp is refused by `Grant.__post_init__`, not here. A second check would be
+    # a subsumed guard — it can only fire where the model's would also fire, with the same
+    # observable result — and the loader already wraps the model's `InvalidArgument` in a
+    # `PolicyError` naming this location. What is *not* subsumed is the isinstance check
+    # above: without it the model would be handed a `str` and raise `AttributeError`.
+    return value
+
+
+def _reject_unknown_keys(mapping: Mapping[Any, Any], allowed: Iterable[str], where: str) -> None:
+    """Key sets are closed at every level (§4.2), so `action:` for `actions:` fails loudly."""
+    known = set(allowed)
+    unknown = sorted(repr(key) for key in mapping if key not in known)
+    if unknown:
+        raise PolicyError(
+            f"{where}: unknown key(s) {', '.join(unknown)}; allowed: {', '.join(sorted(known))}"
+        )
+
+
+__all__ = [
+    "ACTION_SEPARATOR",
+    "AUTHORITY_CONSTRAINT",
+    "AUTHORITY_ESCALATION",
+    "AUTHORITY_EXPIRED",
+    "AUTHORITY_GRANT",
+    "AUTHORITY_REVOKED",
+    "AUTHORITY_UNREADABLE",
+    "DEFAULT_MAX_DELEGATION_DEPTH",
+    "DELEGATION_ID_PREFIX",
+    "NO_AUTHORITY",
+    "RESOURCE_SEPARATOR",
+    "Authority",
+    "AuthorityResult",
+    "Grant",
+    "Subject",
+    "contains",
+    "matches",
+    "validate_pattern",
+]

--- a/src/ctrlrun/control.py
+++ b/src/ctrlrun/control.py
@@ -27,6 +27,7 @@ from .approval import (
     ApprovalStatus,
     LocalApprovalProvider,
 )
+from .authority import Authority, AuthorityResult, _optional_from_yaml
 from .effect import (
     DEFAULT_LEASE,
     RECONCILED_STATES,
@@ -44,12 +45,14 @@ from .errors import (
     AmbiguousEffect,
     ApprovalMismatch,
     ApprovalRequired,
+    AuthorityDenied,
     CTRLRunError,
     DuplicateEffect,
     EffectKeyError,
     IdentityError,
     InvalidArgument,
     NotExecuted,
+    PolicyError,
     Suspended,
 )
 from .identity import IdentityContext, IdentityProvider
@@ -222,6 +225,7 @@ class Control:
         sinks: Sequence[EventSink] = (),
         suspend_timeout: timedelta = DEFAULT_SUSPEND_TIMEOUT,
         identity: IdentityProvider | None = None,
+        authority: Authority | None = None,
         environment: str | None = None,
     ) -> None:
         self._policy = policy
@@ -235,6 +239,7 @@ class Control:
         self._sinks = tuple(sinks)
         self._suspend_timeout = _checked_lease(suspend_timeout, "Control(suspend_timeout=...)")
         self._identity = identity
+        self._authority = authority
         self._environment = _resolve_environment(environment, policy)
         #: SPEC-v0.3 §3.2 — the provider-versus-context warning is emitted at most once per
         #: Control. A warning that repeats per call is a warning nobody reads.
@@ -252,6 +257,10 @@ class Control:
         are shared by every worker that loaded the same policy (§5.3 E1, §8).
         """
         policy = Policy.from_file(path)
+        # SPEC-v0.3 §4.1 — the same document, read again for its `authority:` section, and
+        # `None` where it has none. Opt-in is the whole rule: a loader that returned an empty
+        # `Authority` here would deny every action in a v0.2 configuration.
+        authority = _optional_authority(policy.source)
         state = state_path(policy.source)
         store = SQLiteStateStore(state)
         # SPEC-v0.2 §4.3 — the two files of v0.1 §6 land exactly where v0.1 put them,
@@ -261,6 +270,7 @@ class Control:
             store,
             LocalApprovalProvider(store),
             sinks=[JSONLEventSink(state.parent)],
+            authority=authority,
             environment=environment,
         )
 
@@ -292,6 +302,15 @@ class Control:
         return self._identity
 
     @property
+    def authority(self) -> Authority | None:
+        """The grants this Control evaluates against, if any (SPEC-v0.3 §4.1).
+
+        `None` is v0.2 behaviour, exactly: no authority evaluation, no `AUTHORITY_*` event,
+        no change to any decision. Not `None` means every principal needs a grant.
+        """
+        return self._authority
+
+    @property
     def environment(self) -> str:
         """The environment every Action this Control decides carries (SPEC-v0.3 §2.5).
 
@@ -316,7 +335,62 @@ class Control:
         self._check_environment(action)
         if self._is_expired(action.principal):
             return Evaluation(Decision.DENY, PRINCIPAL_EXPIRED)
+        # SPEC-v0.3 §4.6 — the combined decision, not the policy axis alone. This method is
+        # the public "what will happen to this action" query and it would stop answering that
+        # question if it reported one axis while `execute` acted on both. It reads the store
+        # to resolve delegations and still writes nothing.
+        result = self._authority_result(action)
+        if result is not None and not result.passed:
+            return Evaluation(Decision.DENY, result.reason)
         return self._policy.evaluate(action)
+
+    def _authority_result(self, action: Action) -> AuthorityResult | None:
+        """The authority axis for this action, or `None` where there is no section (§4.1)."""
+        if self._authority is None:
+            return None
+        return self._authority.evaluate(action, now=self._clock(), store=self._store)
+
+    def _authority_data(self, result: AuthorityResult) -> dict[str, Any]:
+        """SPEC-v0.3 §7 — the ids travel here, and never in `decision_reason`.
+
+        A grant may legally be named `no_authority`, so evidence that could be spoofed by
+        naming a grant is not evidence. Absent keys are omitted rather than written `null`:
+        `grant_id` is present "where one grant was implicated", and `no_authority` implicates
+        none.
+        """
+        data: dict[str, Any] = {"reason": result.reason}
+        if result.grant_id is not None:
+            data["grant_id"] = result.grant_id
+        if result.delegation_id is not None:
+            data["delegation_id"] = result.delegation_id
+            data["depth"] = result.depth
+        return data
+
+    def _refuse_authority(
+        self, action: Action, result: AuthorityResult, started_at: datetime, effect_key: str | None
+    ) -> NoReturn:
+        """Record an authority denial and raise (SPEC-v0.3 §4.3).
+
+        `AUTHORITY_DENIED` then `ACTION_DENIED`, and **no** `POLICY_EVALUATED`: policy is never
+        evaluated, so no approval request is created and no human is left staring at a request
+        for an action that could never run.
+        """
+        self._append(EventType.AUTHORITY_DENIED, action, self._authority_data(result), effect_key)
+        self._append(EventType.ACTION_DENIED, action, {"reason": result.reason}, effect_key)
+        self._record(
+            action,
+            Evaluation(Decision.DENY, result.reason),
+            ReceiptResult.DENIED,
+            started_at,
+            effect_key=effect_key,
+        )
+        raise AuthorityDenied(
+            f"{action.name} denied: {result.reason}",
+            reason=result.reason,
+            action_id=action.action_id,
+            grant_id=result.grant_id,
+            delegation_id=result.delegation_id,
+        )
 
     def _is_expired(self, principal: Principal) -> bool:
         """SPEC-v0.3 §2.3. `expires_at is None` is the absence of a check, not one that passes."""
@@ -339,11 +413,13 @@ class Control:
 
         resolved = self._ask_provider(action_name, from_context)
         if resolved is None:
-            # A decline. SPEC-v0.3 §3.2 adds one more row here in build-list item 2: once an
-            # `authority:` section is loaded a decline is refused rather than backfilled,
-            # because omitting a credential would otherwise be an easier route than forging
-            # one. `Authority` does not exist yet, so that row lands with the code it needs.
-            if from_context is None:
+            # A decline, and SPEC-v0.3 §3.2's last row: once an `authority:` section is loaded
+            # a decline is refused rather than backfilled. Otherwise agent code already running
+            # inside `with context("finance-agent")` executes every un-credentialed call as
+            # finance-agent, with finance-agent's grants — omitting a credential reaches the
+            # same destination as forging one, by an easier route. This is not a flag and there
+            # is nothing to configure: it follows from §4.1's opt-in rule.
+            if from_context is None or self._authority is not None:
                 _refuse_no_principal(action_name)
             return from_context
 
@@ -437,6 +513,15 @@ class Control:
                 f"{action.name}: the principal's credential expired at "
                 f"{action.principal.expires_at}"
             )
+        # SPEC-v0.3 §4.3.1 — the order, stated once so it can be tested: principal_expired →
+        # authority → policy → approval → reservation → execution.
+        result = self._authority_result(action)
+        if result is not None:
+            if not result.passed:
+                self._refuse_authority(action, result, started_at, effect_key)
+            self._append(
+                EventType.AUTHORITY_RESOLVED, action, self._authority_data(result), effect_key
+            )
         evaluation = self._policy.evaluate(action)
         self._append(
             EventType.POLICY_EVALUATED,
@@ -507,7 +592,23 @@ class Control:
         # The action was decided and reserved on the first leg; refusing here would strand a
         # reservation the remote may already be acting on, which is the one thing a held
         # reservation exists to avoid.
-        evaluation = self._policy.evaluate(action)
+        #
+        # SPEC-v0.3 §5.6.1 gives authority the same treatment, and for a sharper reason: this
+        # is the *only* receipt an MCP multi round-trip or ACS action ever gets (§8.3), so a
+        # receipt reporting a bare policy reason would be the whole evidence for that action.
+        result = self._authority_result(action)
+        if result is None:
+            evaluation = self._policy.evaluate(action)
+        elif result.passed:
+            self._append(
+                EventType.AUTHORITY_RESOLVED, action, self._authority_data(result), held.effect_key
+            )
+            evaluation = self._policy.evaluate(action)
+        else:
+            self._append(
+                EventType.AUTHORITY_DENIED, action, self._authority_data(result), held.effect_key
+            )
+            evaluation = Evaluation(Decision.DENY, result.reason)
         return self._outcome(
             action,
             evaluation,
@@ -681,6 +782,24 @@ class Control:
                 f"{action.name}: the principal's credential expired at "
                 f"{action.principal.expires_at}, so the reservation is not held across the "
                 "round trip; the lease will lapse and the record becomes AMBIGUOUS"
+            )
+        result = self._authority_result(action)
+        if result is not None and not result.passed:
+            # SPEC-v0.3 §5.6.1 — an extension asks to keep holding a reservation the grant no
+            # longer authorizes. Refused, and the record is deliberately not moved: the lease
+            # lapses and it becomes AMBIGUOUS by the ordinary path of v0.1 §5.3 E3, which is
+            # the safe state reached without inventing one. Without this, §5.7's "a chain of
+            # any depth is cut by one write" is false for exactly the actions in flight when
+            # an operator hits the switch.
+            self._append(EventType.ACTION_DENIED, action, self._authority_data(result), effect_key)
+            raise AuthorityDenied(
+                f"{action.name}: authority no longer covers this action ({result.reason}), so "
+                "the reservation is not held across the round trip; the lease will lapse and "
+                "the record becomes AMBIGUOUS",
+                reason=result.reason,
+                action_id=action.action_id,
+                grant_id=result.grant_id,
+                delegation_id=result.delegation_id,
             )
         rounds = self._store.hold_continuation(
             action, effect_key, suspension.continuation, self._clock() + self._suspend_timeout
@@ -1168,6 +1287,26 @@ def _refusal_data(refused: DuplicateEffect | AmbiguousEffect) -> dict[str, str]:
     if isinstance(refused, DuplicateEffect):
         return {"reason": "duplicate", "state": refused.state}
     return {"reason": "ambiguous"}
+
+
+def _optional_authority(source: str) -> Authority | None:
+    """The `authority:` section of the policy document, or `None` (SPEC-v0.3 §4.1).
+
+    Reads the file a second time rather than threading the parsed document through `Policy`:
+    `policy.py` must not learn what an `authority:` section means (`ARCHITECTURE.md` §6), and
+    a configuration file is read once at startup. Called only from `Control.from_file`, which
+    has just loaded a `Policy` from this path — so a read that fails here is a `PolicyError`
+    and never a silent `None`. "The file went away, so run every action unchecked" is the
+    fail-open direction, and §4.1 has no half-way.
+    """
+    try:
+        text = Path(source).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PolicyError(
+            f"the policy at {source} loaded but could not be read again for its 'authority:' "
+            f"section: {exc}"
+        ) from exc
+    return _optional_from_yaml(text, source=source)
 
 
 def state_path(source: str | os.PathLike[str] | None = None) -> Path:

--- a/src/ctrlrun/errors.py
+++ b/src/ctrlrun/errors.py
@@ -37,6 +37,54 @@ class ActionDenied(CTRLRunError):
         self.action_id = action_id
 
 
+class AuthorityDenied(ActionDenied):
+    """The principal holds no grant that covers this action (SPEC-v0.3 §4.3).
+
+    A subclass of `ActionDenied`, because an authority denial *is* the action being denied and
+    an agent loop's existing `except ActionDenied` should keep working. `reason` is one of the
+    closed set in §4.3 — `no_authority`, `authority_constraint`, `authority_expired`,
+    `authority_escalation`, `authority_revoked`, `authority_unreadable` — never a grant id: a
+    grant may legally be named `no_authority`, and evidence that can be spoofed by naming a
+    grant is not evidence. The id travels in `grant_id`.
+    """
+
+    def __init__(
+        self,
+        message: str | None = None,
+        *,
+        reason: str,
+        action_id: str | None = None,
+        grant_id: str | None = None,
+        delegation_id: str | None = None,
+    ) -> None:
+        super().__init__(message, reason=reason, action_id=action_id)
+        self.grant_id = grant_id
+        self.delegation_id = delegation_id
+
+
+class AuthorityEscalation(CTRLRunError):
+    """A delegation that may not exist: it is not contained in its parent (SPEC-v0.3 §5.3).
+
+    Not an `ActionDenied`: nothing was proposed. This is the creation-time vocabulary —
+    `containment`, `unknown_parent`, `parent_not_delegable`, `parent_not_valid`,
+    `not_the_subject`, `max_depth` — and it is disjoint from `AuthorityDenied`'s evaluation
+    reasons. The two are never used interchangeably.
+    """
+
+    def __init__(
+        self,
+        message: str | None = None,
+        *,
+        reason: str,
+        parent_id: str | None = None,
+        dimension: str | None = None,
+    ) -> None:
+        super().__init__(message if message is not None else reason)
+        self.reason = reason
+        self.parent_id = parent_id
+        self.dimension = dimension
+
+
 class ApprovalRequired(CTRLRunError):
     """The action needs a human. `request_id` is what `ctrlrun approve` takes (SPEC §4.3).
 

--- a/src/ctrlrun/policy.py
+++ b/src/ctrlrun/policy.py
@@ -63,10 +63,16 @@ _OPERATORS: Final = ("eq", "neq", "in", *_NUMERIC_COMPARE)
 #: Longest first, so `amount_neq` reads as (amount, neq) and never as (amount_n, eq).
 _OPERATORS_BY_LENGTH: Final = tuple(sorted(_OPERATORS, key=len, reverse=True))
 
-_TOP_LEVEL_KEYS: Final = frozenset({"schema", "actions", "environment"})
+_TOP_LEVEL_KEYS: Final = frozenset({"schema", "actions", "environment", "authority"})
 
-#: SPEC-v0.3 §12.1 — the top-level keys that need `ctrlrun.policy/v3`.
-_V3_TOP_LEVEL_KEYS: Final = frozenset({"environment"})
+#: SPEC-v0.3 §12.1 — the top-level keys that need `ctrlrun.policy/v3`, and what an older
+#: reader would do with each if it ignored one. `mode:` joins them with build-list item 4.
+_V3_TOP_LEVEL_KEYS: Final[Mapping[str, str]] = {
+    "environment": ("an older reader would ignore it and put every action in the wrong deployment"),
+    "authority": (
+        "an older reader would ignore it and run every action with no authority check at all"
+    ),
+}
 _RULE_KEYS: Final = frozenset({"when", "decision"})
 
 #: SPEC-v0.2 §3.1 — the keys `ctrlrun.policy/v2` adds to an action entry. The gateway has no
@@ -82,8 +88,23 @@ _MCP_KEYS: Final = frozenset({"not_executed_on_error"})
 #: rule — `when: { environment_eq: production }` — and matches nothing, so it is refused at
 #: load. Same fail-closed reading as `{resource}` in §5.1: two candidate meanings for one
 #: name, so make the author rename rather than silently pick one.
+#: SPEC-v0.3 §4.5 adds `claims`, `issuer` and `expires_at`: before v0.3 those names meant
+#: nothing, and now they name fields of a `Principal`, so v0.1 §3.2's rule applies — a name
+#: with two candidate meanings is refused until the author renames. Not gated on the schema
+#: version (§12.1): the splitter runs for every condition in every document, and gating it
+#: would leave the same name meaning two things in two files.
 RESERVED_ARGUMENTS: Final = frozenset(
-    {"action_id", "agent", "environment", "principal", "resource", "user"}
+    {
+        "action_id",
+        "agent",
+        "claims",
+        "environment",
+        "expires_at",
+        "issuer",
+        "principal",
+        "resource",
+        "user",
+    }
 )
 
 
@@ -142,7 +163,14 @@ def _is_container(value: object) -> bool:
 
 
 @dataclass(frozen=True)
-class _Condition:
+class Condition:
+    """One `<argument>_<op>: operand` test against an action's arguments (SPEC-v0.1 §3.2).
+
+    Public since SPEC-v0.3 §11, because a `Grant`'s constraints are made of them and the two
+    axes share one evaluator: a second implementation would be a second place for `True` to
+    start comparing equal to `1`. `key` is the raw condition key the author wrote.
+    """
+
     key: str
     argument: str
     op: str
@@ -184,7 +212,7 @@ class _Condition:
 @dataclass(frozen=True)
 class _Rule:
     decision: Decision
-    conditions: tuple[_Condition, ...]
+    conditions: tuple[Condition, ...]
 
     def matches(self, action_name: str, arguments: Mapping[str, Any]) -> bool:
         # A rule with no `when` has no conditions, so all() holds and it always matches.
@@ -283,19 +311,14 @@ class Policy:
                 f"{source}: 'actions' must be a mapping of action name to entry, "
                 f"got {_type_name(entries)}"
             )
+        require_v3(document, str(schema), source)
         environment = document.get("environment")
-        if "environment" in document:
-            if str(schema) != POLICY_SCHEMA_V3:
-                raise PolicyError(
-                    f"{source}: 'environment' needs 'schema: {POLICY_SCHEMA_V3}'; this document "
-                    f"declares {schema!r}, and an older reader would ignore it and put every "
-                    "action in the wrong deployment"
-                )
-            if not isinstance(environment, str) or not environment.strip():
-                raise PolicyError(
-                    f"{source}: 'environment' must be a non-empty string, "
-                    f"got {_type_name(environment)}"
-                )
+        if "environment" in document and (
+            not isinstance(environment, str) or not environment.strip()
+        ):
+            raise PolicyError(
+                f"{source}: 'environment' must be a non-empty string, got {_type_name(environment)}"
+            )
         actions: dict[str, _ActionPolicy] = {}
         for name, entry in entries.items():
             if not isinstance(name, str) or not name:
@@ -345,6 +368,37 @@ def discover_policy_path() -> Path:
     if not configured.strip():
         raise PolicyError(f"{CONFIG_ENV_VAR} is set but empty; unset it or point it at a policy")
     return Path(configured)
+
+
+def require_v3(document: Mapping[Any, Any], schema: str, source: str) -> None:
+    """Refuse a `ctrlrun.policy/v3` key in an older document (SPEC-v0.3 §12.1).
+
+    Shared with `authority.py`, which reads the same key from a document the policy loader
+    may never see: SPEC-v0.3 §8.3's `--authority` file carries `schema` and `authority` and
+    nothing else, so the check has to exist on both paths rather than on whichever runs first.
+    """
+    if schema == POLICY_SCHEMA_V3:
+        return
+    for key, consequence in _V3_TOP_LEVEL_KEYS.items():
+        if key in document:
+            raise PolicyError(
+                f"{source}: {key!r} needs 'schema: {POLICY_SCHEMA_V3}'; this document "
+                f"declares {schema!r}, and {consequence}"
+            )
+
+
+def parse_conditions(mapping: Mapping[Any, Any], *, where: str) -> Mapping[str, Condition]:
+    """Parse a `when:`-shaped mapping into conditions, keyed by the raw condition key.
+
+    Public since SPEC-v0.3 §11: a grant's `constraints:` is in exactly this syntax and MUST be
+    parsed by this code (§4.5). The key is injective given §3.2's longest-suffix split, which
+    is what lets `Grant`'s containment check look a dimension up by name.
+    """
+    conditions: dict[str, Condition] = {}
+    for key, operand in mapping.items():
+        condition = _parse_condition(key, operand, where)
+        conditions[condition.key] = condition
+    return conditions
 
 
 def _reject_unknown_keys(mapping: Mapping[Any, Any], allowed: Iterable[str], where: str) -> None:
@@ -478,15 +532,15 @@ def _parse_rule(rule: object, where: str) -> _Rule:
         )
     return _Rule(
         decision=decision,
-        conditions=tuple(_parse_condition(key, operand, where) for key, operand in when.items()),
+        conditions=tuple(parse_conditions(when, where=where).values()),
     )
 
 
-def _parse_condition(key: object, operand: object, where: str) -> _Condition:
+def _parse_condition(key: object, operand: object, where: str) -> Condition:
     if not isinstance(key, str):
         raise PolicyError(f"{where}: condition keys must be strings, got {key!r}")
     argument, op = _split_condition_key(key, where)
-    return _Condition(
+    return Condition(
         key=key,
         argument=argument,
         op=op,
@@ -516,9 +570,15 @@ def _split_condition_key(key: str, where: str) -> tuple[str, str]:
 def _parse_operand(op: str, operand: object, where: str, key: str) -> object:
     if op in _NUMERIC_COMPARE:
         if not _is_int(operand):
+            # SPEC-v0.3 §4.5 — the message names the representation rule, because the operator
+            # who wrote `amount_lte: "2000.00"` has hit a real limit and not a typo: only
+            # integer arguments can be bounded, so a deployment representing money as decimal
+            # strings cannot express an amount ceiling in a grant at all.
             raise PolicyError(
                 f"{where}: condition {key!r}: a numeric operator needs an int operand, "
-                f"got {_type_name(operand)}"
+                f"got {_type_name(operand)}. Only integers can be bounded, so an amount that "
+                "a rule or a grant compares is written in integer minor units "
+                "(amount_lte: 200000), never as a decimal string"
             )
         return operand
     if op == "in":

--- a/src/ctrlrun/receipt.py
+++ b/src/ctrlrun/receipt.py
@@ -99,6 +99,18 @@ class EventType(StrEnum):
     #: caused it: `receipt.py` does not learn MCP vocabulary (ARCHITECTURE §6).
     EXECUTION_SUSPENDED = "EXECUTION_SUSPENDED"
     EXECUTION_RESUMED = "EXECUTION_RESUMED"
+    #: SPEC-v0.3 §7 — the five types authority and delegation add. `AUTHORITY_RESOLVED` is
+    #: appended for *every* action that passes authority, not only for a delegated one:
+    #: evidence has to record that CTRLRun checked and found a grant, or a deployment with a
+    #: permissive grant is indistinguishable from one with no `authority:` section at all.
+    #: The three `DELEGATION_*` types are produced by `Control.delegate` and `Control.revoke`,
+    #: which land with build-list item 3; the vocabulary is closed here so a reader of an
+    #: evidence file has one list to check against.
+    AUTHORITY_RESOLVED = "AUTHORITY_RESOLVED"
+    AUTHORITY_DENIED = "AUTHORITY_DENIED"
+    DELEGATION_CREATED = "DELEGATION_CREATED"
+    DELEGATION_REVOKED = "DELEGATION_REVOKED"
+    DELEGATION_REJECTED = "DELEGATION_REJECTED"
 
 
 @dataclass(frozen=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,3 +40,63 @@ def state_store(request, tmp_path, fake_clock):
     )
     yield store
     store.close()
+
+
+# --- SPEC-v0.3 §7 / T66: the five new event types stay inside authority's tests ----------
+
+#: The event types SPEC-v0.3 §7 adds. A configuration with no `authority:` section must
+#: never produce one (§4.1), and T66's mechanical half is the assertion that none of them
+#: appeared anywhere in the run except in a test that built such a section.
+AUTHORITY_EVENT_TYPES = frozenset(
+    {
+        "AUTHORITY_RESOLVED",
+        "AUTHORITY_DENIED",
+        "DELEGATION_CREATED",
+        "DELEGATION_REVOKED",
+        "DELEGATION_REJECTED",
+    }
+)
+
+
+def check_authority_events_declared(appended, *, declared, nodeid="<test>"):
+    """Raise unless every SPEC-v0.3 §7 event came from a test that opted into authority.
+
+    A separate function so T66 can exercise the check itself. A guard whose only evidence is
+    that the suite stayed green is a guard nothing exercises, and this one is only ever *not*
+    triggered.
+    """
+    leaked = sorted(set(appended) & AUTHORITY_EVENT_TYPES)
+    if leaked and not declared:
+        raise AssertionError(
+            f"{nodeid} appended {', '.join(leaked)} without an `authority` marker. "
+            "SPEC-v0.3 §4.1: a configuration with no `authority:` section behaves exactly as "
+            "v0.2, which means none of the §7 event types exists in it. Mark the test "
+            "`@pytest.mark.authority` if it really does build an `authority:` section."
+        )
+
+
+@pytest.fixture(autouse=True)
+def authority_events_are_declared(request, monkeypatch):
+    """Record every event either shipped store appends, and check T66's rule per test.
+
+    Per test rather than at session finish, so the failure names the test that leaked and
+    fails red where a reader is looking.
+    """
+    appended: list[str] = []
+
+    for store_class in (InMemoryStateStore, SQLiteStateStore):
+        original = store_class.append_event
+
+        def recording(self, event, _original=original):
+            appended.append(str(event.type))
+            return _original(self, event)
+
+        monkeypatch.setattr(store_class, "append_event", recording)
+
+    yield appended
+
+    check_authority_events_declared(
+        appended,
+        declared=request.node.get_closest_marker("authority") is not None,
+        nodeid=request.node.nodeid,
+    )

--- a/tests/test_acs.py
+++ b/tests/test_acs.py
@@ -489,3 +489,37 @@ def test_T55_the_response_is_json_serialisable(hook):
     """A Guardian puts this on a wire; anything that will not serialise is a bug here."""
     for envelope in (_call(), _call(amount=200000), _call(amount=99999999)):
         assert json.loads(json.dumps(hook.handle(envelope)))
+
+
+# --- SPEC-v0.3 §8.4: the hook needs an identity, for the reason the gateway does --------
+
+
+@pytest.mark.authority
+def test_an_authority_holding_control_is_refused_at_construction(store):
+    """§8.4 — this hook reads `params.metadata.agent_id` off the inbound envelope, and §4 makes
+    the principal an authorization input. A self-reported name cannot be one, which is the same
+    sentence that removes `--principal-from-client-info` (§8.1); the ACS hook is that flag in a
+    different module, and removing one while leaving the other would make the removal a
+    gesture. T91d asserts the item-5 form of this, where the hook takes an `identity` of its
+    own; until then it has none, so an `Authority` is refused outright."""
+    from ctrlrun import Authority, InvalidArgument
+
+    authority = Authority.from_yaml(
+        "schema: ctrlrun.policy/v3\n"
+        "authority:\n"
+        "  grants:\n"
+        "    - id: g\n"
+        '      subject: { agent: "refund-agent" }\n'
+        '      actions: ["**"]\n',
+        standalone=True,
+    )
+    control = Control(Policy.from_yaml(POLICY), store, authority=authority)
+
+    with pytest.raises(InvalidArgument, match="identity"):
+        AcsControlHook(control, prefix="acs")
+
+
+def test_a_control_with_no_authority_still_constructs(control):
+    """The control for the refusal above: without it, an implementation that refused every
+    Control would satisfy the first half."""
+    assert AcsControlHook(control, prefix="acs") is not None

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -1,0 +1,1391 @@
+"""The `authority:` section, grants and evaluation. Build-list item 2; SPEC-v0.3 §4.
+
+The acceptance tests are T66 to T74b. Four sentences run through all of them:
+
+**Authority is opt-in, then fail-closed** (§4.1). No `authority:` key at all is v0.2, exactly —
+T66 — and the moment one exists every principal needs a grant, including for actions the policy
+allows outright.
+
+**A grant carries no decision** (§4.2). Authority answers "may this principal do this at all";
+policy answers "how much autonomy does the action have". So T70 is a 2-by-3 whose bottom
+row collapses to one case, not the 3-by-3 the build brief asked for.
+
+**Authority runs before policy** (§4.3). A denial there must not leave a pending approval
+request behind, so T74 asserts the trace and not merely the outcome.
+
+**The reason is asserted by name, everywhere** (§4.3). A guard that can only fire where a later
+guard would also fire, with the same observable result, is documentation rather than defence;
+a test asserting only "it was refused" cannot tell which check ran.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from conftest import AUTHORITY_EVENT_TYPES, check_authority_events_declared
+from ctrlrun import (
+    Action,
+    ActionDenied,
+    ApprovalRequired,
+    Authority,
+    AuthorityDenied,
+    Control,
+    Decision,
+    Grant,
+    InMemoryStateStore,
+    InvalidArgument,
+    Policy,
+    PolicyError,
+    Principal,
+    Subject,
+)
+from ctrlrun.authority import (
+    AUTHORITY_CONSTRAINT,
+    AUTHORITY_EXPIRED,
+    AUTHORITY_GRANT,
+    NO_AUTHORITY,
+    contains,
+    matches,
+)
+from ctrlrun.policy import Condition
+from ctrlrun.receipt import EventType
+
+pytestmark = pytest.mark.authority
+
+V3 = "schema: ctrlrun.policy/v3\n"
+
+ACTIONS = """
+actions:
+  stripe.refund:
+    rules:
+      - when: { amount_lte: 50000 }
+        decision: allow
+      - when: { amount_lte: 5000000 }
+        decision: approve
+      - decision: deny
+  customer.read:
+    decision: allow
+"""
+
+GRANT = """
+authority:
+  grants:
+    - id: head-of-support
+      subject: { agent: "support-agent", user: "alice@example.com" }
+      actions: ["stripe.refund"]
+      resources: ["payment:EU-*"]
+      constraints: { amount_lte: 200000 }
+      environments: ["production"]
+"""
+
+
+class _Clock:
+    """Static: it moves only when a test moves it, so an expiry boundary is exact."""
+
+    def __init__(self) -> None:
+        self.now = datetime(2026, 9, 3, 10, 12, 1, tzinfo=UTC)
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, delta: timedelta) -> None:
+        self.now += delta
+
+
+@pytest.fixture
+def clock():
+    return _Clock()
+
+
+@pytest.fixture
+def store(clock):
+    return InMemoryStateStore(clock=clock)
+
+
+def _document(authority: str = "", actions: str = ACTIONS) -> str:
+    return V3 + authority + actions
+
+
+def _control(document, store, clock, environment="production"):
+    """One document, both loaders — the shape `Control.from_file` builds (§4.8)."""
+    authority = Authority.from_yaml(document) if "authority:" in document else None
+    return Control(
+        Policy.from_yaml(document),
+        store,
+        authority=authority,
+        clock=clock,
+        environment=environment,
+    )
+
+
+def _action(**overrides):
+    fields = {
+        "name": "stripe.refund",
+        "arguments": {"amount": 1000, "payment_id": "EU-42"},
+        "principal": Principal(agent="support-agent", user="alice@example.com"),
+        "resource": "payment:EU-42",
+        "environment": "production",
+    }
+    fields.update(overrides)
+    return Action(**fields)
+
+
+def _types(store, action_id=None):
+    return [
+        str(event.type)
+        for event in store.events()
+        if action_id is None or event.action_id == action_id
+    ]
+
+
+def _data(store, type_):
+    return [event.data for event in store.events() if str(event.type) == type_]
+
+
+class _Executor:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self):
+        self.calls += 1
+        return "ok"
+
+
+# --- T66: no `authority:` section is v0.2, exactly (§4.1) ------------------------------
+
+
+def test_T66_a_document_with_no_authority_section_leaves_control_authority_none(
+    tmp_path, store, clock
+):
+    (tmp_path / "ctrlrun.yaml").write_text(_document())
+    control = Control.from_file(tmp_path / "ctrlrun.yaml")
+
+    assert control.authority is None
+    assert _control(_document(), store, clock).authority is None
+
+
+def test_T66_no_authority_event_is_appended_without_a_section(store, clock):
+    """The behavioural half: a full v0.1 path — allow, approve, deny — under a document with
+    no `authority:` key produces not one of the five §7 types."""
+    control = _control(_document(), store, clock)
+    executor = _Executor()
+
+    control.execute(_action(), executor, "refund:EU-42")
+    with pytest.raises(ApprovalRequired):
+        control.execute(_action(arguments={"amount": 100000, "payment_id": "EU-43"}), executor)
+    with pytest.raises(ActionDenied):
+        control.execute(_action(arguments={"amount": 90000000, "payment_id": "EU-44"}), executor)
+
+    assert executor.calls == 1
+    assert AUTHORITY_EVENT_TYPES.isdisjoint(_types(store))
+
+
+def test_T66_the_session_guard_refuses_an_undeclared_authority_event():
+    """The mechanical half of T66 is `tests/conftest.py`'s autouse fixture, and this asserts
+    the fixture would actually fail. A guard whose only evidence is that the suite stayed
+    green is a guard nothing exercises."""
+    for leaked in sorted(AUTHORITY_EVENT_TYPES):
+        with pytest.raises(AssertionError, match=leaked):
+            check_authority_events_declared(["ACTION_PROPOSED", leaked], declared=False, nodeid="t")
+        check_authority_events_declared(["ACTION_PROPOSED", leaked], declared=True, nodeid="t")
+
+
+def test_T66_the_session_guard_records_what_the_stores_append(
+    store, clock, authority_events_are_declared
+):
+    """And that it is wired to the stores at all: without this the fixture could be recording
+    nothing and every `isdisjoint` above would hold vacuously."""
+    control = _control(_document(GRANT), store, clock)
+
+    control.execute(_action(), _Executor(), None)
+
+    assert "AUTHORITY_RESOLVED" in authority_events_are_declared
+    assert "ACTION_PROPOSED" in authority_events_are_declared
+
+
+# --- T67: a principal with no grant is denied (§4.1, §4.3) -----------------------------
+
+
+def test_T67_a_principal_with_no_grant_is_denied(store, clock):
+    control = _control(_document(GRANT), store, clock)
+    action = _action(principal=Principal(agent="other-agent", user="alice@example.com"))
+    executor = _Executor()
+
+    with pytest.raises(AuthorityDenied) as refused:
+        control.execute(action, executor, "refund:EU-42")
+
+    assert refused.value.reason == NO_AUTHORITY
+    assert executor.calls == 0
+    receipt = store.receipts()[-1]
+    assert str(receipt.result) == "denied"
+    assert receipt.decision is Decision.DENY
+    assert receipt.decision_reason == NO_AUTHORITY
+    assert store.approvals_for(action.action_hash) == ()
+    assert store.get_effect("refund:EU-42") is None
+
+
+def test_T67_an_authority_denial_is_an_action_denied(store, clock):
+    """§11 — `AuthorityDenied` subclasses `ActionDenied`, so an agent loop's existing handler
+    keeps working."""
+    control = _control(_document(GRANT), store, clock)
+
+    with pytest.raises(ActionDenied):
+        control.execute(_action(principal=Principal(agent="other-agent")), _Executor(), None)
+
+
+def test_T67_an_action_the_policy_allows_outright_still_needs_a_grant(store, clock):
+    """§4.1 — including reads, including actions with no effect key."""
+    control = _control(_document(GRANT), store, clock)
+
+    with pytest.raises(AuthorityDenied) as refused:
+        control.execute(_action(name="customer.read", resource=None), _Executor(), None)
+
+    assert refused.value.reason == NO_AUTHORITY
+
+
+def test_T67_an_empty_grants_list_denies_everything(store, clock):
+    """§4.1 — `grants: []` is valid and denies every action, the shape of v0.1's `actions: {}`."""
+    control = _control(_document("authority:\n  grants: []\n"), store, clock)
+
+    with pytest.raises(AuthorityDenied) as refused:
+        control.execute(_action(), _Executor(), None)
+
+    assert refused.value.reason == NO_AUTHORITY
+
+
+# --- T67b: subject matching, by name (§4.2) --------------------------------------------
+
+
+def _subject_grant(subject: str) -> str:
+    return f"""
+authority:
+  grants:
+    - id: g
+      subject: {subject}
+      actions: ["**"]
+"""
+
+
+@pytest.mark.parametrize(
+    ("subject", "principal", "expected"),
+    [
+        # A grant naming a user is not satisfied by an agent acting alone.
+        ('{ agent: "support-agent", user: "alice@example.com" }', ("support-agent", None), False),
+        ('{ agent: "support-agent", user: "alice@example.com" }', ("support-agent", "bob"), False),
+        (
+            '{ agent: "support-agent", user: "alice@example.com" }',
+            ("support-agent", "alice@example.com"),
+            True,
+        ),
+        # A grant omitting `user` matches a principal that has one, and one that has not.
+        ('{ agent: "support-agent" }', ("support-agent", "alice@example.com"), True),
+        ('{ agent: "support-agent" }', ("support-agent", None), True),
+        # A subject has no separator, so `*` matches a dotted agent name whole.
+        ('{ agent: "*" }', ("acme.support.agent", None), True),
+        # A prefix wildcard is a prefix, not a substring.
+        ('{ agent: "support-*" }', ("support-agent", None), True),
+        ('{ agent: "support-*" }', ("supporter", None), False),
+        ('{ agent: "support-*" }', ("the-support-agent", None), False),
+        # Omitting `agent` means any agent (§4.2), and is spelled out rather than inferred.
+        ('{ user: "alice@example.com" }', ("any-agent-at-all", "alice@example.com"), True),
+        ('{ user: "alice@example.com" }', ("any-agent-at-all", None), False),
+    ],
+)
+def test_T67b_subject_matching(store, clock, subject, principal, expected):
+    control = _control(_document(_subject_grant(subject)), store, clock)
+    agent, user = principal
+    action = _action(
+        name="customer.read", resource=None, principal=Principal(agent=agent, user=user)
+    )
+    executor = _Executor()
+
+    if expected:
+        control.execute(action, executor, None)
+        assert executor.calls == 1
+    else:
+        with pytest.raises(AuthorityDenied) as refused:
+            control.execute(action, executor, None)
+        assert refused.value.reason == NO_AUTHORITY
+        assert executor.calls == 0
+
+
+# --- T67c: a grant scoped to another environment does not match (§4.2, §2.5) -----------
+
+ENVIRONMENT_GRANT = """
+authority:
+  grants:
+    - id: staging-only
+      subject: { agent: "support-agent" }
+      actions: ["stripe.refund"]
+      environments: ["staging"]
+"""
+
+
+def test_T67c_a_grant_scoped_to_another_environment_does_not_match(store, clock):
+    control = _control(_document(ENVIRONMENT_GRANT), store, clock, environment="production")
+    executor = _Executor()
+
+    with pytest.raises(AuthorityDenied) as refused:
+        control.execute(_action(resource=None), executor, None)
+
+    assert refused.value.reason == NO_AUTHORITY
+    assert executor.calls == 0
+
+
+def test_T67c_the_same_grant_in_its_own_environment_passes(store, clock):
+    """The control for the pair. Without it an implementation that matched no environment at
+    all would satisfy the first half. No calling code participates in either outcome."""
+    control = _control(_document(ENVIRONMENT_GRANT), store, clock, environment="staging")
+    executor = _Executor()
+
+    control.execute(_action(resource=None, environment="staging"), executor, None)
+
+    assert executor.calls == 1
+
+
+# --- T68: a matching grant passes to policy (§4.3) -------------------------------------
+
+
+def test_T68_a_matching_grant_passes_to_policy(store, clock):
+    control = _control(_document(GRANT), store, clock)
+    executor = _Executor()
+
+    receipt = control.execute(_action(), executor, "refund:EU-42")
+
+    assert executor.calls == 1
+    assert str(receipt.result) == "committed"
+    types = _types(store)
+    assert types.index("AUTHORITY_RESOLVED") < types.index("POLICY_EVALUATED")
+    resolved = _data(store, "AUTHORITY_RESOLVED")[0]
+    # By name: §4.6 sends both passing cells' `decision_reason` to the policy axis, so this
+    # event is the only place a *pass* reason is observable at all.
+    assert resolved["reason"] == AUTHORITY_GRANT
+    assert resolved["grant_id"] == "head-of-support"
+    assert receipt.decision_reason == "rule[0]"
+
+
+SHAPE_GRANT = """
+authority:
+  grants:
+    - id: eu-refunds
+      subject: { agent: "support-agent" }
+      actions: ["stripe.refund"]
+      resources: ["payment:EU-*"]
+"""
+
+
+@pytest.mark.parametrize(
+    ("name", "resource", "expected"),
+    [
+        ("stripe.refund", "payment:EU-42", True),
+        # One dimension away from the row above, each time, so nothing else can be doing
+        # the refusing: the mutation run caught a resource test that was actually being
+        # denied by the action pattern.
+        ("stripe.refund", "payment:US-42", False),
+        ("stripe.refund", "payment:EU-42:leg2", False),
+        ("stripe.refund", None, False),
+        ("customer.read", "payment:EU-42", False),
+    ],
+    ids=["match", "other-resource", "deeper-resource", "no-resource", "other-action"],
+)
+def test_T67d_the_action_name_and_the_resource_are_both_matched(clock, name, resource, expected):
+    store = InMemoryStateStore(clock=clock)
+    control = _control(_document(SHAPE_GRANT), store, clock)
+    action = _action(name=name, resource=resource, principal=Principal(agent="support-agent"))
+    executor = _Executor()
+
+    if expected:
+        control.execute(action, executor, None)
+        assert executor.calls == 1
+    else:
+        with pytest.raises(AuthorityDenied) as refused:
+            control.execute(action, executor, None)
+        assert refused.value.reason == NO_AUTHORITY
+        assert executor.calls == 0
+
+
+def test_T68_a_grant_omitting_resources_matches_an_action_with_none(store, clock):
+    """§4.4 — an action whose `resource` is None does not match a grant that declares
+    `resources:`; to grant one, omit the key."""
+    with_resources = _document(GRANT)
+    without = _document(
+        """
+authority:
+  grants:
+    - id: reader
+      subject: { agent: "support-agent" }
+      actions: ["customer.read"]
+"""
+    )
+    read = _action(name="customer.read", resource=None)
+
+    with pytest.raises(AuthorityDenied) as refused:
+        _control(with_resources, store, clock).execute(read, _Executor(), None)
+    assert refused.value.reason == NO_AUTHORITY
+
+    executor = _Executor()
+    _control(without, InMemoryStateStore(clock=clock), clock).execute(read, executor, None)
+    assert executor.calls == 1
+
+
+# --- T69: a failed constraint denies what policy would allow (§4.5) --------------------
+
+
+def test_T69_a_failed_constraint_denies_what_policy_would_allow(store, clock):
+    """Policy says allow at this amount; the grant's ceiling excludes it. By reason, so
+    removing the constraint check cannot pass as `no_authority`."""
+    policy_allows = """
+actions:
+  stripe.refund:
+    rules:
+      - decision: allow
+"""
+    control = _control(_document(GRANT, policy_allows), store, clock)
+    action = _action(arguments={"amount": 300000, "payment_id": "EU-42"})
+    executor = _Executor()
+
+    assert control.policy.evaluate(action).decision is Decision.ALLOW
+    with pytest.raises(AuthorityDenied) as refused:
+        control.execute(action, executor, None)
+
+    assert refused.value.reason == AUTHORITY_CONSTRAINT
+    assert refused.value.grant_id == "head-of-support"
+    assert executor.calls == 0
+    assert store.receipts()[-1].decision_reason == AUTHORITY_CONSTRAINT
+
+
+def test_T69_an_absent_argument_makes_a_constraint_false(store, clock, caplog):
+    """§4.5 — a condition that cannot be evaluated never matches, and says so in the log."""
+    control = _control(_document(GRANT), store, clock)
+
+    with pytest.raises(AuthorityDenied) as refused:
+        control.execute(_action(arguments={"payment_id": "EU-42"}), _Executor(), None)
+
+    assert refused.value.reason == AUTHORITY_CONSTRAINT
+    assert "amount" in caplog.text
+
+
+# --- T69b: only integers can be bounded (§4.5) -----------------------------------------
+
+
+def test_T69b_a_decimal_string_operand_is_a_load_error_naming_the_rule():
+    decimal = """
+authority:
+  grants:
+    - id: g
+      subject: { agent: "a" }
+      actions: ["stripe.refund"]
+      constraints: { amount_lte: "2000.00" }
+"""
+    with pytest.raises(PolicyError) as refused:
+        Authority.from_yaml(_document(decimal))
+
+    assert "int" in str(refused.value)
+    assert "minor units" in str(refused.value)
+
+
+def test_T69b_no_control_is_constructed(tmp_path):
+    decimal = """
+authority:
+  grants:
+    - id: g
+      subject: { agent: "a" }
+      actions: ["stripe.refund"]
+      constraints: { amount_lte: "2000.00" }
+"""
+    (tmp_path / "ctrlrun.yaml").write_text(_document(decimal))
+    control = None
+
+    with pytest.raises(PolicyError):
+        control = Control.from_file(tmp_path / "ctrlrun.yaml")
+
+    assert control is None
+
+
+# --- T70: stricter wins, four cases (§4.6) ---------------------------------------------
+
+PERMISSIVE_GRANT = """
+authority:
+  grants:
+    - id: everything
+      subject: { agent: "support-agent" }
+      actions: ["**"]
+"""
+
+_POLICY_BY_DECISION = {
+    "allow": "\nactions:\n  stripe.refund:\n    rules:\n      - decision: allow\n",
+    "approve": "\nactions:\n  stripe.refund:\n    rules:\n      - decision: approve\n",
+    "deny": "\nactions:\n  stripe.refund:\n    rules:\n      - decision: deny\n",
+}
+
+
+@pytest.mark.parametrize(
+    ("grant", "policy_decision", "expected", "reason"),
+    [
+        (PERMISSIVE_GRANT, "allow", Decision.ALLOW, "rule[0]"),
+        (PERMISSIVE_GRANT, "approve", Decision.APPROVE, "rule[0]"),
+        (PERMISSIVE_GRANT, "deny", Decision.DENY, "rule[0]"),
+        # §4.6's bottom row is reached without evaluating policy at all, so its three cells
+        # are indistinguishable — same outcome, same events, same reason. One case, not
+        # three: running it three times would be one assertion over three configurations
+        # nothing can tell apart.
+        (GRANT, "allow", Decision.DENY, NO_AUTHORITY),
+    ],
+    ids=["pass-allow", "pass-approve", "pass-deny", "deny-any"],
+)
+def test_T70_the_stricter_of_the_two_wins(store, clock, grant, policy_decision, expected, reason):
+    document = _document(grant, _POLICY_BY_DECISION[policy_decision])
+    control = _control(document, store, clock)
+    # The deny row's grant is scoped to another agent, so authority refuses before policy.
+    action = _action(principal=Principal(agent="support-agent"), resource=None)
+    executor = _Executor()
+
+    evaluation = control.evaluate(action)
+    assert evaluation.decision is expected
+    assert evaluation.reason == reason
+
+    if expected is Decision.ALLOW:
+        receipt = control.execute(action, executor, None)
+        assert executor.calls == 1
+        assert receipt.decision is expected
+        assert receipt.decision_reason == reason
+    elif expected is Decision.APPROVE:
+        with pytest.raises(ApprovalRequired):
+            control.execute(action, executor, None)
+        assert executor.calls == 0
+    else:
+        with pytest.raises(ActionDenied) as refused:
+            control.execute(action, executor, None)
+        assert refused.value.reason == reason
+        assert executor.calls == 0
+        assert store.receipts()[-1].decision_reason == reason
+
+
+def test_T70_authority_cannot_loosen_a_policy_denial(store, clock):
+    """Neither axis loosens the other, stated as its own assertion: the widest possible grant
+    over an action the policy denies is still a denial, with the *policy* reason."""
+    control = _control(_document(PERMISSIVE_GRANT, _POLICY_BY_DECISION["deny"]), store, clock)
+
+    with pytest.raises(ActionDenied) as refused:
+        control.execute(_action(principal=Principal(agent="support-agent")), _Executor(), None)
+
+    assert refused.value.reason == "rule[0]"
+    assert not isinstance(refused.value, AuthorityDenied)
+
+
+# --- T70b: several matching grants, and order does not matter (§4.6) -------------------
+
+TWO_MATCHING = """
+authority:
+  grants:
+    - id: {first}
+      subject: {{ agent: "support-agent" }}
+      actions: ["stripe.**"]
+    - id: {second}
+      subject: {{ agent: "support-agent" }}
+      actions: ["**"]
+"""
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [("a-narrow", "b-wide"), ("b-wide", "a-narrow")],
+    ids=["a-first", "b-first"],
+)
+def test_T70b_several_matching_grants_name_the_lowest_id(clock, first, second):
+    store = InMemoryStateStore(clock=clock)
+    document = _document(TWO_MATCHING.format(first=first, second=second))
+    control = _control(document, store, clock)
+    executor = _Executor()
+
+    receipt = control.execute(_action(principal=Principal(agent="support-agent")), executor, None)
+
+    assert executor.calls == 1
+    assert receipt.decision is Decision.ALLOW
+    # The one assertion that can catch an implementation returning whichever grant it reached
+    # first: `a-narrow` sorts first by codepoint whichever order the document is written in.
+    assert _data(store, "AUTHORITY_RESOLVED")[0]["grant_id"] == "a-narrow"
+
+
+def test_T70b_holding_two_permissions_is_never_worse_than_holding_one(store, clock):
+    """§4.6 — denial arises from the absence of a matching grant, never from the presence of a
+    stricter one. The narrow grant's constraint excludes the action; the wide one does not."""
+    both = """
+authority:
+  grants:
+    - id: a-narrow
+      subject: { agent: "support-agent" }
+      actions: ["stripe.refund"]
+      constraints: { amount_lte: 100 }
+    - id: b-wide
+      subject: { agent: "support-agent" }
+      actions: ["stripe.refund"]
+"""
+    control = _control(_document(both), store, clock)
+    executor = _Executor()
+
+    control.execute(_action(principal=Principal(agent="support-agent")), executor, None)
+
+    assert executor.calls == 1
+    assert _data(store, "AUTHORITY_RESOLVED")[0]["grant_id"] == "b-wide"
+
+
+# --- T71: an expired grant denies (§4.2, §4.3) -----------------------------------------
+
+EXPIRING_GRANT = """
+authority:
+  grants:
+    - id: head-of-support
+      subject: { agent: "support-agent" }
+      actions: ["stripe.refund"]
+      expires_at: 2026-09-03T10:12:01Z
+"""
+
+
+def test_T71_an_expired_grant_denies(store, clock):
+    control = _control(_document(EXPIRING_GRANT), store, clock)
+    clock.now = datetime(2026, 9, 3, 10, 12, 2, tzinfo=UTC)
+    executor = _Executor()
+
+    with pytest.raises(AuthorityDenied) as refused:
+        control.execute(_action(principal=Principal(agent="support-agent")), executor, None)
+
+    assert refused.value.reason == AUTHORITY_EXPIRED
+    assert refused.value.grant_id == "head-of-support"
+    assert executor.calls == 0
+    assert store.receipts()[-1].decision_reason == AUTHORITY_EXPIRED
+
+
+def test_T71_a_grant_is_valid_up_to_and_including_its_expiry(store, clock):
+    control = _control(_document(EXPIRING_GRANT), store, clock)
+    clock.now = datetime(2026, 9, 3, 10, 12, 1, tzinfo=UTC)
+    executor = _Executor()
+
+    control.execute(_action(principal=Principal(agent="support-agent")), executor, None)
+
+    assert executor.calls == 1
+
+
+def test_T71_one_microsecond_past_the_expiry_does_not(store, clock):
+    control = _control(_document(EXPIRING_GRANT), store, clock)
+    clock.now = datetime(2026, 9, 3, 10, 12, 1, 1, tzinfo=UTC)
+
+    with pytest.raises(AuthorityDenied) as refused:
+        control.execute(_action(principal=Principal(agent="support-agent")), _Executor(), None)
+
+    assert refused.value.reason == AUTHORITY_EXPIRED
+
+
+def test_T71_a_naive_expires_at_is_a_load_error():
+    """§4.2 — both the quoted string form and the form PyYAML parses into a naive datetime."""
+    for written in ("2026-12-31 23:59:59", '"2026-12-31T23:59:59"'):
+        naive = f"""
+authority:
+  grants:
+    - id: g
+      subject: {{ agent: "a" }}
+      actions: ["**"]
+      expires_at: {written}
+"""
+        with pytest.raises(PolicyError, match="offset"):
+            Authority.from_yaml(_document(naive))
+
+
+def test_T71_pyyaml_returns_an_aware_datetime_for_an_offset(store, clock):
+    """The floor under §4.2's rule, asserted rather than assumed: PyYAML 5 subtracts the
+    offset and hands back a naive value, which would reject §4.1's own example at load."""
+    import yaml
+
+    parsed = yaml.safe_load("when: 2026-12-31T23:59:59Z")["when"]
+    assert parsed.tzinfo is not None
+
+
+# --- T71b: reason precedence, collected and fixed (§4.3) -------------------------------
+
+# `authority_revoked`, `authority_escalation` and `authority_unreadable` need a delegation
+# record, which arrives with build-list item 3; T71b's full three-grant form lands there.
+# What is reachable here is the half that decides the argument: expiry outranks constraint,
+# both within one grant and across grants, and neither turns on document order.
+
+# `a-expired` sorts *after* `b-constrained` by codepoint on neither name, so the two carry
+# ids that make the precedence assertion independent of the sort tie-break below.
+_EXPIRED_GRANT = """    - id: a-expired
+      subject: { agent: "support-agent" }
+      actions: ["stripe.refund"]
+      expires_at: 2026-09-03T09:00:00Z
+"""
+_CONSTRAINED_GRANT = """    - id: b-constrained
+      subject: { agent: "support-agent" }
+      actions: ["stripe.refund"]
+      constraints: { amount_lte: 1 }
+"""
+
+
+@pytest.mark.parametrize(
+    "order",
+    [(_EXPIRED_GRANT, _CONSTRAINED_GRANT), (_CONSTRAINED_GRANT, _EXPIRED_GRANT)],
+    ids=["expired-first", "constrained-first"],
+)
+def test_T71b_expiry_outranks_a_failed_constraint_across_grants(clock, order):
+    store = InMemoryStateStore(clock=clock)
+    section = "authority:\n  grants:\n" + "".join(order)
+    control = _control(_document(section), store, clock)
+
+    with pytest.raises(AuthorityDenied) as refused:
+        control.execute(_action(principal=Principal(agent="support-agent")), _Executor(), None)
+
+    # Fixed and collected rather than short-circuited: the reason names what will still be
+    # wrong after the caller changes the request.
+    assert refused.value.reason == AUTHORITY_EXPIRED
+    assert refused.value.grant_id == "a-expired"
+    assert _data(store, "AUTHORITY_DENIED")[0] == {
+        "reason": AUTHORITY_EXPIRED,
+        "grant_id": "a-expired",
+    }
+
+
+def test_T71b_one_grant_failing_both_ways_reports_the_expiry(store, clock):
+    """Evaluation collects every reason a grant failed for rather than short-circuiting."""
+    both = """
+authority:
+  grants:
+    - id: g
+      subject: { agent: "support-agent" }
+      actions: ["stripe.refund"]
+      constraints: { amount_lte: 1 }
+      expires_at: 2026-09-03T09:00:00Z
+"""
+    control = _control(_document(both), store, clock)
+
+    with pytest.raises(AuthorityDenied) as refused:
+        control.execute(_action(principal=Principal(agent="support-agent")), _Executor(), None)
+
+    assert refused.value.reason == AUTHORITY_EXPIRED
+
+
+def test_T71b_two_grants_failing_the_same_way_name_the_lowest_id(store, clock):
+    same = """
+authority:
+  grants:
+    - id: b-second
+      subject: { agent: "support-agent" }
+      actions: ["stripe.refund"]
+      constraints: { amount_lte: 1 }
+    - id: a-first
+      subject: { agent: "support-agent" }
+      actions: ["stripe.refund"]
+      constraints: { amount_lte: 2 }
+"""
+    control = _control(_document(same), store, clock)
+
+    with pytest.raises(AuthorityDenied) as refused:
+        control.execute(_action(principal=Principal(agent="support-agent")), _Executor(), None)
+
+    assert refused.value.reason == AUTHORITY_CONSTRAINT
+    assert refused.value.grant_id == "a-first"
+
+
+def test_T71b_no_authority_implicates_no_grant(store, clock):
+    """§7 — `grant_id` is present "where one grant was implicated", and no grant matching the
+    shape implicates none."""
+    control = _control(_document(GRANT), store, clock)
+
+    with pytest.raises(AuthorityDenied) as refused:
+        control.execute(_action(principal=Principal(agent="other-agent")), _Executor(), None)
+
+    assert refused.value.grant_id is None
+    assert _data(store, "AUTHORITY_DENIED")[0] == {"reason": NO_AUTHORITY}
+
+
+# --- T72: pattern matching does not cross a separator (§4.4) ---------------------------
+
+
+@pytest.mark.parametrize(
+    ("pattern", "value", "expected"),
+    [
+        ("stripe.*", "stripe.refund", True),
+        ("stripe.*", "stripe.refund.partial", False),
+        ("stripe.*", "stripe", False),
+        ("stripe.**", "stripe.refund", True),
+        ("stripe.**", "stripe.refund.partial", True),
+        ("stripe.**", "stripe", False),
+        ("stripe.**", "stripes.refund", False),
+        ("*", "refund", True),
+        ("*", "stripe.refund", False),
+        ("**", "refund", True),
+        ("**", "stripe.refund.partial", True),
+        ("stripe.refund", "stripe.refund", True),
+        ("stripe.refund", "stripe.refunded", False),
+    ],
+)
+def test_T72_action_patterns(pattern, value, expected):
+    assert matches(pattern, value, separator=".") is expected
+
+
+@pytest.mark.parametrize(
+    ("pattern", "value", "expected"),
+    [
+        ("payment:EU-*", "payment:EU-42", True),
+        ("payment:EU-*", "payment:EU-42:leg2", False),
+        ("payment:EU-*", "payment:US-42", False),
+        ("payment:*", "payment:EU-42", True),
+        ("payment:**", "payment:EU-42:leg2", True),
+        ("**", "payment:EU-42", True),
+    ],
+)
+def test_T72_resource_patterns(pattern, value, expected):
+    assert matches(pattern, value, separator=":") is expected
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        "stripe.?efund",
+        "stripe.[abc]",
+        "stripe.*refund",
+        "stri*pe.refund",
+        "a**",
+        "**a",
+        "**.refund",
+        "stripe.a*.**",
+        "*.**",
+        "",
+        "stripe.",
+        ".refund",
+        "stripe..refund",
+        "**.**",
+    ],
+)
+def test_T72_a_pattern_outside_the_grammar_is_a_load_error(pattern):
+    bad = f"""
+authority:
+  grants:
+    - id: g
+      subject: {{ agent: "a" }}
+      actions: ["{pattern}"]
+"""
+    with pytest.raises(PolicyError):
+        Authority.from_yaml(_document(bad))
+
+
+def test_T72_a_deep_wildcard_in_a_subject_is_a_load_error():
+    """§4.2 — a subject has no separator, so `**` means nothing there that `*` does not, and
+    leaving it legal would give "any agent" a spelling a review grep for `"*"` misses."""
+    with pytest.raises(PolicyError, match=r"\*\*"):
+        Authority.from_yaml(_document(_subject_grant('{ agent: "**" }')))
+
+
+# --- T72b: pattern containment, in both directions (§5.5) ------------------------------
+
+
+@pytest.mark.parametrize(
+    "pattern", ["stripe.refund", "stripe.*", "stripe.**", "**", "*", "stripe.refund.partial"]
+)
+def test_T72b_every_well_formed_pattern_contains_itself(pattern):
+    """Load-bearing rather than pedantic: T76's whole construction — vary one dimension, hold
+    the rest identical — silently depends on it."""
+    assert contains(pattern, pattern, separator=".") is True
+
+
+@pytest.mark.parametrize(
+    ("parent", "child", "expected"),
+    [
+        ("stripe.*", "stripe.refund", True),
+        ("stripe.*", "stripe.ref*", True),
+        ("stripe.ref*", "stripe.*", False),
+        ("stripe.ref*", "stripe.refund", True),
+        ("stripe.**", "stripe.*", True),
+        ("stripe.**", "stripe.refund", True),
+        ("**", "stripe.**", True),
+        ("**", "stripe.refund.partial", True),
+        ("stripe.refund", "stripe.*", False),
+        ("stripe.*", "stripe.refund.partial", False),
+        ("stripe.**", "stripe", False),
+        ("stripe.*", "stripe.**", False),
+        ("stripe.refund", "stripe.refunded", False),
+    ],
+)
+def test_T72b_action_containment(parent, child, expected):
+    assert contains(parent, child, separator=".") is expected
+
+
+@pytest.mark.parametrize(
+    ("parent", "child", "expected"),
+    [
+        ("payment:EU-*", "payment:EU-42", True),
+        ("payment:*", "payment:EU-*", True),
+        ("payment:EU-4*", "payment:EU-*", False),
+        ("payment:EU-42", "payment:EU-*", False),
+        ("payment:*", "payment:EU-42:leg2", False),
+    ],
+)
+def test_T72b_resource_containment(parent, child, expected):
+    assert contains(parent, child, separator=":") is expected
+
+
+def test_T72b_containment_is_not_matching():
+    """The two relations are different functions, and an implementation of containment as
+    `fnmatch` or `startswith` passes an evaluation test while breaking attenuation."""
+    assert matches("stripe.**", "stripe.refund", separator=".") is True
+    assert contains("stripe.refund", "stripe.**", separator=".") is False
+    assert matches("stripe.*", "stripe.refund", separator=".") is True
+    assert contains("stripe.refund", "stripe.*", separator=".") is False
+
+
+# --- T73: a malformed authority section fails at load (§4.1, §4.2) ---------------------
+
+_MALFORMED = {
+    "no-grants": "authority:\n  max_delegation_depth: 3\n",
+    "grants-not-a-list": 'authority:\n  grants: { id: "g" }\n',
+    "grants-null": "authority:\n  grants:\n",
+    "no-subject": 'authority:\n  grants:\n    - id: g\n      actions: ["**"]\n',
+    "empty-subject": (
+        'authority:\n  grants:\n    - id: g\n      subject: {}\n      actions: ["**"]\n'
+    ),
+    "no-actions": 'authority:\n  grants:\n    - id: g\n      subject: { agent: "a" }\n',
+    "empty-actions": (
+        'authority:\n  grants:\n    - id: g\n      subject: { agent: "a" }\n      actions: []\n'
+    ),
+    "unknown-top-key": (
+        'authority:\n  depth: 3\n  grants:\n    - id: g\n      subject: { agent: "a" }\n'
+        '      actions: ["**"]\n'
+    ),
+    "unknown-grant-key": (
+        'authority:\n  grants:\n    - id: g\n      subject: { agent: "a" }\n'
+        '      actions: ["**"]\n      action: ["**"]\n'
+    ),
+    "unknown-subject-key": (
+        'authority:\n  grants:\n    - id: g\n      subject: { agent: "a", group: "g" }\n'
+        '      actions: ["**"]\n'
+    ),
+    "duplicate-id": (
+        'authority:\n  grants:\n    - id: g\n      subject: { agent: "a" }\n      actions: ["**"]\n'
+        '    - id: g\n      subject: { agent: "b" }\n      actions: ["**"]\n'
+    ),
+    "dlg-prefixed-id": (
+        'authority:\n  grants:\n    - id: dlg_abc\n      subject: { agent: "a" }\n'
+        '      actions: ["**"]\n'
+    ),
+    "id-charset": (
+        'authority:\n  grants:\n    - id: "-leading"\n      subject: { agent: "a" }\n'
+        '      actions: ["**"]\n'
+    ),
+    "expiry-not-a-timestamp": (
+        'authority:\n  grants:\n    - id: g\n      subject: { agent: "a" }\n      actions: ["**"]\n'
+        "      expires_at: 12345\n"
+    ),
+    "naive-expiry": (
+        'authority:\n  grants:\n    - id: g\n      subject: { agent: "a" }\n      actions: ["**"]\n'
+        "      expires_at: 2026-12-31 23:59:59\n"
+    ),
+    "empty-constraints": (
+        'authority:\n  grants:\n    - id: g\n      subject: { agent: "a" }\n      actions: ["**"]\n'
+        "      constraints: {}\n"
+    ),
+    "null-constraints": (
+        'authority:\n  grants:\n    - id: g\n      subject: { agent: "a" }\n      actions: ["**"]\n'
+        "      constraints:\n"
+    ),
+    "reserved-constraint": (
+        'authority:\n  grants:\n    - id: g\n      subject: { agent: "a" }\n      actions: ["**"]\n'
+        "      constraints: { agent_eq: a }\n"
+    ),
+    "float-operand": (
+        'authority:\n  grants:\n    - id: g\n      subject: { agent: "a" }\n      actions: ["**"]\n'
+        "      constraints: { amount_lte: 20.0 }\n"
+    ),
+    "negative-depth": (
+        "authority:\n  max_delegation_depth: -1\n  grants:\n    - id: g\n"
+        '      subject: { agent: "a" }\n      actions: ["**"]\n'
+    ),
+    "empty-environments": (
+        'authority:\n  grants:\n    - id: g\n      subject: { agent: "a" }\n      actions: ["**"]\n'
+        "      environments: []\n"
+    ),
+    "empty-resources": (
+        'authority:\n  grants:\n    - id: g\n      subject: { agent: "a" }\n      actions: ["**"]\n'
+        "      resources: []\n"
+    ),
+    "delegable-without-expiry": (
+        'authority:\n  grants:\n    - id: g\n      subject: { agent: "a" }\n      actions: ["**"]\n'
+        "      delegable: true\n"
+    ),
+}
+
+
+@pytest.mark.parametrize("case", sorted(_MALFORMED), ids=sorted(_MALFORMED))
+def test_T73_a_malformed_authority_section_fails_at_load(tmp_path, case):
+    (tmp_path / "ctrlrun.yaml").write_text(_document(_MALFORMED[case]))
+    control = None
+
+    with pytest.raises(PolicyError):
+        control = Control.from_file(tmp_path / "ctrlrun.yaml")
+
+    # Asserted, not assumed: a `Control` that came into existence with a section nobody could
+    # parse is the fail-open §4.1 exists to refuse.
+    assert control is None
+
+
+def test_T73_authority_in_a_v1_document_names_the_schema():
+    v1 = "schema: ctrlrun.policy/v1\n" + GRANT + ACTIONS
+
+    with pytest.raises(PolicyError) as refused:
+        Policy.from_yaml(v1)
+    assert "ctrlrun.policy/v3" in str(refused.value)
+    assert "authority" in str(refused.value)
+
+    # And the authority loader refuses it on its own, because §8.3's `--authority` document is
+    # never read by the policy loader at all.
+    with pytest.raises(PolicyError) as also:
+        Authority.from_yaml(v1)
+    assert "ctrlrun.policy/v3" in str(also.value)
+
+
+def test_T73_a_standalone_document_refuses_actions_and_mode():
+    """§4.8, §8.3 — one constructor, two closed key sets, told which."""
+    combined = _document(GRANT)
+
+    Authority.from_yaml(combined, standalone=False)
+    with pytest.raises(PolicyError, match="actions"):
+        Authority.from_yaml(combined, standalone=True)
+    with pytest.raises(PolicyError, match="mode"):
+        Authority.from_yaml(V3 + GRANT + "mode: observe\n", standalone=True)
+    Authority.from_yaml(V3 + GRANT, standalone=True)
+
+
+def test_T73_a_document_with_no_authority_section_is_refused_by_the_loader():
+    """`from_yaml` is asked for a section; `Control.from_file` is what decides there is none
+    (§4.1). A loader that invented an empty `Authority` would deny every action in a v0.2
+    configuration."""
+    with pytest.raises(PolicyError, match="authority"):
+        Authority.from_yaml(_document())
+
+
+# --- T73b: the models refuse in Python what the loader refuses in YAML (§4.8) ----------
+
+
+def test_T73b_a_subject_addressed_to_every_principal_is_refused():
+    with pytest.raises(InvalidArgument):
+        Subject()
+    with pytest.raises(InvalidArgument):
+        Subject(agent=None, user=None)
+
+
+def test_T73b_a_subject_may_not_carry_a_deep_wildcard():
+    with pytest.raises(InvalidArgument):
+        Subject(agent="**")
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"actions": ("stripe.a*.**",)},
+        {"actions": ("**a",)},
+        {"actions": ()},
+        {"resources": ("payment:*:**",)},
+        {"resources": ()},
+        {"expires_at": datetime(2026, 12, 31, 23, 59, 59)},
+        {"constraints": {"amount_gte": Condition("amount_lte", "amount", "lte", 10)}},
+        {"delegable": True},
+        {"environments": ()},
+    ],
+    ids=[
+        "wildcard-before-deep",
+        "deep-inside-a-segment",
+        "no-actions",
+        "resource-wildcard-before-deep",
+        "no-resources",
+        "naive-expiry",
+        "constraint-key-disagrees",
+        "delegable-without-expiry",
+        "no-environments",
+    ],
+)
+def test_T73b_grant_refuses_what_the_loader_refuses(kwargs):
+    fields = {
+        "id": "g",
+        "subject": Subject(agent="a"),
+        "actions": ("stripe.refund",),
+    }
+    fields.update(kwargs)
+
+    with pytest.raises(InvalidArgument):
+        Grant(**fields)
+
+
+def test_T73b_a_well_formed_grant_is_accepted():
+    """The control for the parametrization above: every refusal is one dimension away from a
+    grant that constructs."""
+    grant = Grant(
+        id="g",
+        subject=Subject(agent="a"),
+        actions=("stripe.refund",),
+        resources=("payment:EU-*",),
+        constraints={"amount_lte": Condition("amount_lte", "amount", "lte", 10)},
+        environments=("production",),
+        expires_at=datetime(2026, 12, 31, tzinfo=UTC),
+        delegable=True,
+    )
+
+    assert grant.actions == ("stripe.refund",)
+    assert grant.delegable is True
+
+
+# --- T74: authority is evaluated before policy (§4.3) ----------------------------------
+
+
+def test_T74_a_denial_emits_authority_denied_and_never_policy_evaluated(store, clock):
+    control = _control(_document(GRANT), store, clock)
+    action = _action(principal=Principal(agent="other-agent"))
+
+    with pytest.raises(AuthorityDenied):
+        control.execute(action, _Executor(), "refund:EU-42")
+
+    assert _types(store, action.action_id) == [
+        str(EventType.ACTION_PROPOSED),
+        "AUTHORITY_DENIED",
+        str(EventType.ACTION_DENIED),
+    ]
+
+
+def test_T74_a_denial_leaves_no_pending_approval_request(store, clock):
+    """The load-bearing half of §4.3's ordering: policy reaching `approve` creates a request,
+    and an authority denial afterwards would leave a human staring at one that can never run."""
+    approves = "\nactions:\n  stripe.refund:\n    rules:\n      - decision: approve\n"
+    control = _control(_document(GRANT, approves), store, clock)
+    action = _action(principal=Principal(agent="other-agent"))
+
+    with pytest.raises(AuthorityDenied):
+        control.execute(action, _Executor(), None)
+
+    assert store.approvals_for(action.action_hash) == ()
+    assert str(EventType.APPROVAL_REQUESTED) not in _types(store)
+
+
+def test_T74_a_pass_emits_authority_resolved_before_policy_evaluated(store, clock):
+    control = _control(_document(GRANT), store, clock)
+    action = _action()
+
+    control.execute(action, _Executor(), None)
+
+    types = _types(store, action.action_id)
+    assert types[:3] == [
+        str(EventType.ACTION_PROPOSED),
+        "AUTHORITY_RESOLVED",
+        str(EventType.POLICY_EVALUATED),
+    ]
+
+
+def test_T74_an_expired_principal_refuses_before_authority(store, clock):
+    """§4.3.1's order, stated once so it can be tested: `principal_expired` → authority →
+    policy. An expired credential produces no `AUTHORITY_*` event at all."""
+    from ctrlrun import IdentityError
+
+    control = _control(_document(GRANT), store, clock)
+    expired = Principal(
+        agent="support-agent",
+        user="alice@example.com",
+        expires_at=datetime(2026, 9, 3, 9, 0, tzinfo=UTC),
+    )
+
+    with pytest.raises(IdentityError):
+        control.execute(_action(principal=expired), _Executor(), None)
+
+    assert AUTHORITY_EVENT_TYPES.isdisjoint(_types(store))
+
+
+# --- T74b: `claims`, `issuer` and `expires_at` are reserved in conditions (§4.5) -------
+
+
+@pytest.mark.parametrize("key", ["claims_eq", "issuer_eq", "expires_at_gt"])
+@pytest.mark.parametrize("schema", ["ctrlrun.policy/v1", "ctrlrun.policy/v3"])
+def test_T74b_a_reserved_name_in_a_policy_rule_is_a_load_error(key, schema):
+    operand = 1 if key.endswith("_gt") else "x"
+    document = (
+        f"schema: {schema}\nactions:\n  stripe.refund:\n    rules:\n"
+        f"      - when: {{ {key}: {operand} }}\n        decision: allow\n"
+    )
+
+    with pytest.raises(PolicyError) as refused:
+        Policy.from_yaml(document)
+
+    assert "rename" in str(refused.value)
+
+
+@pytest.mark.parametrize("key", ["claims_eq", "issuer_eq", "expires_at_gt"])
+def test_T74b_a_reserved_name_in_a_grant_constraint_is_a_load_error(key):
+    operand = 1 if key.endswith("_gt") else "x"
+    reserved = f"""
+authority:
+  grants:
+    - id: g
+      subject: {{ agent: "a" }}
+      actions: ["**"]
+      constraints: {{ {key}: {operand} }}
+"""
+
+    with pytest.raises(PolicyError) as refused:
+        Authority.from_yaml(_document(reserved))
+
+    assert "rename" in str(refused.value)
+
+
+# --- §5.6.1: authority across an action already under way ------------------------------
+# T80b asserts this table in full at build-list item 3, over a revoked chain. The half that
+# is reachable with root grants alone is asserted here, because it is reachable here: an
+# expired grant must not keep holding a reservation across a round trip.
+
+
+def test_an_expired_grant_refuses_a_lease_extension(store, clock):
+    from ctrlrun import Suspended
+
+    control = _control(_document(EXPIRING_GRANT), store, clock)
+    action = _action(principal=Principal(agent="support-agent"))
+
+    def suspends():
+        raise Suspended("round-1")
+
+    clock.now = datetime(2026, 9, 3, 10, 12, 1, tzinfo=UTC)
+    with pytest.raises(AuthorityDenied) as refused:
+        # The grant is live when the action is decided and expired when the executor asks to
+        # hold the reservation open, which is the window §5.6.1 exists for.
+        control.execute(action, _expire_then(clock, suspends), "refund:EU-42")
+
+    assert refused.value.reason == AUTHORITY_EXPIRED
+    # The record is deliberately not moved: the lapsing lease does that (v0.1 §5.3 E3).
+    assert str(store.get_effect("refund:EU-42").state) == "executing"
+
+
+def _expire_then(clock, executor):
+    def run():
+        clock.advance(timedelta(seconds=1))
+        return executor()
+
+    return run
+
+
+def test_a_live_grant_still_holds_the_reservation(store, clock):
+    """The control: without it an implementation that refused every suspension would pass."""
+    from ctrlrun import Suspended
+
+    control = _control(_document(EXPIRING_GRANT), store, clock)
+
+    def suspends():
+        raise Suspended("round-1")
+
+    with pytest.raises(Suspended):
+        control.execute(
+            _action(principal=Principal(agent="support-agent")), suspends, "refund:EU-42"
+        )
+
+    assert store.continuation_rounds("refund:EU-42") == 1
+
+
+# --- §3.2: once an `authority:` section is loaded, a decline is not backfilled ----------
+
+
+def test_a_declining_provider_is_not_backfilled_under_authority(store, clock):
+    """§3.2's last row, which lands with the code it needs. Agent code already running inside
+    `with context("support-agent")` that installs a provider would otherwise execute every
+    un-credentialed call as support-agent, with support-agent's grants — omitting a credential
+    reaching the same destination as forging one, by an easier route."""
+
+    class Declines:
+        def resolve(self, identity_context):
+            return None
+
+    from ctrlrun import context, protect
+
+    control = _control(_document(GRANT), store, clock)
+    control_with_provider = Control(
+        control.policy,
+        store,
+        authority=control.authority,
+        clock=clock,
+        identity=Declines(),
+    )
+
+    @protect(name="stripe.refund", control=control_with_provider)
+    def refund(amount: int, payment_id: str) -> str:
+        raise AssertionError("the executor must not run")
+
+    with context("support-agent", "alice@example.com"), pytest.raises(ActionDenied) as refused:
+        refund(amount=1000, payment_id="EU-42")
+
+    assert refused.value.reason == "no_principal"
+
+
+def test_a_declining_provider_is_still_backfilled_without_authority(store, clock):
+    """The control, and the compatibility half of §3.2: with no `authority:` section the v0.2
+    decline row is unchanged, so installing a provider never breaks code that uses
+    `context()`."""
+
+    class Declines:
+        def resolve(self, identity_context):
+            return None
+
+    from ctrlrun import context, protect
+
+    control = Control(Policy.from_yaml(_document()), store, clock=clock, identity=Declines())
+    calls = []
+
+    @protect(name="stripe.refund", control=control)
+    def refund(amount: int, payment_id: str) -> str:
+        calls.append(amount)
+        return "ok"
+
+    with context("support-agent", "alice@example.com"):
+        refund(amount=1000, payment_id="EU-42")
+
+    assert calls == [1000]
+
+
+def test_the_resumed_leg_records_the_authority_axis(store, clock):
+    """§5.6.1 — evaluated and recorded, not re-decided. This is the *only* receipt an MCP
+    multi round-trip or ACS action ever gets (§8.3), so a receipt reporting a bare policy
+    reason with no authority axis would be the whole evidence for that action. Refusing here
+    is the wrong answer for the same reason v0.2 §6.9.2 gave for policy: the reservation is
+    held and the remote may already be acting on it."""
+    from ctrlrun import Suspended
+
+    control = _control(_document(EXPIRING_GRANT), store, clock)
+    action = _action(principal=Principal(agent="support-agent"))
+
+    def suspends():
+        raise Suspended("round-1")
+
+    with pytest.raises(Suspended):
+        control.execute(action, suspends, "refund:EU-42")
+
+    # The grant expires while the client is answering.
+    clock.advance(timedelta(seconds=1))
+    receipt = control.resume("round-1", lambda: "ok")
+
+    assert str(receipt.result) == "committed"
+    assert receipt.decision is Decision.DENY
+    assert receipt.decision_reason == AUTHORITY_EXPIRED
+    assert "AUTHORITY_DENIED" in _types(store)
+
+
+def test_the_resumed_leg_records_a_pass_too(store, clock):
+    """The control: without it an implementation that appended `AUTHORITY_DENIED` on every
+    resumption would satisfy the assertion above."""
+    from ctrlrun import Suspended
+
+    control = _control(_document(EXPIRING_GRANT), store, clock)
+
+    def suspends():
+        raise Suspended("round-1")
+
+    with pytest.raises(Suspended):
+        control.execute(
+            _action(principal=Principal(agent="support-agent")), suspends, "refund:EU-42"
+        )
+    receipt = control.resume("round-1", lambda: "ok")
+
+    assert str(receipt.result) == "committed"
+    assert receipt.decision is Decision.ALLOW
+    assert _types(store).count("AUTHORITY_RESOLVED") == 2
+    assert "AUTHORITY_DENIED" not in _types(store)

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -805,3 +805,73 @@ def test_a_remote_bind_is_permitted_only_when_it_is_meant():
     )
 
     assert config.host == "0.0.0.0"
+
+
+# --- SPEC-v0.3 §4: authority reaches the gateway's execution path ------------------------
+
+AUTHORITY_ONLY = """
+schema: ctrlrun.policy/v3
+authority:
+  grants:
+    - id: refunds-only
+      subject: { agent: "refund-agent" }
+      actions: ["mcp.acme.create_refund"]
+      resources: ["payment:*"]
+      constraints: { amount_lte: 20000 }
+"""
+
+
+@pytest.fixture
+def authority_gateway(upstream, store):
+    from ctrlrun import Authority
+
+    policy = Policy.from_yaml(POLICY.replace("ctrlrun.policy/v2", "ctrlrun.policy/v3"))
+    control = Control(policy, store, authority=Authority.from_yaml(AUTHORITY_ONLY, standalone=True))
+    config = GatewayConfig(upstream=upstream.url, alias="acme", principal_header="X-Agent", port=0)
+    forwarder = httpx_forwarder(config)
+    yield Gateway(config, control, forwarder)
+    forwarder.close()
+
+
+@pytest.fixture
+def authority_client(authority_gateway):
+    server = build_server(authority_gateway)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = server.server_address[1]
+    with httpx.Client(base_url=f"http://127.0.0.1:{port}", timeout=10) as opened:
+        yield opened
+    server.shutdown()
+    server.server_close()
+
+
+@pytest.mark.authority
+def test_a_call_outside_the_grant_never_reaches_the_upstream(authority_client, upstream, store):
+    """§4.3 at the gateway. The `-41012` code and the `--authority` flag are build-list item
+    5 (§8.3); what item 2 owns is that a gateway whose Control holds an `Authority` refuses
+    before dispatch and writes the evidence, rather than forwarding and finding out later."""
+    response = _post(
+        authority_client,
+        _call(arguments={"amount": 50000, "payment_id": "pi_1"}),
+        headers={"X-Agent": "refund-agent"},
+    )
+
+    assert upstream.calls == []
+    assert response.json()["error"]["data"]["reason"] == "authority_constraint"
+    assert [str(event.type) for event in store.events()][1] == "AUTHORITY_DENIED"
+    assert store.receipts()[-1].decision_reason == "authority_constraint"
+
+
+@pytest.mark.authority
+def test_a_call_inside_the_grant_is_forwarded(authority_client, upstream):
+    """The control for the refusal: without it a gateway that refused everything would pass."""
+    upstream.respond({"resultType": "complete", "content": []})
+
+    response = _post(
+        authority_client,
+        _call(arguments={"amount": 1000, "payment_id": "pi_2"}),
+        headers={"X-Agent": "refund-agent"},
+    )
+
+    assert len(upstream.calls) == 1
+    assert "error" not in response.json()


### PR DESCRIPTION
SPEC-v0.3 §4, build-list item 2. Tests come from §10: **T66–T74b**.

## What this adds

A second axis. Policy answers *how much autonomy does this action have* and has never been able
to see who is asking (`v0.1 §3.2` refuses `agent_eq` at load, and still does). Authority answers
*may this principal propose it at all*.

- **Opt-in, then fail-closed.** No `authority:` key → v0.2 behaviour, exactly. One `authority:`
  key → every principal needs a grant, including for actions the policy allows outright,
  including reads, including actions with no effect key. There is no `default: allow` and no
  flag that makes a missing grant permissive.
- **Authority runs before policy, and the two combine as the stricter of the pair.** A denial
  appends `AUTHORITY_DENIED` and **never** `POLICY_EVALUATED`, so it cannot leave a pending
  approval request behind for an action that could never run. Neither axis loosens the other.
- **A grant carries no `decision:`.** How much autonomy an action has stays the same for every
  principal; what differs is whether they may propose it at all. So T70 is a 2×3 whose bottom
  row collapses to one case, not the 3×3 the build brief asked for — the reasoning is §4.2.
- **A pattern grammar smaller than `fnmatch`**, because containment (§5.5) — the relation item
  3's attenuation rests on — has to be decidable rather than approximated. A literal, a
  `prefix*` that cannot cross a separator, and a final `**` whose preceding segments are all
  literals. Granting the whole surface of a system is spelled `**`: one token, greppable, and
  impossible to write by accident.

## Public API (SPEC-v0.3 §11)

`Authority`, `Grant`, `Subject`, `AuthorityResult`, `AuthorityDenied`, `AuthorityEscalation`,
`Control(authority=...)`, `Control.authority`; `policy._Condition` is promoted to
`policy.Condition` and `policy.parse_conditions` is public, because a grant's `constraints:` is
in exactly a rule's `when:` syntax and **must** be parsed by the same code — a second condition
evaluator would be a second place for `True` to start comparing equal to `1`.

`AuthorityEscalation` is defined and exported but not yet raised: it is item 3's creation-time
vocabulary, and defining it here avoids a second edit to a frozen surface.

## Breaking

- **`claims`, `issuer` and `expires_at` join `RESERVED_ARGUMENTS`**, in a document of *every*
  schema version (§4.5, §12.1). The reservation lives in the condition-key splitter, which runs
  for every condition in every document; gating it on `v3` would leave the same name meaning two
  things in two files. A `v1` policy whose protected function takes an argument called `claims`
  stops loading until it is renamed, and the load error says so.
- **`AcsControlHook` refuses a `Control` that holds an `Authority`** (§8.4). It reads
  `params.metadata.agent_id` straight off the inbound envelope, and an authorization decision
  may not be made against a principal the caller asserted — the same sentence that removed
  `--principal-from-client-info` in item 1. §8.4 requires the hook to take an
  `identity: IdentityProvider` of its own, which is item 5; until then it has none, so the
  refusal is unconditional rather than §8.4's `authority and no identity` form. `T91d` asserts
  the item-5 shape.

## Beyond the brief's test list, and why

- **§3.2's last row lands here**, because it is the row that needs `Authority` to exist: once a
  section is loaded, a provider returning `None` is refused rather than backfilled from
  `context()`. Otherwise agent code already inside `with context("finance-agent")` executes every
  un-credentialed call as finance-agent, with finance-agent's grants.
- **`Control.resume` records the authority axis** (§5.6.1) — evaluated and recorded, not
  re-decided. It writes the only receipt a multi-round-trip or ACS action ever gets (§8.3), so a
  bare policy reason there would be the whole evidence for that action.
- **A lease extension the grant no longer covers is refused**, so the lease lapses and the record
  becomes `AMBIGUOUS` by the ordinary path. `T80b` asserts this table in full at item 3 over a
  revoked chain; the half reachable with root grants alone is asserted here because it is
  reachable here.
- **The gateway's authority path**, two tests: a call outside the grant never reaches the
  upstream and writes the evidence. The `-41012` code and `--authority` are item 5.

## Not in this PR, deliberately

- **T71b's `authority_revoked` row.** Revocation needs a delegation record, which is item 3. What
  is asserted here is the half that decides the argument — expiry outranks a failed constraint,
  within one grant and across grants, and neither turns on document order. The precedence list
  itself is complete.
- **The three `DELEGATION_*` event types** are in the enum and nothing emits them; the vocabulary
  is closed here so a reader of an evidence file has one list to check against.
- **`Event.action_id: str | None`** and `mode:` stay with items 3 and 4.
- **The gateway's and `Control.resume`'s `Policy.evaluate` pre-checks**: §8.3 assigns those three
  call sites to item 5 by name. `Control.resume` is done here because §5.6.1 required it; the
  gateway's is read-only and behaviourally identical under item 2 (authority denies before any
  approval is consumed), so it waits for the item where `-41012` gives it something to say.

## Mutation table

44 rows against §4's MUSTs, `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` cleared before each
run, unique anchors verified. **44/44 caught.** Seven were green on the first run and every one
was a real gap rather than a passing check:

| Row | First run | Why, and what changed |
|---|---|---|
| authority before policy | green | The mutation moved a *pure* `Policy.evaluate` call — an equivalent mutant. Re-anchored on the block that has observable order: the `POLICY_EVALUATED` append, and separately the approval gate |
| resources are matched | green | The test's read action was being denied by the *action* pattern, not the resource one — a subsumed guard in the test rather than the code. New `T67d` varies one dimension at a time |
| a `None` resource does not match | green | Same cause, same fix |
| the action name is matched | green | Same cause, same fix |
| prefix-wildcard containment | green | The containment parametrization had no prefix ⊆ prefix row at all. Added, both directions |
| a naive `expires_at` at load | green | **A subsumed guard**: `Grant.__post_init__` refuses it too, with the same observable result. Deleted rather than kept; the loader's `isinstance` check, which is *not* subsumed, stays and has its own row |
| `Control.resume` records authority | green | Nothing resumed under an authority section. Two tests added — a denial recorded on the receipt without re-deciding, and its control |

## Checks

`ruff format --check`, `ruff check`, `mypy --strict src`, 1539 tests. `import ctrlrun` still
imports no module from an extra; `ctrlrun demo` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
