### PR TITLE
docs: give adapters their own version line, and name the frameworks

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@ Standards rule: integrate first, map second, never claim compliance. A standard 
 
 Sector rule: every pack cites its sources and ships its `REVIEW.md`. No compliance claims.
 
-Track rule: kernel versions ship correctness; content tracks (packs, templates, mappings) ship on their own cadence and never block or share a version with the kernel.
+Track rule: kernel versions ship correctness; the tracks that ship beside it (packs, templates, mappings, adapters) ship on their own cadence and never block or share a version with the kernel.
 
 ## v0.1 — Kernel (current)
 
@@ -62,12 +62,25 @@ Standards: align principal/delegation semantics with NIST agent identity work an
 
 Standards: first mapping doc — each `ctrlrun verify` guarantee mapped to the OWASP Agentic Top 10 entries it mitigates. Entries not covered are listed as not covered.
 
-## v0.5 — Framework ecosystem
+## v0.5 — Adapter contract
 
-- Thin adapters: OpenAI Agents SDK, LangGraph. Reuse each framework's own HITL/approval primitives where they exist; never reimplement them.
-- Adapter contract documented so the community writes the rest (CrewAI, ADK, PydanticAI, TypeScript).
+- The adapter contract, documented. It is one of the six contracts v1.0 freezes, so it is written to be lived with.
+- Two reference adapters, to prove the contract is real rather than aspirational: OpenAI Agents SDK and LangGraph. Each reuses the framework's own HITL primitives — LangGraph's `interrupt()` and checkpointers, the Agents SDK's tool-approval interruption — mapped onto `Suspended` / `Control.resume`, which v0.2 already ships for exactly this shape. Never a second approval path beside the framework's own.
+- An adapter is an entry point, so each one is a `SPEC` §4.3.1 row before it is code: principal validity and expiry, then authority, then policy.
+
+Exit: both reference adapters pass the v0.1 and v0.3 acceptance suites through the adapter surface; and a third adapter is written against the contract alone, in a session that may not read the kernel, because a contract that only its author can implement is not a contract.
 
 Standards: none new.
+
+## Adapters — their own version line
+
+Versioned as `adapters-<framework>-MAJOR.MINOR` — `adapters-crewai-1.0`, `adapters-google-adk-1.0` — and never as a kernel version. An adapter answers to two upstreams and neither is this roadmap: it breaks when its framework makes a breaking release, on that project's schedule, for reasons that have nothing to do with what the kernel is doing. Each adapter's README states a supported kernel range and a supported framework range, and its major version tracks whichever of the two forced the break. Each is reviewed in a session that did not write it, on the rule that covers every adapter already.
+
+**The frameworks.** Every adapter is Python and in-process. Google ADK · Microsoft Agent Framework (Python) · Claude Agent SDK (Python) · PydanticAI · CrewAI · Strands Agents · LlamaIndex. Each reuses its framework's own approval and interrupt primitives where they exist and reimplements none of them, ships when its own review is clean, and gates no kernel release. The order they arrive in is demand, not this list.
+
+**Everything else.** The contract, so the community writes the rest.
+
+Standards: none of its own.
 
 ## v0.6 — Durable runtime
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -65,18 +65,21 @@ Standards: first mapping doc — each `ctrlrun verify` guarantee mapped to the O
 ## v0.5 — Adapter contract
 
 - The adapter contract, documented. It is one of the six contracts v1.0 freezes, so it is written to be lived with.
-- Two reference adapters, to prove the contract is real rather than aspirational: OpenAI Agents SDK and LangGraph. Each reuses the framework's own HITL primitives — LangGraph's `interrupt()` and checkpointers, the Agents SDK's tool-approval interruption — mapped onto `Suspended` / `Control.resume`, which v0.2 already ships for exactly this shape. Never a second approval path beside the framework's own.
+- Two reference adapters, to prove the contract is real rather than aspirational: OpenAI Agents SDK and LangGraph. Each reuses the framework's own HITL primitives — LangGraph's `interrupt()` and checkpointers, the Agents SDK's tool-approval interruption — mapped onto `Suspended` / `Control.resume`, which v0.2 already ships for exactly this shape. Never a second approval path beside the framework's own. They ship on the adapters track under their own versions like every other adapter; what v0.5 owns is the requirement that two exist and that the contract survived writing them.
+- LangGraph and not LangChain, deliberately. LangGraph owns the primitive the adapter reuses, and LangChain's agent path runs on LangGraph, so one adapter covers both. A separate LangChain adapter would buy only the legacy `AgentExecutor` path.
 - An adapter is an entry point, so each one is a `SPEC` §4.3.1 row before it is code: principal validity and expiry, then authority, then policy.
 
-Exit: both reference adapters pass the v0.1 and v0.3 acceptance suites through the adapter surface; and a third adapter is written against the contract alone, in a session that may not read the kernel, because a contract that only its author can implement is not a contract.
+Exit: two adapters pass the v0.1 and v0.3 acceptance suites through the adapter surface; and a third is written against the contract alone, in a session that may not read the kernel, because a contract that only its author can implement is not a contract.
 
 Standards: none new.
 
 ## Adapters — their own version line
 
+**Three ways in, and only one of them is an adapter.** `@protect` covers anything running in this process, today, with no adapter and no framework support: a raw OpenAI call or a LangChain tool is a decorated function. The gateway covers anything reaching its tools over MCP, in any language, also with no adapter. An adapter exists for one reason — to route an APPROVE through a framework's own interrupt instead of raising past it — so a framework with no human-in-the-loop primitive of its own has nothing for an adapter to reuse and does not need one. That is the answer to "what about X" for every X, and it is why this list is short rather than growing by one each time a framework is named.
+
 Versioned as `adapters-<framework>-MAJOR.MINOR` — `adapters-crewai-1.0`, `adapters-google-adk-1.0` — and never as a kernel version. An adapter answers to two upstreams and neither is this roadmap: it breaks when its framework makes a breaking release, on that project's schedule, for reasons that have nothing to do with what the kernel is doing. Each adapter's README states a supported kernel range and a supported framework range, and its major version tracks whichever of the two forced the break. Each is reviewed in a session that did not write it, on the rule that covers every adapter already.
 
-**The frameworks.** Every adapter is Python and in-process. Google ADK · Microsoft Agent Framework (Python) · Claude Agent SDK (Python) · PydanticAI · CrewAI · Strands Agents · LlamaIndex. Each reuses its framework's own approval and interrupt primitives where they exist and reimplements none of them, ships when its own review is clean, and gates no kernel release. The order they arrive in is demand, not this list.
+**The frameworks.** Every adapter is Python and in-process. OpenAI Agents SDK · LangGraph · Google ADK · Microsoft Agent Framework (Python) · Claude Agent SDK (Python) · PydanticAI · CrewAI · Strands Agents · LlamaIndex. The first two are v0.5's references and arrive with the contract; they are on this track and not in that milestone's version, because an OpenAI or LangGraph breaking release is no more a kernel event than a CrewAI one. Each reuses its framework's own approval and interrupt primitives where they exist and reimplements none of them, ships when its own review is clean, and gates no kernel release. The order they arrive in is demand, not this list.
 
 **Everything else.** The contract, so the community writes the rest.
 

--- a/docs/SPEC-v0.2.md
+++ b/docs/SPEC-v0.2.md
@@ -51,7 +51,8 @@ Both use **v0.1 primitives only**, which is what lets them land before §3 chang
 schema. A template MUST therefore declare `schema: ctrlrun.policy/v1` and MUST NOT use
 `effect:`, `resource:` or `mcp:`. Templates are starting points; `ROADMAP.md`'s sector rule
 holds, so no template describes itself as compliant with anything, and the depth-first sector
-packs with their `REVIEW.md` files remain a v0.6 item.
+packs with their `REVIEW.md` files ship on their own track, after v0.6 supplies the primitives
+they configure and never as part of a kernel release.
 
 Running every example, and loading every template, is T31.
 


### PR DESCRIPTION
Follows the packs split merged in #23, applying the same rule to adapters.

## What changes

**v0.5 becomes "Adapter contract."** It ships the contract plus two reference adapters that prove it — OpenAI Agents SDK and LangGraph — each reusing its framework's own HITL primitive (`interrupt()` and checkpointers; the Agents SDK's tool-approval interruption) mapped onto `Suspended` / `Control.resume`, never a second approval path beside the framework's own. It gains an exit criterion it lacked: a third adapter written against the contract alone, by a session that may not read the kernel. A contract only its author can implement is not a contract.

**Adapters get their own version line.** `adapters-<framework>-MAJOR.MINOR`, with a supported kernel range *and* a supported framework range in each README, the major tracking whichever upstream forced the break.

The frameworks are named rather than left to "the community writes the rest": Google ADK, Microsoft Agent Framework, PydanticAI, CrewAI, Strands Agents, LlamaIndex, and the agent SDK in the roadmap's list.

## Why not v0.5.1 … v0.5.8

An adapter answers to two upstreams, and the one that breaks it is almost always the framework, on that project's schedule — LangGraph making a breaking release is not an event the kernel's version number can describe. Sub-versions would also move the version of `ctrlrun` on PyPI for adapters most installs do not use, and would park v0.6 durability behind eight SDKs.

## Scope note

Every adapter is Python and in-process. TypeScript and .NET frameworks are not listed: an in-process adapter against a Python kernel is not available to them, and listing them would have meant claiming support that resolves to "their tools happen to be reachable over MCP" — which the gateway already covers for any language, with no adapter at all.

## Known, not fixed here

`docs/SPEC-v0.2.md:54` still says the depth-first sector packs "remain a v0.6 item", which #23 made untrue. Left for the item that next opens that spec.