### PR TITLE
item 3: delegation with attenuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,35 @@ shipped, and the only thing in the tree today is the contract.
 
 ### Added
 
+- **Delegation with attenuation** (build-list item 3, SPEC-v0.3 §5). A principal who holds a
+  `delegable` grant can create a narrower one at runtime — `Control.delegate`, `ctrlrun
+  delegate` — and revoke it — `Control.revoke`, `ctrlrun revoke`. A delegated grant is valid
+  only if it is provably a subset of its parent on every dimension, checked **at creation and
+  again at every evaluation**: a check performed only at creation would leave every delegation
+  exactly as wide as the file used to be, which is the shape of every stale-permission incident
+  there has ever been.
+- **Omission never means unlimited.** A child that drops a dimension its parent constrains is
+  rejected, not treated as inheriting the parent's limit and certainly not as unconstrained —
+  including a child subject that carries a wildcard, omits `agent`, or drops the parent's
+  `user`, each of which hands the grant to a wider population rather than a narrower one.
+- **Revocation is transitive by structure.** Nothing is rewritten and no children are visited:
+  a chain of any depth is cut by one write, because every evaluation walks to the root. Chain
+  depth is **recomputed, never read** from the stored column, the walk is bounded and refuses a
+  chain that revisits an id, and a stored delegation that cannot be read denies the action
+  outright rather than being skipped in favour of a broader grant that happens to match.
+- **A `delegations` table in both stores**, and `DelegationRecord` with it. A **new** table, so
+  `CREATE TABLE IF NOT EXISTS` adds it to a database that already exists and v0.3 still needs
+  no migration story; no existing table gains a column. `put_delegation` is an `INSERT` and
+  never an upsert — an upsert on an existing id would clear `revoked_at`, which is `unrevoke`
+  by another door in a release that says there is no such thing.
+- **Three delegation event types**, `DELEGATION_CREATED`, `DELEGATION_REVOKED` and
+  `DELEGATION_REJECTED`. They are about an authority record rather than an action, so
+  `Event.action_id` becomes `str | None` and they carry `null`; `OTelEventSink` emits a
+  standalone span for each rather than dropping them, because the highest-privilege operations
+  in the release must not be the only ones missing from the export path.
+- **An expired credential mints nothing.** `Control.delegate` refuses a `by` whose credential
+  has lapsed, before it looks at the parent at all — a delegation is the most durable thing a
+  principal can create, and it is the last place a stale credential should still work.
 - **The `authority:` section: grants, patterns and evaluation** (build-list item 2,
   SPEC-v0.3 §4). A second axis, and it is **opt-in and then fail-closed**: a document with no
   `authority:` key behaves exactly as v0.2, and the moment one exists every principal needs a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,7 +126,20 @@ approvals(
 );
 receipts(receipt_id TEXT PRIMARY KEY, action_id TEXT, effect_key TEXT, result TEXT, json TEXT, ts TEXT);
 events(event_id INTEGER PRIMARY KEY AUTOINCREMENT, ts TEXT, type TEXT, action_id TEXT, effect_key TEXT, approval_id TEXT, data_json TEXT);
+delegations(                      -- v0.3; a NEW table, so no migration story is needed
+  delegation_id TEXT PRIMARY KEY, -- "dlg_" + 32 hex
+  parent_id TEXT NOT NULL,        -- a root grant's id, or another delegation_id
+  depth INTEGER NOT NULL,         -- recorded, never trusted: evaluation walks to the root
+  grant_json TEXT NOT NULL,       -- the child grant; `state.py` stores the string, `authority.py` parses it
+  created_by_agent TEXT NOT NULL, created_by_user TEXT,
+  created_via TEXT NOT NULL,      -- api|cli: an act, or an assertion at a terminal
+  created_at TEXT NOT NULL, revoked_at TEXT, revoked_by TEXT
+);
 ```
+
+`delegations` holds rows, not grants. `grant_json` stays a string in `state.py` so the store does
+not import `authority.py` and transitively acquire `policy.py`, which is the edge §6 puts in
+`state.py`'s "must not know about" column.
 
 Pragmas: `journal_mode=WAL`, `busy_timeout=5000`, `synchronous=NORMAL`.
 

--- a/docs/SPEC-v0.3.md
+++ b/docs/SPEC-v0.3.md
@@ -1325,6 +1325,12 @@ Control.delegate(parent_id: str, grant: Grant, *, by: Principal) -> Delegation
 Control.revoke(delegation_id: str, *, by: str | None = None) -> None
 ```
 
+`AuthorityResult` carries four further optional fields, added by build-list item 3 and listed
+here rather than left to be inferred: `dimension`, `missing_parent_id`, `expired_parent_id`,
+`depth_exceeded` and `cycle_at`. They are §7's `AUTHORITY_DENIED` evidence, and they exist because
+§5.6's rules 1, 3, 4, 5 and 6 all report `authority_escalation` — without them five guards would
+be one guard as far as any reader or test could tell.
+
 `Subject.__post_init__` refuses both fields `None`, and **`Grant.__post_init__` validates
 everything the YAML loader validates** — every pattern against §4.4's grammar, every condition key
 and operand against §4.5, `expires_at` timezone-aware, and each `constraints` key equal to
@@ -1804,6 +1810,13 @@ rather than by being it. That is why the record carries `created_via` (§5.2): `
 for this command, where it came from a shell. A reader of the evidence can tell an act from an
 assertion, which is the whole reason the field exists.
 
+**How `created_via` reaches the record.** §11 freezes `Control.delegate(parent_id, grant, *, by)`
+with no `via` argument, and `ctrlrun delegate` needs to say `cli`. It therefore goes through a
+package-private `Control._delegate(..., via=...)` that the public method calls with `"api"`. This
+is recorded because the alternative — widening a frozen signature so the CLI can pass one value —
+would put a caller-supplied provenance field on the public API, and a `created_via` a caller
+chooses says nothing at all.
+
 CLI delegation is an operator act inside the trust boundary, exactly as `ctrlrun approve` is
 (`docs/THREAT_MODEL.md`: "A compromised approver … is out of scope"). §13 records that v0.3 does
 not authenticate the delegator any more than it authenticates the approver, and item 6 puts the
@@ -2084,7 +2097,7 @@ DELEGATION_REJECTED
 | Type | `data` |
 |---|---|
 | `AUTHORITY_RESOLVED` | `reason` (`authority_grant`), `grant_id`, and for a delegated grant `delegation_id` and `depth` |
-| `AUTHORITY_DENIED` | `reason` (§4.3); `grant_id` / `delegation_id` where one grant was implicated; `dimension` for a §5.6 rule-4 failure; `missing_parent_id` for rule 1; `depth_exceeded` or `cycle_at` for rule 5 |
+| `AUTHORITY_DENIED` | `reason` (§4.3); `grant_id` / `delegation_id` where one grant was implicated; `dimension` for a §5.6 rule-4 failure; `missing_parent_id` for rule 1; `expired_parent_id` for rule 3; `depth_exceeded` or `cycle_at` for rule 5 |
 | `DELEGATION_CREATED` | `delegation_id`, `parent_id`, `depth`, `created_by_agent`, `created_by_user`, `created_via` |
 | `DELEGATION_REVOKED` | `delegation_id`, `revoked_by` |
 | `DELEGATION_REJECTED` | `reason` and `parent_id`; `dimension` **only** for a §5.3 rule-6 containment refusal |
@@ -2097,6 +2110,14 @@ argument `v0.2 §2.5` makes for appending `RECONCILIATION_RESOLVED` on `"unknown
 `dimension` is present only where a §5.4 row failed. The other refusals of §5.3 — `unknown_parent`,
 `parent_not_delegable`, `parent_not_valid`, `not_the_subject`, `max_depth` — name no row, and
 inventing a dimension for them would make two distinguishable guards report the same shape.
+
+`expired_parent_id` was added by build-list item 3, and the amendment is recorded rather than
+silent. §5.6 rule 3 says its whole contribution is that "the denial names the ancestor that
+lapsed rather than the leaf that inherited its deadline"; §5.6's ordering paragraph then lists the
+`data` shapes as "`missing_parent_id`, `dimension`, or neither", which would leave rule 3 carrying
+nothing and therefore indistinguishable in evidence from rule 6. A guard no reader and no test can
+tell has run is the subsumed guard this document keeps refusing to ship, so the key exists and
+T77 asserts it. The ordering paragraph's list is illustrative; this table is the closed one.
 
 **`Event.action_id` becomes `str | None`.** The three delegation events are not about an action:
 they are about an authority record, created and revoked outside any action's life. They carry

--- a/docs/SPEC-v0.3.md
+++ b/docs/SPEC-v0.3.md
@@ -1241,6 +1241,19 @@ gateway's approval path (§8.3), and `ctrlrun.acs`'s hook. Reading `Policy.evalu
 a decision is a defect after v0.3, and the two places in shipped code that do it are named in
 §8.3 so item 5 cannot miss them.
 
+**What §4.6's blast radius costs, stated because item 3 made it real.** A single unreadable
+`delegations` row denies **every** action for **every** principal, root-grant holders included,
+and it is not recoverable from the CLI: `ctrlrun revoke` refuses the row for the same reason
+evaluation does, and revoking would not help anyway because evaluation enumerates revoked rows
+too (§5.6 rule 2 has to be able to report `authority_revoked`). The recovery is deleting the row
+with `sqlite3`, which §5.5 already concedes is how such a row arrives. This is the fail-closed
+direction and it is what the paragraph below asks for; it is recorded here so that an operator
+meets it in the specification rather than during an incident, and so that a future release
+proposing to relax it — skipping a row that is *both* revoked and unreadable, say, which can
+never contribute a pass — is amending a stated position rather than a silent one. The one thing
+item 3 does fix is the evidence: `AUTHORITY_DENIED.data.delegation_id` names the row, because
+§13 ships no way to list delegations and an operator who cannot name the row cannot delete it.
+
 **A record that cannot be read denies the action outright.** A stored delegation whose
 `grant_json` no longer parses (§5.2), or whose chain cannot be walked (§5.5), MUST NOT be skipped
 in favour of some other grant that happens to match — it is `authority_unreadable`, first in the
@@ -1787,6 +1800,16 @@ Revoking an already-revoked delegation is idempotent: it logs, appends no second
 `ctrlrun delegate` reads a one-grant YAML document with the keys of §4.2 minus `id` (§5.2),
 validates it, runs every check of §5.3, and prints the new `delegation_id`. Its refusals exit
 non-zero and name the rule that failed.
+
+**Rule 4 has no evaluation-time counterpart, and that is deliberate.** §5.6 re-checks
+containment, revocation, expiry, `delegable` and the walk on every evaluation, but not §5.3 rule
+4: nothing at evaluation asks whether whoever created a delegation held its parent. A writer to
+the `delegations` table can therefore mint a fully-contained delegation from any `delegable` root
+grant to an agent of its choosing without ever holding it. It cannot exceed the parent — every
+other rule still applies — so the escalation available is in *population*, not in powers, and
+`docs/THREAT_MODEL.md` puts store write access out of scope. It is stated because §5.6's list of
+six rules is where a reader looks for "you may only delegate authority you hold", and finding it
+absent should read as a decision rather than as an omission.
 
 **§5.3's order tells a caller which grants exist.** Rules 1 to 3 — `unknown_parent`,
 `parent_not_delegable`, `parent_not_valid` — run before rule 4's `not_the_subject`, so in-process

--- a/src/ctrlrun/__init__.py
+++ b/src/ctrlrun/__init__.py
@@ -11,7 +11,7 @@ from .approval import (
     LocalApprovalProvider,
     ScriptedApprovalProvider,
 )
-from .authority import Authority, AuthorityResult, Grant, Subject
+from .authority import Authority, AuthorityResult, Delegation, Grant, Subject
 from .control import Control, context, protect, with_approval
 from .effect import EffectRecord, EffectState, ReconcileOutcome
 from .errors import (
@@ -40,7 +40,7 @@ from .identity import (
 )
 from .policy import Condition, Decision, Policy, parse_conditions
 from .receipt import Event, EventSink, JSONLEventSink, Receipt
-from .state import InMemoryStateStore, SQLiteStateStore, StateStore
+from .state import DelegationRecord, InMemoryStateStore, SQLiteStateStore, StateStore
 from .webhook import WebhookApprovalProvider
 
 __all__ = [
@@ -61,6 +61,8 @@ __all__ = [
     "Condition",
     "Control",
     "Decision",
+    "Delegation",
+    "DelegationRecord",
     "DuplicateEffect",
     "EffectKeyError",
     "EffectRecord",

--- a/src/ctrlrun/authority.py
+++ b/src/ctrlrun/authority.py
@@ -539,14 +539,18 @@ def grant_from_json(text: str, *, delegation_id: str) -> Grant:
         return Grant(
             id=delegation_id,
             subject=Subject(agent=subject.get("agent"), user=subject.get("user")),
-            actions=tuple(document.get("actions") or ()),
-            resources=_optional_tuple(document.get("resources")),
+            # A list or nothing, never a coercion: `"actions": "stripe.refund"` would
+            # otherwise become thirteen single-character patterns, every one of them
+            # grammar-valid. §5.2 requires reading a grant back to validate exactly what
+            # loading one from YAML validates, and `_parse_patterns` refuses a non-list.
+            actions=_optional_tuple(document.get("actions"), delegation_id) or (),
+            resources=_optional_tuple(document.get("resources"), delegation_id),
             constraints=(
                 parse_conditions(constraints, where=f"delegation {delegation_id}")
                 if constraints
                 else NO_CONSTRAINTS
             ),
-            environments=_optional_tuple(document.get("environments")),
+            environments=_optional_tuple(document.get("environments"), delegation_id),
             expires_at=None if expires_at is None else datetime.fromisoformat(str(expires_at)),
             delegable=bool(document.get("delegable", False)),
         )
@@ -554,11 +558,14 @@ def grant_from_json(text: str, *, delegation_id: str) -> Grant:
         raise _UnreadableError(delegation_id, str(exc)) from exc
 
 
-def _optional_tuple(value: object) -> tuple[str, ...] | None:
+def _optional_tuple(value: object, delegation_id: str) -> tuple[str, ...] | None:
+    """A list of strings, or `None`. Takes the row's id because it raises past
+    `grant_from_json`'s `except` clause, and evidence that cannot name the corrupted row is
+    evidence an operator cannot act on — §13 ships no way to list delegations."""
     if value is None:
         return None
     if not isinstance(value, list):
-        raise _UnreadableError("<grant>", f"expected a list or null, got {_type_name(value)}")
+        raise _UnreadableError(delegation_id, f"expected a list or null, got {_type_name(value)}")
     return tuple(str(item) for item in value)
 
 
@@ -1093,10 +1100,16 @@ class Authority:
             return _ChainCheck(
                 depth, AuthorityResult(False, AUTHORITY_UNREADABLE, cycle_at=walk.cycle_at)
             )
-        if walk.depth_exceeded is not None:
+        if depth > self._max_delegation_depth:
+            # Compared here rather than inferred from `_walk` truncating. The walk returns as
+            # soon as it reaches a root grant, *before* it consults the bound, so a chain that
+            # completes in one step is never measured against anything — and
+            # `max_delegation_depth: 0`, which §5.5 offers as the legible way to switch
+            # delegation off, would leave every existing depth-1 delegation authorizing while
+            # appearing to work, because deeper chains truncate and deny. A guard that is a
+            # side effect of a bound is not a guard.
             return _ChainCheck(
-                depth,
-                AuthorityResult(False, AUTHORITY_ESCALATION, depth_exceeded=walk.depth_exceeded),
+                depth, AuthorityResult(False, AUTHORITY_ESCALATION, depth_exceeded=depth)
             )
         if any(not ancestor.delegable for ancestor in walk.ancestors):
             # Rule 6 exists because `delegable` is not a §5.4 row and rule 4 would therefore

--- a/src/ctrlrun/authority.py
+++ b/src/ctrlrun/authority.py
@@ -24,19 +24,23 @@ single.
 
 from __future__ import annotations
 
+import itertools
+import json
 import re
-from collections.abc import Iterable, Mapping
-from dataclasses import dataclass, field
+import secrets
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from types import MappingProxyType
-from typing import Any, Final
+from typing import Any, Final, Literal
 
 import yaml
 
 from .action import Action, Principal
-from .errors import InvalidArgument, PolicyError
+from .errors import AuthorityEscalation, IdentityError, InvalidArgument, PolicyError
 from .policy import SUPPORTED_SCHEMAS, Condition, parse_conditions, require_v3
-from .state import StateStore
+from .policy import _equal as _type_strict_equal
+from .state import DelegationRecord, StateStore
 
 #: SPEC-v0.3 §4.4 — an action name is dotted (`v0.1 §2.1`) and a resource is `type:id`.
 ACTION_SEPARATOR: Final = "."
@@ -78,6 +82,42 @@ _GRANT_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 #: §5.2 mints delegation ids in this namespace, and one namespace addresses both kinds.
 DELEGATION_ID_PREFIX: Final = "dlg_"
+
+#: §5.2 — enforced on the way *out* of the store as well as on the way in. A row that does not
+#: match is a corrupted record, never a grant: without this a hand-inserted row named
+#: `head-of-finance` could shadow the root grant of that name.
+_DELEGATION_ID = re.compile(r"^dlg_[0-9a-f]{32}$")
+_ID_HEX_BYTES: Final = 16  # "dlg_" + 32 hex chars
+
+#: §5.2, §5.7 — `api` for `Control.delegate`, where `by` came from wherever the application's
+#: identity came from, and `cli` for `ctrlrun delegate`, where it came from a shell. A reader of
+#: the evidence can tell an act from an assertion, which is the whole reason the field exists.
+_CREATED_VIA: Final[Mapping[str, Literal["api", "cli"]]] = {"api": "api", "cli": "cli"}
+
+#: SPEC-v0.3 §5.3 — the creation-time vocabulary. Disjoint from the evaluation reasons above,
+#: and never used interchangeably with them: a test asserting `authority_escalation` on a
+#: creation is asserting a value that creation never produces.
+UNKNOWN_PARENT: Final = "unknown_parent"
+PARENT_NOT_DELEGABLE: Final = "parent_not_delegable"
+PARENT_NOT_VALID: Final = "parent_not_valid"
+NOT_THE_SUBJECT: Final = "not_the_subject"
+MAX_DEPTH: Final = "max_depth"
+CONTAINMENT: Final = "containment"
+
+#: §5.4's rows, in the order they are checked. Each is separately testable and separately
+#: mutable; T76 breaks each one alone.
+DIMENSIONS: Final = ("subject", "actions", "resources", "constraints", "environments", "expires_at")
+
+#: §5.4 — how a child operand must compare with its parent's, per operator. `neq` is equality
+#: rather than the superset a deny-list would need: `v0.1 §3.2` has no deny-list operator and a
+#: `when:` mapping holds at most one `neq` per argument, so "the parent's exclusions plus more"
+#: is not expressible even in principle.
+_STRICTER: Final = {
+    "lt": lambda child, parent: child <= parent,
+    "lte": lambda child, parent: child <= parent,
+    "gt": lambda child, parent: child >= parent,
+    "gte": lambda child, parent: child >= parent,
+}
 
 _AUTHORITY_KEY: Final = "authority"
 _AUTHORITY_KEYS: Final = frozenset({"max_delegation_depth", "grants"})
@@ -369,14 +409,331 @@ class Grant:
 
 
 @dataclass(frozen=True)
+class Delegation:
+    """A grant created at runtime by a principal who already holds one (SPEC-v0.3 §5.1).
+
+    The parsed form of a `DelegationRecord`: `state.py` persists rows with `grant_json` as a
+    string, and this module is what parses a `Grant` out of one. `grant.id` **is** the
+    `delegation_id` — one namespace addresses root grants and delegations, and `--parent`
+    takes either (§5.2).
+    """
+
+    delegation_id: str
+    parent_id: str
+    depth: int
+    grant: Grant
+    created_by: Principal
+    created_via: Literal["api", "cli"]
+    created_at: datetime
+    revoked_at: datetime | None = None
+    revoked_by: str | None = None
+
+    @property
+    def is_revoked(self) -> bool:
+        return self.revoked_at is not None
+
+    def to_record(self) -> DelegationRecord:
+        """The row `StateStore.put_delegation` writes (§5.2)."""
+        return DelegationRecord(
+            delegation_id=self.delegation_id,
+            parent_id=self.parent_id,
+            depth=self.depth,
+            grant_json=grant_to_json(self.grant),
+            created_by_agent=self.created_by.agent,
+            created_by_user=self.created_by.user,
+            created_via=self.created_via,
+            created_at=self.created_at,
+            revoked_at=self.revoked_at,
+            revoked_by=self.revoked_by,
+        )
+
+
+@dataclass(frozen=True)
 class AuthorityResult:
-    """What the authority axis decided, and which grant it decided on (§4.8)."""
+    """What the authority axis decided, and which grant it decided on (§4.8).
+
+    The four trailing fields carry §7's `AUTHORITY_DENIED` evidence: the `dimension` a §5.6
+    rule-4 step failed on, the `missing_parent_id` of rule 1, the `expired_parent_id` of rule
+    3, and rule 5's `depth_exceeded` or `cycle_at`. They exist because rules 1, 3, 4, 5 and 6
+    all report `authority_escalation`, so without them five guards would be indistinguishable
+    in evidence and no test could tell which had run.
+    """
 
     passed: bool
     reason: str
     grant_id: str | None = None
     delegation_id: str | None = None
     depth: int = 0
+    dimension: str | None = None
+    missing_parent_id: str | None = None
+    expired_parent_id: str | None = None
+    depth_exceeded: int | None = None
+    cycle_at: str | None = None
+
+
+# --- serialization and containment (SPEC-v0.3 §5.2, §5.4, §5.5) -------------------------
+
+
+class _UnreadableError(Exception):
+    """A stored delegation that could not be read, parsed or addressed (§5.2).
+
+    Internal: `evaluate` turns it into `authority_unreadable`, which is first in §4.3's
+    precedence order and therefore denies the action outright. It is never skipped in favour
+    of another matching grant — that is how a principal holding both a broad root grant and a
+    narrow delegation ends up authorized by the broad one because the narrow one was
+    corrupted (§4.6).
+    """
+
+    def __init__(self, delegation_id: str, detail: str) -> None:
+        super().__init__(f"delegation {delegation_id!r} is unreadable: {detail}")
+        self.delegation_id = delegation_id
+
+
+def new_delegation_id() -> str:
+    """`"dlg_" + 32 hex`, the shape of `act_` and `ctr_` (SPEC-v0.3 §5.2)."""
+    return f"{DELEGATION_ID_PREFIX}{secrets.token_hex(_ID_HEX_BYTES)}"
+
+
+def grant_to_json(grant: Grant) -> str:
+    """A grant as the `grant_json` column of §5.2.
+
+    A **storage encoding**, deliberately not called canonical: nothing hashes it, and
+    `v0.1 §2.3`'s canonical form is a versioned security primitive that a change here must not
+    be read as touching. `expires_at` keeps the offset it was written with rather than being
+    normalized to UTC, so a grant round-trips to an equal `Grant`.
+    """
+    document = {
+        "subject": {"agent": grant.subject.agent, "user": grant.subject.user},
+        "actions": list(grant.actions),
+        "resources": None if grant.resources is None else list(grant.resources),
+        "constraints": {key: condition.operand for key, condition in grant.constraints.items()},
+        "environments": None if grant.environments is None else list(grant.environments),
+        "expires_at": None if grant.expires_at is None else grant.expires_at.isoformat(),
+        "delegable": grant.delegable,
+    }
+    return json.dumps(document, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def grant_from_json(text: str, *, delegation_id: str) -> Grant:
+    """Parse a stored grant, validating it exactly as the YAML loader would (§5.2).
+
+    A store is not more trusted than a file. A delegation whose stored form no longer parses
+    is a refusal naming it, never a grant with a field quietly defaulted.
+    """
+    try:
+        document = json.loads(text)
+    except ValueError as exc:
+        raise _UnreadableError(delegation_id, f"grant_json is not JSON: {exc}") from exc
+    if not isinstance(document, Mapping):
+        raise _UnreadableError(
+            delegation_id, f"grant_json is {_type_name(document)}, not an object"
+        )
+    subject = document.get("subject")
+    if not isinstance(subject, Mapping):
+        raise _UnreadableError(delegation_id, "grant_json has no 'subject' object")
+    expires_at = document.get("expires_at")
+    constraints = document.get("constraints")
+    if not isinstance(constraints, Mapping):
+        raise _UnreadableError(delegation_id, "grant_json has no 'constraints' object")
+    try:
+        return Grant(
+            id=delegation_id,
+            subject=Subject(agent=subject.get("agent"), user=subject.get("user")),
+            actions=tuple(document.get("actions") or ()),
+            resources=_optional_tuple(document.get("resources")),
+            constraints=(
+                parse_conditions(constraints, where=f"delegation {delegation_id}")
+                if constraints
+                else NO_CONSTRAINTS
+            ),
+            environments=_optional_tuple(document.get("environments")),
+            expires_at=None if expires_at is None else datetime.fromisoformat(str(expires_at)),
+            delegable=bool(document.get("delegable", False)),
+        )
+    except (InvalidArgument, PolicyError, TypeError, ValueError) as exc:
+        raise _UnreadableError(delegation_id, str(exc)) from exc
+
+
+def _optional_tuple(value: object) -> tuple[str, ...] | None:
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        raise _UnreadableError("<grant>", f"expected a list or null, got {_type_name(value)}")
+    return tuple(str(item) for item in value)
+
+
+def _delegation_from_record(record: DelegationRecord) -> Delegation:
+    """Parse a row into a `Delegation`, refusing an id outside the namespace (§5.2)."""
+    if not _DELEGATION_ID.match(record.delegation_id):
+        # Enforcing the namespace on the way in only would leave the other side open: a
+        # hand-inserted row named `head-of-finance` would otherwise shadow the root grant of
+        # that name, and quietly disconnect the one lever §5.6 offers against a compromised
+        # root grant.
+        raise _UnreadableError(record.delegation_id, f"an id must match {_DELEGATION_ID.pattern}")
+    via = _CREATED_VIA.get(record.created_via)
+    if via is None:
+        # §5.2 — the column tells an act from an assertion, so a value outside the two is a
+        # record whose provenance cannot be read.
+        raise _UnreadableError(record.delegation_id, f"unknown created_via {record.created_via!r}")
+    return Delegation(
+        delegation_id=record.delegation_id,
+        parent_id=record.parent_id,
+        depth=record.depth,
+        grant=grant_from_json(record.grant_json, delegation_id=record.delegation_id),
+        created_by=Principal(agent=record.created_by_agent, user=record.created_by_user),
+        created_via=via,
+        created_at=record.created_at,
+        revoked_at=record.revoked_at,
+        revoked_by=record.revoked_by,
+    )
+
+
+def contained_dimension(parent: Grant, child: Grant) -> str | None:
+    """The first §5.4 row `child` violates, or `None` where it is contained on every one.
+
+    Checked at creation *and* again at every evaluation (§5.6). **Omission is never
+    "unlimited"**: a child that drops a dimension its parent constrains is rejected, not
+    treated as inheriting the parent's limit and certainly not as unconstrained. Inheritance
+    would be worse than rejection, because a child that silently inherits looks, in the file
+    and in the receipt, like a child that was authorized for what it says.
+    """
+    if not _subject_contained(parent.subject, child.subject):
+        return "subject"
+    if not _patterns_contained(parent.actions, child.actions, separator=ACTION_SEPARATOR):
+        return "actions"
+    if parent.resources is not None and (
+        child.resources is None
+        or not _patterns_contained(parent.resources, child.resources, separator=RESOURCE_SEPARATOR)
+    ):
+        return "resources"
+    if not _constraints_contained(parent.constraints, child.constraints):
+        return "constraints"
+    if parent.environments is not None and (
+        child.environments is None or not set(child.environments) <= set(parent.environments)
+    ):
+        return "environments"
+    if parent.expires_at is not None and (
+        child.expires_at is None or child.expires_at > parent.expires_at
+    ):
+        return "expires_at"
+    return None
+
+
+def _subject_contained(parent: Subject, child: Subject) -> bool:
+    """§5.4's `subject` row: two things that look like naming the grantee are widening.
+
+    *Dropping the parent's `user`* turns authority to act **for alice** into authority for the
+    agent acting alone. *An unbounded grantee* — `agent: "*"`, or an omitted `agent`, which
+    §4.2 makes match any agent — hands the parent's authority to every agent in the
+    deployment, and with it the right to delegate onward. Which concrete agent the child names
+    is otherwise unconstrained; that is what delegation is for.
+    """
+    if child.agent is None or "*" in child.agent:
+        return False
+    if parent.user is not None:
+        if child.user is None or "*" in child.user:
+            return False
+        return matches(parent.user, child.user, separator=None)
+    # SPEC: §5.4's row conditions the `user` rule on the parent declaring one, and its second
+    # bullet argues only about `agent`. A wildcard `user` under a parent that declares none is
+    # the same unbounded grantee spelled on the other field, so the fail-closed reading — the
+    # design note's "a delegation's subject may carry no wildcard" — applies to both.
+    return child.user is None or "*" not in child.user
+
+
+def _patterns_contained(
+    parent: Sequence[str], child: Sequence[str], *, separator: str | None
+) -> bool:
+    """Every child pattern is contained in **some** parent pattern (§5.4)."""
+    return all(
+        any(contains(outer, inner, separator=separator) for outer in parent) for inner in child
+    )
+
+
+def _constraints_contained(parent: Mapping[str, Condition], child: Mapping[str, Condition]) -> bool:
+    """For every `(argument, op)` the parent declares, the child declares it at least as strict.
+
+    The child may add constraints the parent does not have. It may **not** discharge the
+    parent's by omitting it, nor by constraining a different operator: a child bounding
+    `amount_lt` where the parent bounds `amount_lte` may hold that *as well*, but the parent's
+    key must be present. Requiring the same operator keeps containment decidable; a solver
+    reasoning across operators would be a second policy engine.
+    """
+    for key, outer in parent.items():
+        inner = child.get(key)
+        if inner is None or not _operand_at_least_as_strict(outer, inner):
+            return False
+    return True
+
+
+def _operand_at_least_as_strict(parent: Condition, child: Condition) -> bool:
+    """§5.4's operand table. The key is `f"{argument}_{op}"`, so the ops are already equal."""
+    compare = _STRICTER.get(parent.op)
+    if compare is not None:
+        return bool(compare(child.operand, parent.operand))
+    if parent.op == "in":
+        return all(
+            any(_type_strict_equal(item, other) for other in parent.operand)
+            for item in child.operand
+        )
+    # `eq` and `neq`: equal to the parent's, type-strictly. See §5.4 on why `neq` is not
+    # inverted here — `v0.1 §3.2` has no deny-list operator, so "the parent's exclusions plus
+    # more" is not expressible and equality is the only rule there is.
+    return _type_strict_equal(child.operand, parent.operand)
+
+
+@dataclass(frozen=True)
+class _Walk:
+    """What walking a delegation to its root found (SPEC-v0.3 §5.5).
+
+    Depth is **recomputed, never trusted**: the `depth` column is recorded for reading, so a
+    row edited directly in the database cannot assert its way to a shorter chain.
+    """
+
+    nodes: tuple[Delegation, ...]  # leaf first
+    root: Grant | None = None
+    root_id: str | None = None
+    missing_parent_id: str | None = None
+    cycle_at: str | None = None
+    depth_exceeded: int | None = None
+
+    @property
+    def complete(self) -> bool:
+        return self.root is not None
+
+    @property
+    def ancestors(self) -> tuple[Grant, ...]:
+        """Every grant above the leaf, root first — the root grant and the delegations."""
+        above: list[Grant] = [] if self.root is None else [self.root]
+        above.extend(node.grant for node in reversed(self.nodes[1:]))
+        return tuple(above)
+
+    @property
+    def ancestor_ids(self) -> tuple[str, ...]:
+        above: list[str] = [] if self.root_id is None else [self.root_id]
+        above.extend(node.delegation_id for node in reversed(self.nodes[1:]))
+        return tuple(above)
+
+    @property
+    def steps(self) -> tuple[tuple[Grant, Grant], ...]:
+        """Every parent→child pair, root first, for §5.4's containment re-check."""
+        chain = [*self.ancestors, self.nodes[0].grant]
+        return tuple(itertools.pairwise(chain))
+
+
+@dataclass(frozen=True)
+class _ChainCheck:
+    """The walked depth, and the §5.6 rule that failed — or `None` where none did."""
+
+    depth: int
+    failure: AuthorityResult | None
+
+
+def _by_grant_id(result: AuthorityResult) -> str:
+    """§4.3, §4.6 — ties break on simple codepoint order, a property of the set of matching
+    grants rather than of the document. Reordering the file changes neither the decision nor
+    the id."""
+    return result.grant_id or ""
 
 
 class Authority:
@@ -443,33 +800,310 @@ class Authority:
         fixed precedence order — so the evidence for one configuration does not depend on the
         order grants appear in the document.
 
-        `store` is required and unused while every grant is a root grant: build-list item 3
-        walks a delegation's chain through it on every evaluation, and an optional store would
-        give an implementation a fail-open reading in which a revoked delegation stays valid.
+        `store` is required, not optional: §5.6 re-checks a delegation's whole chain on every
+        evaluation and that walk reads the store. An optional one would give an implementation
+        a fail-open reading in which a revoked delegation evaluates as valid, and "a chain of
+        any depth is cut by one write" would stop being true.
         """
-        passed: list[str] = []
-        failed: dict[str, list[str]] = {}
-        for grant_id, grant in self._grants.items():
+        passed: list[AuthorityResult] = []
+        failed: dict[str, list[AuthorityResult]] = {}
+        try:
+            candidates = self._candidates(store)
+        except _UnreadableError as unreadable:
+            return AuthorityResult(
+                False, AUTHORITY_UNREADABLE, delegation_id=unreadable.delegation_id
+            )
+        for grant_id, grant, delegation in candidates:
             if not grant.matches_shape(action):
                 continue
-            reasons: list[str] = []
+            outcomes: list[AuthorityResult] = []
+            depth = 0
+            if delegation is not None:
+                try:
+                    chain = self._check_chain(delegation, store=store, now=now)
+                except _UnreadableError as unreadable:
+                    return AuthorityResult(
+                        False, AUTHORITY_UNREADABLE, delegation_id=unreadable.delegation_id
+                    )
+                depth = chain.depth
+                if chain.failure is not None:
+                    outcomes.append(chain.failure)
             if grant.is_expired(now):
-                reasons.append(AUTHORITY_EXPIRED)
+                outcomes.append(AuthorityResult(False, AUTHORITY_EXPIRED))
             if not grant.constraints_hold(action):
-                reasons.append(AUTHORITY_CONSTRAINT)
-            if reasons:
-                for reason in reasons:
-                    failed.setdefault(reason, []).append(grant_id)
+                outcomes.append(AuthorityResult(False, AUTHORITY_CONSTRAINT))
+            named = None if delegation is None else grant_id
+            if outcomes:
+                # §4.3 — every reason a grant failed for, collected rather than
+                # short-circuited, so the reported one is a property of the configuration and
+                # not of the order an implementation happened to check things in.
+                for outcome in outcomes:
+                    failed.setdefault(outcome.reason, []).append(
+                        replace(outcome, grant_id=grant_id, delegation_id=named, depth=depth)
+                    )
             else:
-                passed.append(grant_id)
+                passed.append(
+                    AuthorityResult(
+                        True,
+                        AUTHORITY_GRANT,
+                        grant_id=grant_id,
+                        delegation_id=named,
+                        depth=depth,
+                    )
+                )
         if passed:
             # §4.6 — holding two permissions is never worse than holding one, and the grant
             # named is a property of the set rather than of the document.
-            return AuthorityResult(True, AUTHORITY_GRANT, grant_id=min(passed))
+            return min(passed, key=_by_grant_id)
         for reason in REASON_PRECEDENCE:
             if reason in failed:
-                return AuthorityResult(False, reason, grant_id=min(failed[reason]))
+                return min(failed[reason], key=_by_grant_id)
         return AuthorityResult(False, NO_AUTHORITY)
+
+    # --- delegation (SPEC-v0.3 §5) -----------------------------------------------------
+
+    def plan_delegation(
+        self, parent_id: str, grant: Grant, *, by: Principal, store: StateStore, now: datetime
+    ) -> Delegation:
+        """The delegation `Control.delegate` would write, or a refusal (SPEC-v0.3 §5.3).
+
+        Pure: it reads the store, writes nothing, and appends no event. `Control` performs the
+        write and the §7 events, which is what keeps `ARCHITECTURE.md` §6's single composer
+        single (§4.8).
+
+        The six checks run **in the order §5.3 lists** and the first that fails is the
+        refusal's reason — fixed, so the evidence for one attempted creation does not depend on
+        the order an implementation happens to check things in.
+
+        `# SPEC:` §5.2 says `Control.delegate` mints the id. §11 freezes this signature without
+        one, and a `Delegation` is frozen and complete, so the mint happens here, where the
+        record is constructed. `Control` is still the only thing that writes it.
+        """
+        # Rule 0. Scoped to `Control.execute`, §2.3's expiry check would leave this path open:
+        # an agent whose token lapsed five minutes ago, and whose every proposed action is now
+        # refused, could still write a permanent, re-delegable grant for an agent of its
+        # choosing. A delegation is the most durable thing a principal can create.
+        if by.expires_at is not None and now > by.expires_at:
+            raise IdentityError(
+                f"the delegating principal's credential expired at {by.expires_at}; an expired "
+                "credential may not create authority (SPEC-v0.3 §5.3 rule 0)"
+            )
+        if grant.id:
+            raise InvalidArgument(
+                f"the grant passed to delegate() carries id {grant.id!r}; a delegation's id is "
+                "assigned, not chosen (SPEC-v0.3 §5.2)"
+            )
+        parent, parent_depth = self._parent_for_creation(parent_id, store=store, now=now)
+        # Rule 4. You may only delegate authority you hold; a process that could delegate from
+        # a grant addressed to somebody else would make the subject field decorative.
+        if not parent.subject.matches(by):
+            raise AuthorityEscalation(
+                f"{by.agent!r} does not match the subject of {parent_id!r}",
+                reason=NOT_THE_SUBJECT,
+                parent_id=parent_id,
+            )
+        depth = parent_depth + 1
+        if depth > self._max_delegation_depth:
+            raise AuthorityEscalation(
+                f"a delegation of {parent_id!r} would be at depth {depth}, beyond "
+                f"max_delegation_depth {self._max_delegation_depth}",
+                reason=MAX_DEPTH,
+                parent_id=parent_id,
+            )
+        dimension = contained_dimension(parent, grant)
+        if dimension is not None:
+            raise AuthorityEscalation(
+                f"the child grant is not contained in {parent_id!r} on {dimension!r}; "
+                "omission never means unlimited (SPEC-v0.3 §5.4)",
+                reason=CONTAINMENT,
+                parent_id=parent_id,
+                dimension=dimension,
+            )
+        delegation_id = new_delegation_id()
+        return Delegation(
+            delegation_id=delegation_id,
+            parent_id=parent_id,
+            depth=depth,
+            grant=replace(grant, id=delegation_id),
+            created_by=by,
+            created_via="api",
+            created_at=now,
+        )
+
+    def plan_revocation(
+        self, delegation_id: str, *, by: str | None, store: StateStore, now: datetime
+    ) -> Delegation:
+        """The delegation `Control.revoke` would revoke (SPEC-v0.3 §5.7). Reads only."""
+        record = store.get_delegation(delegation_id)
+        if record is None:
+            raise InvalidArgument(f"no delegation {delegation_id}")
+        try:
+            return _delegation_from_record(record)
+        except _UnreadableError as unreadable:
+            raise InvalidArgument(str(unreadable)) from unreadable
+
+    def _parent_for_creation(
+        self, parent_id: str, *, store: StateStore, now: datetime
+    ) -> tuple[Grant, int]:
+        """§5.3 rules 1 to 3, and the walked depth rule 5 needs."""
+        # §5.2 — a root grant wins any collision: an id is resolved against the document first
+        # and the store second.
+        root = self._grants.get(parent_id)
+        if root is not None:
+            if not root.delegable:
+                raise AuthorityEscalation(
+                    f"{parent_id!r} is not delegable",
+                    reason=PARENT_NOT_DELEGABLE,
+                    parent_id=parent_id,
+                )
+            if root.is_expired(now):
+                raise AuthorityEscalation(
+                    f"{parent_id!r} expired at {root.expires_at}",
+                    reason=PARENT_NOT_VALID,
+                    parent_id=parent_id,
+                )
+            return root, 0
+        record = store.get_delegation(parent_id)
+        if record is None or record.is_revoked:
+            # Rule 1 — "a root grant or a *live* delegation". A revoked one is neither, and
+            # saying so here rather than in rule 3 keeps rule 3 about the *chain above* it.
+            raise AuthorityEscalation(
+                f"no live grant or delegation {parent_id!r}",
+                reason=UNKNOWN_PARENT,
+                parent_id=parent_id,
+            )
+        try:
+            parent = _delegation_from_record(record)
+        except _UnreadableError as unreadable:
+            raise AuthorityEscalation(
+                str(unreadable), reason=PARENT_NOT_VALID, parent_id=parent_id
+            ) from unreadable
+        if not parent.grant.delegable:
+            raise AuthorityEscalation(
+                f"{parent_id!r} is not delegable",
+                reason=PARENT_NOT_DELEGABLE,
+                parent_id=parent_id,
+            )
+        if parent.grant.is_expired(now):
+            raise AuthorityEscalation(
+                f"{parent_id!r} expired at {parent.grant.expires_at}",
+                reason=PARENT_NOT_VALID,
+                parent_id=parent_id,
+            )
+        try:
+            walk = self._walk(parent, store=store)
+        except _UnreadableError as unreadable:
+            raise AuthorityEscalation(
+                str(unreadable), reason=PARENT_NOT_VALID, parent_id=parent_id
+            ) from unreadable
+        # Rule 3 covers `delegable` and revocation across the whole chain, not just the
+        # immediate parent, so an operator who sets `delegable: false` on a root grant stops
+        # new delegations appearing anywhere beneath it rather than only one level down.
+        invalid = walk.missing_parent_id is not None or walk.cycle_at is not None
+        if not invalid:
+            invalid = any(node.is_revoked for node in walk.nodes[1:]) or any(
+                ancestor.is_expired(now) or not ancestor.delegable for ancestor in walk.ancestors
+            )
+        if invalid:
+            raise AuthorityEscalation(
+                f"the chain above {parent_id!r} is no longer valid",
+                reason=PARENT_NOT_VALID,
+                parent_id=parent_id,
+            )
+        if walk.depth_exceeded is not None:
+            return parent.grant, walk.depth_exceeded
+        return parent.grant, len(walk.nodes)
+
+    def _candidates(self, store: StateStore) -> list[tuple[str, Grant, Delegation | None]]:
+        """Every grant this principal could hold: the document's, then the store's (§4.3)."""
+        found: list[tuple[str, Grant, Delegation | None]] = [
+            (grant_id, grant, None) for grant_id, grant in self._grants.items()
+        ]
+        for record in store.delegations(include_revoked=True):
+            delegation = _delegation_from_record(record)
+            found.append((delegation.delegation_id, delegation.grant, delegation))
+        return found
+
+    def _walk(self, leaf: Delegation, *, store: StateStore) -> _Walk:
+        """Walk a delegation to its root, bounded and cycle-checked (SPEC-v0.3 §5.5).
+
+        Bounded at `max_delegation_depth + 1` steps and refusing a chain that revisits an id.
+        A cycle is not reachable through `Control.delegate` — a parent exists before its child
+        — but it is reachable with `sqlite3` and a text editor.
+        """
+        nodes = [leaf]
+        seen = {leaf.delegation_id}
+        while True:
+            parent_id = nodes[-1].parent_id
+            root = self._grants.get(parent_id)
+            if root is not None:
+                return _Walk(tuple(nodes), root=root, root_id=parent_id)
+            if parent_id in seen:
+                return _Walk(tuple(nodes), cycle_at=parent_id)
+            record = store.get_delegation(parent_id)
+            if record is None:
+                return _Walk(tuple(nodes), missing_parent_id=parent_id)
+            if len(nodes) >= self._max_delegation_depth:
+                # One more node would put the chain past the bound, and the bound is what
+                # stops an edited store hanging the process.
+                return _Walk(tuple(nodes), depth_exceeded=len(nodes) + 1)
+            seen.add(parent_id)
+            nodes.append(_delegation_from_record(record))
+
+    def _check_chain(self, leaf: Delegation, *, store: StateStore, now: datetime) -> _ChainCheck:
+        """§5.6's six rules, evaluated 1 → 6, the first failure naming the refusal.
+
+        Fixed order, because rules 1, 3, 4, 5 and 6 all yield `authority_escalation` while
+        carrying different `data` — so a chain that is both orphaned above and non-contained
+        below would otherwise record implementation-defined evidence for one configuration.
+
+        Re-checking is not belt-and-braces. It is what makes revocation transitive, what makes
+        an expiring parent stop authorizing without anyone finding its children, and what makes
+        a narrowed root grant narrow everything beneath it.
+        """
+        walk = self._walk(leaf, store=store)
+        depth = walk.depth_exceeded if walk.depth_exceeded is not None else len(walk.nodes)
+        if walk.missing_parent_id is not None:
+            return _ChainCheck(
+                depth,
+                AuthorityResult(
+                    False, AUTHORITY_ESCALATION, missing_parent_id=walk.missing_parent_id
+                ),
+            )
+        if any(node.is_revoked for node in walk.nodes):
+            return _ChainCheck(depth, AuthorityResult(False, AUTHORITY_REVOKED))
+        for ancestor_id, ancestor in zip(walk.ancestor_ids, walk.ancestors, strict=True):
+            if ancestor.is_expired(now):
+                # Attribution rather than prevention (§9): §5.4's `expires_at` row already
+                # makes the leaf expired, so §4.3 would refuse it either way. What this adds is
+                # the name of the ancestor that lapsed, which is the thing an operator fixes.
+                return _ChainCheck(
+                    depth,
+                    AuthorityResult(False, AUTHORITY_ESCALATION, expired_parent_id=ancestor_id),
+                )
+        for parent, child in walk.steps:
+            dimension = contained_dimension(parent, child)
+            if dimension is not None:
+                return _ChainCheck(
+                    depth, AuthorityResult(False, AUTHORITY_ESCALATION, dimension=dimension)
+                )
+        if walk.cycle_at is not None:
+            # A chain that loops is a store somebody has edited by hand, and it belongs with
+            # the other unreadable-record cases rather than with the ordinary escalations.
+            return _ChainCheck(
+                depth, AuthorityResult(False, AUTHORITY_UNREADABLE, cycle_at=walk.cycle_at)
+            )
+        if walk.depth_exceeded is not None:
+            return _ChainCheck(
+                depth,
+                AuthorityResult(False, AUTHORITY_ESCALATION, depth_exceeded=walk.depth_exceeded),
+            )
+        if any(not ancestor.delegable for ancestor in walk.ancestors):
+            # Rule 6 exists because `delegable` is not a §5.4 row and rule 4 would therefore
+            # never see it. An operator setting `delegable: false` on a root grant is shutting
+            # down a chain they believe is compromised.
+            return _ChainCheck(depth, AuthorityResult(False, AUTHORITY_ESCALATION))
+        return _ChainCheck(depth, None)
 
 
 # --- loading (SPEC-v0.3 §4.1, §4.2) ----------------------------------------------------
@@ -552,7 +1186,36 @@ def _from_section(section: object, source: str) -> Authority:
     return Authority(grants, max_delegation_depth=depth, source=source)
 
 
-def _parse_grant(entry: object, where: str) -> Grant:
+def grant_from_yaml(text: str, *, source: str = "<string>") -> Grant:
+    """One grant with the keys of §4.2 **minus `id`** — `ctrlrun delegate --file` (§5.7).
+
+    An `id:` key is a `PolicyError` naming the rule: a delegation's id is assigned, not
+    chosen (§5.2). The returned grant carries `id=""`, which is legal only on the
+    `Control.delegate` path and only until the call returns.
+    """
+    try:
+        document = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise PolicyError(f"{source}: not valid YAML: {exc}") from exc
+    if not isinstance(document, Mapping):
+        raise PolicyError(
+            f"{source}: a delegated grant must be a mapping of the keys of SPEC-v0.3 §4.2 "
+            f"minus 'id', got {_type_name(document)}"
+        )
+    if "id" in document:
+        raise PolicyError(
+            f"{source}: a delegated grant may not carry 'id'; the id is assigned, not chosen "
+            "(SPEC-v0.3 §5.2)"
+        )
+    return _parse_grant({**document, "id": _UNASSIGNED}, source, unassigned=True)
+
+
+#: A placeholder `id` for the `--file` path: `_parse_grant` requires a non-empty string, and
+#: `Grant` accepts `""` only on the `Control.delegate` path. Never stored, never compared.
+_UNASSIGNED: Final = "unassigned"
+
+
+def _parse_grant(entry: object, where: str, *, unassigned: bool = False) -> Grant:
     if not isinstance(entry, Mapping):
         raise PolicyError(f"{where}: a grant must be a mapping, got {_type_name(entry)}")
     _reject_unknown_keys(entry, _GRANT_KEYS, where)
@@ -570,7 +1233,7 @@ def _parse_grant(entry: object, where: str) -> Grant:
 
     try:
         return Grant(
-            id=grant_id,
+            id="" if unassigned else grant_id,
             subject=_parse_subject(entry.get("subject"), where),
             actions=_parse_patterns(entry.get("actions"), "actions", where),
             resources=(
@@ -689,15 +1352,28 @@ __all__ = [
     "AUTHORITY_GRANT",
     "AUTHORITY_REVOKED",
     "AUTHORITY_UNREADABLE",
+    "CONTAINMENT",
     "DEFAULT_MAX_DELEGATION_DEPTH",
     "DELEGATION_ID_PREFIX",
+    "DIMENSIONS",
+    "MAX_DEPTH",
+    "NOT_THE_SUBJECT",
     "NO_AUTHORITY",
+    "PARENT_NOT_DELEGABLE",
+    "PARENT_NOT_VALID",
     "RESOURCE_SEPARATOR",
+    "UNKNOWN_PARENT",
     "Authority",
     "AuthorityResult",
+    "Delegation",
     "Grant",
     "Subject",
+    "contained_dimension",
     "contains",
+    "grant_from_json",
+    "grant_from_yaml",
+    "grant_to_json",
     "matches",
+    "new_delegation_id",
     "validate_pattern",
 ]

--- a/src/ctrlrun/cli/main.py
+++ b/src/ctrlrun/cli/main.py
@@ -22,9 +22,10 @@ import click
 
 from ..action import Principal
 from ..approval import ApprovalRecord
-from ..control import DEFAULT_STATE_DIR, state_path
+from ..authority import Delegation, grant_from_yaml
+from ..control import DEFAULT_STATE_DIR, Control, state_path
 from ..effect import RESOLVED_BY_HUMAN, EffectRecord, EffectState
-from ..errors import CTRLRunError
+from ..errors import AuthorityEscalation, CTRLRunError
 from ..policy import DEFAULT_POLICY_FILENAME
 from ..receipt import Event, EventType, Receipt, iso_timestamp
 from ..state import RESOLUTIONS, SQLiteStateStore
@@ -451,6 +452,91 @@ def _approval_dict(record: ApprovalRecord) -> dict[str, Any]:
         "expires_at": iso_timestamp(record.expires_at),
         "granted_at": None if record.granted_at is None else iso_timestamp(record.granted_at),
         "consumed_at": None if record.consumed_at is None else iso_timestamp(record.consumed_at),
+    }
+
+
+@main.command()
+@click.option("--parent", required=True, help="The grant or delegation being narrowed.")
+@click.option(
+    "--file",
+    "grant_file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="A one-grant YAML document, with the keys of SPEC-v0.3 §4.2 minus 'id'.",
+)
+@click.option(
+    "--as",
+    "as_who",
+    required=True,
+    help="The delegating principal: AGENT or AGENT/USER. Split on the first '/'.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit one JSON object instead.")
+def delegate(parent: str, grant_file: Path, as_who: str, as_json: bool) -> None:
+    """Create a delegated grant beneath an existing one.
+
+    `--as` is an **assertion**, not an authentication: it supplies the creating principal for
+    SPEC-v0.3 §5.3 rule 4, and it is free text typed by whoever runs the command. The record
+    keeps `created_via="cli"` so a reader of the evidence can tell an act from an assertion.
+    An agent name containing '/' cannot be written here, because `--as a/b` would otherwise be
+    ambiguous between the agent `a/b` acting alone and the agent `a` acting for `b`.
+    """
+    agent, _, user = as_who.partition("/")
+    if not agent:
+        raise click.UsageError("--as needs an agent name: AGENT or AGENT/USER")
+    try:
+        control = Control.from_file()
+        grant = grant_from_yaml(grant_file.read_text(encoding="utf-8"), source=str(grant_file))
+        created = control._delegate(
+            parent, grant, by=Principal(agent=agent, user=user or None), via="cli"
+        )
+    except AuthorityEscalation as exc:
+        # §5.7 — a refusal here exits non-zero and **names the rule that failed**, which is the
+        # §5.3 reason rather than the prose. The two vocabularies are disjoint, so an operator
+        # reading `containment` knows to look at §5.4 and not at an evaluation-time denial.
+        raise click.ClickException(f"{exc.reason}: {exc}") from exc
+    except CTRLRunError as exc:
+        raise _fail(exc) from exc
+    if as_json:
+        click.echo(json.dumps(_delegation_dict(created), ensure_ascii=False))
+        return
+    click.echo(f"created {created.delegation_id}")
+    click.echo(f"parent {created.parent_id} at depth {created.depth}")
+    click.echo(f"revoke it with: ctrlrun revoke {created.delegation_id}")
+
+
+@main.command()
+@click.argument("delegation_id")
+@click.option("--by", "by", default=CLI_APPROVER, show_default=True, help="Who revoked it.")
+def revoke(delegation_id: str, by: str) -> None:
+    """Revoke a delegation, and with it every delegation beneath it.
+
+    Transitive by structure and not reversible: there is no `unrevoke`, because the operation
+    whose safety matters is the one taken in a hurry (SPEC-v0.3 §5.7). Revoking an
+    already-revoked delegation is idempotent and exits 0.
+    """
+    try:
+        control = Control.from_file()
+        before = control.store.get_delegation(delegation_id)
+        control.revoke(delegation_id, by=by)
+    except CTRLRunError as exc:
+        raise _fail(exc) from exc
+    if before is not None and before.revoked_at is not None:
+        click.echo(f"{delegation_id} was already revoked at {iso_timestamp(before.revoked_at)}")
+        return
+    click.echo(f"revoked {delegation_id} by {by}")
+    click.echo("every delegation beneath it is denied from the next evaluation")
+
+
+def _delegation_dict(delegation: Delegation) -> dict[str, Any]:
+    """One delegation as portable JSON, for `ctrlrun delegate --json` (SPEC-v0.3 §5.2)."""
+    return {
+        "delegation_id": delegation.delegation_id,
+        "parent_id": delegation.parent_id,
+        "depth": delegation.depth,
+        "created_by_agent": delegation.created_by.agent,
+        "created_by_user": delegation.created_by.user,
+        "created_via": delegation.created_via,
+        "created_at": iso_timestamp(delegation.created_at),
     }
 
 

--- a/src/ctrlrun/control.py
+++ b/src/ctrlrun/control.py
@@ -14,10 +14,10 @@ import os
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any, Final, NoReturn, ParamSpec, TypeVar, cast
+from typing import Any, Final, Literal, NoReturn, ParamSpec, TypeVar, cast
 
 from .action import Action, Principal
 from .approval import (
@@ -27,7 +27,7 @@ from .approval import (
     ApprovalStatus,
     LocalApprovalProvider,
 )
-from .authority import Authority, AuthorityResult, _optional_from_yaml
+from .authority import Authority, AuthorityResult, Delegation, Grant, _optional_from_yaml
 from .effect import (
     DEFAULT_LEASE,
     RECONCILED_STATES,
@@ -46,6 +46,7 @@ from .errors import (
     ApprovalMismatch,
     ApprovalRequired,
     AuthorityDenied,
+    AuthorityEscalation,
     CTRLRunError,
     DuplicateEffect,
     EffectKeyError,
@@ -364,6 +365,15 @@ class Control:
         if result.delegation_id is not None:
             data["delegation_id"] = result.delegation_id
             data["depth"] = result.depth
+        # SPEC-v0.3 §7 — the keys that tell §5.6's rules apart. Rules 1, 3, 4, 5 and 6 all
+        # report `authority_escalation`, so without these five guards would be one guard as
+        # far as any reader or test could tell.
+        for key in ("dimension", "missing_parent_id", "expired_parent_id", "cycle_at"):
+            value = getattr(result, key)
+            if value is not None:
+                data[key] = value
+        if result.depth_exceeded is not None:
+            data["depth_exceeded"] = result.depth_exceeded
         return data
 
     def _refuse_authority(
@@ -1148,6 +1158,113 @@ class Control:
             return None
         record = self._store.get_approval(approval_id)
         return None if record is None else record.approver
+
+    # --- delegation (SPEC-v0.3 §5) ------------------------------------------------------
+
+    def delegate(self, parent_id: str, grant: Grant, *, by: Principal) -> Delegation:
+        """Create a delegated grant beneath `parent_id`, or refuse (SPEC-v0.3 §5.3).
+
+        `by` is the principal creating it, and §5.3 rule 4 checks it against the parent grant's
+        subject: you may only delegate authority you hold. It is checked, not authenticated —
+        on the `ctrlrun delegate` path it came from a shell, which is why the record carries
+        `created_via` (§5.7).
+
+        Every refusal writes no record and appends `DELEGATION_REJECTED`; a success writes the
+        row and appends `DELEGATION_CREATED`, which fans out to every registered sink. Creation
+        is deliberately **not** idempotent: two identical calls make two delegations, each
+        revocable on its own, because a delegation is an act and collapsing two acts into one
+        record would lose which one a receipt refers to (§5.2).
+        """
+        return self._delegate(parent_id, grant, by=by, via="api")
+
+    def revoke(self, delegation_id: str, *, by: str | None = None) -> None:
+        """Revoke one delegation (SPEC-v0.3 §5.7).
+
+        Transitive **by structure**: nothing is rewritten and no children are visited, because
+        §5.6 rule 2 walks to the root on every evaluation. A chain of any depth is cut by one
+        write. Not reversible — there is no `unrevoke` — and idempotent: revoking an
+        already-revoked delegation logs and appends no second event.
+        """
+        authority = self._require_authority("revoke")
+        now = self._clock()
+        delegation = authority.plan_revocation(delegation_id, by=by, store=self._store, now=now)
+        if not self._store.revoke_delegation(delegation_id, by=by, at=now):
+            _LOG.info(
+                "delegation %s was already revoked at %s",
+                delegation_id,
+                delegation.revoked_at,
+            )
+            return
+        self._append_delegation(
+            EventType.DELEGATION_REVOKED,
+            {"delegation_id": delegation_id, "revoked_by": by},
+        )
+
+    def _delegate(
+        self, parent_id: str, grant: Grant, *, by: Principal, via: Literal["api", "cli"]
+    ) -> Delegation:
+        """The one implementation behind `Control.delegate` and `ctrlrun delegate`.
+
+        `via` is not on the public signature `SPEC-v0.3 §11` freezes; it is the one thing the
+        CLI path needs to say that the API path does not, and §5.7 requires the record to keep
+        the two apart so a reader of the evidence can tell an act from an assertion.
+        """
+        authority = self._require_authority("delegate")
+        try:
+            planned = authority.plan_delegation(
+                parent_id, grant, by=by, store=self._store, now=self._clock()
+            )
+        except IdentityError:
+            # §5.3 rule 0 — recorded with the reason `Control.execute` uses for the same fact.
+            self._append_delegation(
+                EventType.DELEGATION_REJECTED,
+                {"reason": PRINCIPAL_EXPIRED, "parent_id": parent_id},
+            )
+            raise
+        except AuthorityEscalation as escalation:
+            data: dict[str, Any] = {"reason": escalation.reason, "parent_id": parent_id}
+            if escalation.dimension is not None:
+                # §7 — present *only* for a rule-6 containment refusal. The other five name no
+                # §5.4 row, and inventing a dimension for them would make two distinguishable
+                # guards report the same shape.
+                data["dimension"] = escalation.dimension
+            self._append_delegation(EventType.DELEGATION_REJECTED, data)
+            raise
+        delegation = replace(planned, created_via=via)
+        self._store.put_delegation(delegation.to_record())
+        self._append_delegation(
+            EventType.DELEGATION_CREATED,
+            {
+                "delegation_id": delegation.delegation_id,
+                "parent_id": delegation.parent_id,
+                "depth": delegation.depth,
+                "created_by_agent": by.agent,
+                "created_by_user": by.user,
+                "created_via": via,
+            },
+        )
+        return delegation
+
+    def _require_authority(self, what: str) -> Authority:
+        if self._authority is None:
+            raise InvalidArgument(
+                f"this Control has no authority section, so there is nothing to {what}; "
+                "load a document with an 'authority:' key (SPEC-v0.3 §4.1)"
+            )
+        return self._authority
+
+    def _append_delegation(self, type_: EventType, data: Mapping[str, Any]) -> None:
+        """Append one of §7's three action-less events and fan it out.
+
+        `action_id` is `None`: these are about an authority record, created and revoked outside
+        any action's life. `Control` appends them and calls every sink, for `v0.2 §4.1`'s
+        reason — the highest-privilege operations in the release must not be the only ones
+        missing from the export path.
+        """
+        stored = self._store.append_event(
+            Event(type=type_, action_id=None, ts=self._clock(), data=data)
+        )
+        self._fan_out("on_event", stored, str(stored.type))
 
     # --- evidence ---------------------------------------------------------------------
 

--- a/src/ctrlrun/otel.py
+++ b/src/ctrlrun/otel.py
@@ -82,7 +82,10 @@ class OTelEventSink:
     # --- EventSink ----------------------------------------------------------------------
 
     def on_event(self, event: Event) -> None:
-        span = self._span_for(event)
+        if event.action_id is None:
+            self._standalone(event)
+            return
+        span = self._span_for(event, event.action_id)
         if span is None:
             return
         span.add_event(str(event.type), attributes=self._event_attributes(event))
@@ -111,11 +114,24 @@ class OTelEventSink:
 
     # --- internals ----------------------------------------------------------------------
 
-    def _span_for(self, event: Event) -> Any:
+    def _standalone(self, event: Event) -> None:
+        """One span for an event that belongs to no action (SPEC-v0.3 §7).
+
+        The three `DELEGATION_*` types are about an authority record, created and revoked
+        outside any action's life, so `_span_for` would look for an open span it will never
+        find and drop them — silently, leaving an operator whose evidence pipeline is OTel to
+        watch a delegation chain appear and be revoked with nothing in the trace. The
+        highest-privilege operations in the release must not be the only ones missing from the
+        export path.
+        """
+        span = self._tracer.start_span(str(event.type), attributes=self._event_attributes(event))
+        span.end()
+
+    def _span_for(self, event: Event, action_id: str) -> Any:
         from .receipt import EventType
 
         with self._lock:
-            span = self._open.get(event.action_id)
+            span = self._open.get(action_id)
             if span is not None:
                 return span
             if event.type is not EventType.ACTION_PROPOSED:
@@ -126,9 +142,9 @@ class OTelEventSink:
                 return None
             span = self._tracer.start_span(
                 PENDING_SPAN_NAME,
-                attributes={f"{PREFIX}action_id": event.action_id},
+                attributes={f"{PREFIX}action_id": action_id},
             )
-            self._open[event.action_id] = span
+            self._open[action_id] = span
             self._evict_if_needed()
             return span
 

--- a/src/ctrlrun/receipt.py
+++ b/src/ctrlrun/receipt.py
@@ -118,10 +118,15 @@ class Event:
     """One ordered step in the life of an action (SPEC-v0.1 §6.2).
 
     `event_id` is assigned by the StateStore on append, not by the caller.
+
+    `action_id` is `None` for the three `DELEGATION_*` types (SPEC-v0.3 §7): they are about an
+    authority record, created and revoked outside any action's life, and they name the
+    delegation in `data.delegation_id`. Inventing a synthetic `action_id` would put a value in
+    a field every reader takes to name a real proposal.
     """
 
     type: EventType
-    action_id: str
+    action_id: str | None
     ts: datetime
     data: Mapping[str, Any] = field(default_factory=dict)
     effect_key: str | None = None

--- a/src/ctrlrun/state.py
+++ b/src/ctrlrun/state.py
@@ -116,6 +116,19 @@ CREATE TABLE IF NOT EXISTS events(
   approval_id TEXT,
   data_json TEXT
 );
+CREATE TABLE IF NOT EXISTS delegations(
+  delegation_id TEXT PRIMARY KEY,
+  parent_id TEXT NOT NULL,
+  depth INTEGER NOT NULL,
+  grant_json TEXT NOT NULL,
+  created_by_agent TEXT NOT NULL,
+  created_by_user TEXT,
+  created_via TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  revoked_at TEXT,
+  revoked_by TEXT
+);
+CREATE INDEX IF NOT EXISTS delegations_by_parent ON delegations(parent_id);
 """
 
 
@@ -331,6 +344,36 @@ class HeldContinuation:
     rounds: int
 
 
+@dataclass(frozen=True)
+class DelegationRecord:
+    """One row of the `delegations` table (SPEC-v0.3 §5.2).
+
+    **The store persists rows, not grants.** `grant_json` stays a string here and
+    `authority.py` is what parses a `Grant` out of it, so `state.py` does not import
+    `authority.py` and therefore does not transitively acquire `policy.py` —
+    `ARCHITECTURE.md` §6's dependency direction. `Delegation`, the parsed form, lives there.
+
+    `depth` is recorded for reading and never trusted: evaluation derives it by walking to the
+    root (§5.5), so a row edited directly in the database cannot assert its way to a shorter
+    chain.
+    """
+
+    delegation_id: str
+    parent_id: str
+    depth: int
+    grant_json: str
+    created_by_agent: str
+    created_by_user: str | None
+    created_via: str
+    created_at: datetime
+    revoked_at: datetime | None = None
+    revoked_by: str | None = None
+
+    @property
+    def is_revoked(self) -> bool:
+        return self.revoked_at is not None
+
+
 class StateStore(ApprovalStore, Protocol):
     """Durable state behind a `Control` (SPEC-v0.1 §5.3): approvals, effects, evidence."""
 
@@ -457,6 +500,43 @@ class StateStore(ApprovalStore, Protocol):
         """
         ...
 
+    def put_delegation(self, record: DelegationRecord) -> None:
+        """Insert one delegation row (SPEC-v0.3 §5.2).
+
+        A plain `INSERT` that raises on a duplicate id, and **never an upsert**: an upsert on
+        an existing id would clear `revoked_at`, which is `unrevoke` by another door in a
+        release that says there is no such thing (§5.7).
+        """
+        ...
+
+    def get_delegation(self, delegation_id: str) -> DelegationRecord | None:
+        """The row with this id, revoked or not, or `None`."""
+        ...
+
+    def delegations_for(self, parent_id: str) -> tuple[DelegationRecord, ...]:
+        """Every row naming this parent, oldest first."""
+        ...
+
+    def delegations(self, *, include_revoked: bool = False) -> tuple[DelegationRecord, ...]:
+        """Every delegation row, oldest first (SPEC-v0.3 §11).
+
+        Evaluation enumerates these because §5.6 walks **upward** from a delegation to its
+        root: a chain whose root grant has been deleted from the document cannot be found by
+        walking downward from the ids that are still in it.
+        """
+        ...
+
+    def revoke_delegation(self, delegation_id: str, *, by: str | None, at: datetime) -> bool:
+        """Revoke one delegation, atomically. `False` if it was already revoked (§5.7).
+
+        The read-then-write happens inside a `BEGIN IMMEDIATE`, as every other read-then-write
+        in this store does (`v0.1 §5.3 E1`), so two concurrent revokes append one
+        `DELEGATION_REVOKED` between them rather than one each. An unknown id is an
+        `InvalidArgument`: there is nothing to revoke, and returning `False` would make that
+        indistinguishable from the idempotent case.
+        """
+        ...
+
     def append_event(self, event: Event) -> Event:
         """Append an event, assigning it the next `event_id`, and return it as stored.
 
@@ -493,6 +573,7 @@ class InMemoryStateStore:
         self._approvals: dict[str, ApprovalRecord] = {}
         self._effects: dict[str, EffectRecord] = {}
         self._continuations: dict[str, tuple[str, Action, int]] = {}
+        self._delegations: dict[str, DelegationRecord] = {}
 
     def close(self) -> None:
         """Nothing to release; here so either store can be closed the same way."""
@@ -518,6 +599,42 @@ class InMemoryStateStore:
         """An immutable snapshot of the receipts, in write order."""
         with self._lock:
             return tuple(self._receipts)
+
+    # --- delegations (SPEC-v0.3 §5.2) -------------------------------------------------
+
+    def put_delegation(self, record: DelegationRecord) -> None:
+        with self._lock:
+            if record.delegation_id in self._delegations:
+                raise InvalidArgument(f"delegation {record.delegation_id} already exists")
+            self._delegations[record.delegation_id] = record
+
+    def get_delegation(self, delegation_id: str) -> DelegationRecord | None:
+        with self._lock:
+            return self._delegations.get(delegation_id)
+
+    def delegations_for(self, parent_id: str) -> tuple[DelegationRecord, ...]:
+        with self._lock:
+            return tuple(
+                record for record in self._delegations.values() if record.parent_id == parent_id
+            )
+
+    def delegations(self, *, include_revoked: bool = False) -> tuple[DelegationRecord, ...]:
+        with self._lock:
+            return tuple(
+                record
+                for record in self._delegations.values()
+                if include_revoked or not record.is_revoked
+            )
+
+    def revoke_delegation(self, delegation_id: str, *, by: str | None, at: datetime) -> bool:
+        with self._lock:
+            record = self._delegations.get(delegation_id)
+            if record is None:
+                raise InvalidArgument(f"no delegation {delegation_id}")
+            if record.is_revoked:
+                return False
+            self._delegations[delegation_id] = replace(record, revoked_at=at, revoked_by=by)
+            return True
 
     # --- approvals (SPEC-v0.1 §4.2) ---------------------------------------------------
 
@@ -890,6 +1007,80 @@ class SQLiteStateStore:
     def receipts(self) -> tuple[Receipt, ...]:
         rows = self._connection().execute("SELECT json FROM receipts ORDER BY rowid").fetchall()
         return tuple(Receipt.from_json(row["json"]) for row in rows)
+
+    # --- delegations (SPEC-v0.3 §5.2) -------------------------------------------------
+
+    def put_delegation(self, record: DelegationRecord) -> None:
+        try:
+            self._connection().execute(
+                "INSERT INTO delegations(delegation_id, parent_id, depth, grant_json, "
+                "created_by_agent, created_by_user, created_via, created_at, revoked_at, "
+                "revoked_by) VALUES(?,?,?,?,?,?,?,?,?,?)",
+                (
+                    record.delegation_id,
+                    record.parent_id,
+                    record.depth,
+                    record.grant_json,
+                    record.created_by_agent,
+                    record.created_by_user,
+                    record.created_via,
+                    _iso(record.created_at),
+                    None if record.revoked_at is None else _iso(record.revoked_at),
+                    record.revoked_by,
+                ),
+            )
+        except sqlite3.IntegrityError as exc:
+            # Never `ON CONFLICT DO UPDATE`: an upsert on an existing id would clear
+            # `revoked_at`, which is `unrevoke` by another door (§5.7).
+            raise InvalidArgument(f"delegation {record.delegation_id} already exists") from exc
+
+    def get_delegation(self, delegation_id: str) -> DelegationRecord | None:
+        row = (
+            self._connection()
+            .execute("SELECT * FROM delegations WHERE delegation_id=?", (delegation_id,))
+            .fetchone()
+        )
+        return None if row is None else _delegation_record(row)
+
+    def delegations_for(self, parent_id: str) -> tuple[DelegationRecord, ...]:
+        rows = (
+            self._connection()
+            .execute("SELECT * FROM delegations WHERE parent_id=? ORDER BY rowid", (parent_id,))
+            .fetchall()
+        )
+        return tuple(_delegation_record(row) for row in rows)
+
+    def delegations(self, *, include_revoked: bool = False) -> tuple[DelegationRecord, ...]:
+        where = "" if include_revoked else " WHERE revoked_at IS NULL"
+        rows = (
+            self._connection()
+            .execute(f"SELECT * FROM delegations{where} ORDER BY rowid")
+            .fetchall()
+        )
+        return tuple(_delegation_record(row) for row in rows)
+
+    def revoke_delegation(self, delegation_id: str, *, by: str | None, at: datetime) -> bool:
+        connection = self._connection()
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            row = connection.execute(
+                "SELECT revoked_at FROM delegations WHERE delegation_id=?", (delegation_id,)
+            ).fetchone()
+            if row is None:
+                raise InvalidArgument(f"no delegation {delegation_id}")
+            if row["revoked_at"] is not None:
+                revoked = False
+            else:
+                connection.execute(
+                    "UPDATE delegations SET revoked_at=?, revoked_by=? WHERE delegation_id=?",
+                    (_iso(at), by, delegation_id),
+                )
+                revoked = True
+        except BaseException:
+            self._unwind(connection)
+            raise
+        connection.commit()
+        return revoked
 
     # --- approvals (SPEC-v0.1 §4.2) ---------------------------------------------------
 
@@ -1378,6 +1569,22 @@ class SQLiteStateStore:
     def _unwind(connection: sqlite3.Connection) -> None:
         """Undo the open transaction, if this failure did not already close one."""
         connection.rollback()
+
+
+def _delegation_record(row: sqlite3.Row) -> DelegationRecord:
+    """One `delegations` row, with the columns of SPEC-v0.3 §5.2 and nothing derived."""
+    return DelegationRecord(
+        delegation_id=str(row["delegation_id"]),
+        parent_id=str(row["parent_id"]),
+        depth=int(row["depth"]),
+        grant_json=str(row["grant_json"]),
+        created_by_agent=str(row["created_by_agent"]),
+        created_by_user=row["created_by_user"],
+        created_via=str(row["created_via"]),
+        created_at=datetime.fromisoformat(str(row["created_at"])),
+        revoked_at=_at(row["revoked_at"]),
+        revoked_by=row["revoked_by"],
+    )
 
 
 _T = TypeVar("_T")

--- a/tests/test_delegation.py
+++ b/tests/test_delegation.py
@@ -576,6 +576,102 @@ def test_t76b_rule_3_an_ancestor_that_is_no_longer_delegable(store, clock):
     assert raised.value.reason == PARENT_NOT_VALID
 
 
+def test_t76b_rule_3_an_ancestor_whose_expiry_was_brought_forward(store, clock):
+    """§5.3 rule 3's ancestor-expiry check, in the one shape §5.4 does not already cover.
+
+    T76b excludes "the parent's own parent is *expired*" because §5.4's `expires_at` row makes
+    a grandparent's expiry imply the parent's — for a chain nobody edited. Editing the root
+    grant's expiry forward breaks that implication: `dlg_1` still expires in December, the root
+    grant now expires in October, and without the ancestor check a child of `dlg_1` is created
+    under a root grant that stopped being authority weeks ago.
+    """
+    control = _control(_document(), store, clock)
+    first = control.delegate("head-of-finance", _child(), by=CFO)
+
+    brought_forward = FINANCE.replace("2027-01-01T00:00:00+00:00", "2026-10-01T00:00:00+00:00")
+    edited = _control(_document(brought_forward), store, clock)
+    clock.advance(timedelta(days=45))  # past the root grant, before `dlg_1`
+
+    try:
+        created = edited.delegate(
+            first.delegation_id,
+            _child(subject=Subject(agent="support-agent", user="cfo@example.com")),
+            by=FINANCE_AGENT,
+        )
+    except AuthorityEscalation as raised:
+        assert raised.reason == PARENT_NOT_VALID
+    else:
+        raise AssertionError(
+            f"SPEC-v0.3 §5.3 rule 3: {created.delegation_id} was minted under a root grant "
+            "that expired 45 days ago"
+        )
+
+
+def test_t76b_rule_3_an_ancestor_that_has_gone_missing(store, clock):
+    """§5.3 rule 3 — a chain that cannot be walked to a root is not a valid chain."""
+    control = _control(_document(), store, clock)
+    chain = _chain(control, depth=2)
+
+    emptied = _control(f"{V3}\nauthority:\n  grants: []\n{ACTIONS}", store, clock)
+    with pytest.raises(AuthorityEscalation) as raised:
+        emptied.delegate(
+            chain[-1].delegation_id,
+            _child(subject=Subject(agent="agent-3", user="cfo@example.com")),
+            by=Principal(agent="agent-2", user="cfo@example.com"),
+        )
+    assert raised.value.reason == PARENT_NOT_VALID
+
+
+def test_a_row_whose_created_via_is_unknown_is_unreadable(store, clock):
+    """§5.2 — the column is what tells an act from an assertion, and `Delegation.created_via`
+    is typed on exactly the two values. A row outside them has provenance nobody can read."""
+    control = _control(_document(), store, clock)
+    store.put_delegation(
+        DelegationRecord(
+            delegation_id=f"dlg_{'b' * 32}",
+            parent_id="head-of-finance",
+            depth=1,
+            grant_json=grant_to_json(_child()),
+            created_by_agent="human-cfo",
+            created_by_user="cfo@example.com",
+            created_via="forged",
+            created_at=clock.now,
+        )
+    )
+    assert _denial(control, _action()).reason == AUTHORITY_UNREADABLE
+
+
+def test_a_stored_actions_that_is_not_a_list_is_unreadable(store, clock):
+    """§5.2 — reading a grant back validates what loading one from YAML validates.
+
+    A coerced `"actions": "stripe.refund"` would become thirteen single-character patterns,
+    every one grammar-valid, and the row would parse into a grant nobody wrote.
+    """
+    control = _control(_document(), store, clock)
+    store.put_delegation(
+        DelegationRecord(
+            delegation_id=f"dlg_{'c' * 32}",
+            parent_id="head-of-finance",
+            depth=1,
+            # `"refund"`, not `"stripe.refund"`: a coercion of the latter would produce a
+            # `"."` segment, which the pattern grammar refuses anyway — the row would be
+            # unreadable for a reason that is not this one, and the test would pass while
+            # exercising nothing. Every character of `"refund"` is a valid literal pattern.
+            grant_json=grant_to_json(_child()).replace(
+                '"actions":["stripe.refund"]', '"actions":"refund"'
+            ),
+            created_by_agent="human-cfo",
+            created_by_user="cfo@example.com",
+            created_via="api",
+            created_at=clock.now,
+        )
+    )
+    denied = _denial(control, _action())
+    assert denied.reason == AUTHORITY_UNREADABLE
+    # §13 ships no way to list delegations, so the event is the only way to find the row.
+    assert _data(store, EventType.AUTHORITY_DENIED)[-1]["delegation_id"] == f"dlg_{'c' * 32}"
+
+
 def test_t76b_rule_5_depth_is_walked_not_read(tmp_path, clock):
     """T76b — a chain whose stored `depth` column says otherwise is still too deep (§5.5)."""
     store = SQLiteStateStore(tmp_path / "state.db", clock=clock)
@@ -847,6 +943,71 @@ def test_t79_a_lowered_maximum_denies_an_existing_chain(store, clock):
     lowered = _control(_document(depth="  max_delegation_depth: 2\n"), store, clock)
     denied = _denial(lowered, _action(principal=Principal(agent="agent-3", user="cfo@example.com")))
     assert denied.reason == AUTHORITY_ESCALATION
+
+
+def test_the_walk_is_bounded_at_max_depth_plus_one_steps(store, clock):
+    """§5.5 — "the walk MUST be bounded", asserted as steps rather than as an outcome.
+
+    Once §5.6 rule 5 compares the walked depth to the maximum outright, the bound no longer
+    changes *what* a long chain decides — both refuse. What it still does is stop the walk
+    reading a hand-edited store to its end, and the only way to tell it ran is to count the
+    reads. A test asserting the denial alone could not tell the bound had been removed.
+    """
+    control = _control(_document(), store, clock)
+    #: 30 rows, each the parent of the next, none of them reachable through `Control.delegate`
+    #: and none of them reaching a root grant — so every one of them denies, and the only
+    #: thing left to measure is how far the walk got.
+    previous = "no-such-parent"
+    for index in range(30):
+        delegation_id = f"dlg_{index:032x}"
+        store.put_delegation(
+            DelegationRecord(
+                delegation_id=delegation_id,
+                parent_id=previous,
+                depth=index + 1,
+                grant_json=grant_to_json(_child()),
+                created_by_agent="human-cfo",
+                created_by_user="cfo@example.com",
+                created_via="api",
+                created_at=clock.now,
+            )
+        )
+        previous = delegation_id
+
+    reads: list[str] = []
+    original = store.get_delegation
+
+    def counting(delegation_id: str):
+        reads.append(delegation_id)
+        return original(delegation_id)
+
+    store.get_delegation = counting  # type: ignore[method-assign]
+    denied = _denial(control, _action())
+
+    assert denied.reason == AUTHORITY_ESCALATION
+    # Every one of the 30 rows matches the action's shape, so each is walked; a walk bounded
+    # at `max_delegation_depth + 1` reads at most that many parents per candidate.
+    assert reads, "the walk read nothing, so this test cannot see the bound at all"
+    assert len(reads) <= 30 * (control.authority.max_delegation_depth + 1)
+
+
+def test_t79_zero_denies_an_existing_depth_one_delegation(store, clock):
+    """T79 / §5.6 rule 5 — the depth-1 case, which the walk's bound never measures.
+
+    `_walk` returns as soon as it reaches a root grant, *before* it consults the bound, so a
+    chain that completes in one step is compared to nothing. Deeper chains truncate and deny,
+    which is what makes this the dangerous shape: `max_delegation_depth: 0` — §5.5's legible
+    way to switch delegation off — would appear to work while every existing depth-1
+    delegation, the common case, kept authorizing.
+    """
+    control = _control(_document(), store, clock)
+    control.delegate("head-of-finance", _child(), by=CFO)
+
+    switched_off = _control(_document(depth="  max_delegation_depth: 0\n"), store, clock)
+    denied = _denial(switched_off, _action())
+
+    assert denied.reason == AUTHORITY_ESCALATION
+    assert _data(store, EventType.AUTHORITY_DENIED)[-1]["depth_exceeded"] == 1
 
 
 def test_t79_zero_refuses_every_creation(store, clock):

--- a/tests/test_delegation.py
+++ b/tests/test_delegation.py
@@ -1,0 +1,1251 @@
+"""Delegation with attenuation. Build-list item 3; SPEC-v0.3 §5.
+
+The acceptance tests are T75 to T81. Four sentences run through all of them:
+
+**Containment is structural, and checked twice** (§5.4, §5.6). A delegated grant is valid only
+if it is provably a subset of its parent on every dimension — at the moment it is created *and*
+again every time it is evaluated. T77, T77b, T78 and T79 are the second half: a check performed
+only at creation would leave every delegation exactly as wide as the file used to be.
+
+**Omission is never "unlimited"** (§5.4, T81). A child that drops a dimension its parent
+constrains is rejected, not treated as inheriting the parent's limit and certainly not as
+unconstrained. Every one of those tests carries an `else` that fails with the delegation id it
+should not have got.
+
+**The two vocabularies are disjoint** (§5.3). Creation refuses with `AuthorityEscalation` and
+reasons like `containment`; evaluation denies with `AuthorityDenied` and reasons like
+`authority_escalation`. A test asserting one on the other is asserting a value that path never
+produces, so every assertion here names the reason.
+
+**A guard nothing can tell ran is not a guard.** §5.6's rules 1, 3, 4, 5 and 6 all yield
+`authority_escalation`, so the reason alone cannot distinguish them: these tests assert the
+`data` — `missing_parent_id`, `expired_parent_id`, `dimension`, `depth_exceeded`, `cycle_at` —
+as well.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from click.testing import CliRunner
+
+from ctrlrun import (
+    Action,
+    AmbiguousEffect,
+    ApprovalRequired,
+    Authority,
+    AuthorityDenied,
+    AuthorityEscalation,
+    Control,
+    Decision,
+    Delegation,
+    EffectState,
+    Grant,
+    IdentityError,
+    InMemoryStateStore,
+    InvalidArgument,
+    Policy,
+    Principal,
+    SQLiteStateStore,
+    Subject,
+    Suspended,
+    parse_conditions,
+)
+from ctrlrun.authority import (
+    AUTHORITY_CONSTRAINT,
+    AUTHORITY_ESCALATION,
+    AUTHORITY_GRANT,
+    AUTHORITY_REVOKED,
+    AUTHORITY_UNREADABLE,
+    CONTAINMENT,
+    MAX_DEPTH,
+    NOT_THE_SUBJECT,
+    PARENT_NOT_DELEGABLE,
+    PARENT_NOT_VALID,
+    UNKNOWN_PARENT,
+    grant_to_json,
+)
+from ctrlrun.cli.main import main
+from ctrlrun.control import PRINCIPAL_EXPIRED
+from ctrlrun.receipt import EventType, ReceiptResult
+from ctrlrun.state import DelegationRecord
+
+pytestmark = pytest.mark.authority
+
+V3 = "schema: ctrlrun.policy/v3\n"
+
+ACTIONS = """
+actions:
+  stripe.refund:
+    rules:
+      - when: { amount_lte: 50000 }
+        decision: allow
+      - decision: approve
+  deploy.rollout:
+    decision: allow
+"""
+
+#: The root grant of the signature scenario (§5.6), wide on every dimension a child narrows.
+FINANCE = """
+    - id: head-of-finance
+      subject: { agent: "human-cfo", user: "cfo@example.com" }
+      actions: ["stripe.**"]
+      resources: ["payment:EU-*"]
+      constraints: { amount_gte: 0, amount_lte: 10000000 }
+      environments: ["production", "staging"]
+      expires_at: "2027-01-01T00:00:00+00:00"
+      delegable: true
+"""
+
+#: A second root grant carrying one constraint per operator, so T76 can loosen each alone.
+OPS = """
+    - id: ops-lead
+      subject: { agent: "human-ops", user: "ops@example.com" }
+      actions: ["deploy.**"]
+      resources: ["service:EU-*"]
+      constraints:
+        replicas_gte: 0
+        replicas_lte: 100
+        tier_eq: "standard"
+        region_neq: "us-east-1"
+        cluster_in: ["eu-1", "eu-2", "eu-3"]
+      environments: ["production", "staging"]
+      expires_at: "2027-01-01T00:00:00+00:00"
+      delegable: true
+"""
+
+#: Not delegable, so §5.3 rule 2 has something to refuse.
+LOCKED = """
+    - id: locked-grant
+      subject: { agent: "human-cfo", user: "cfo@example.com" }
+      actions: ["stripe.**"]
+      environments: ["production"]
+"""
+
+CFO = Principal(agent="human-cfo", user="cfo@example.com")
+OPS_LEAD = Principal(agent="human-ops", user="ops@example.com")
+FINANCE_AGENT = Principal(agent="finance-agent", user="cfo@example.com")
+SUPPORT_AGENT = Principal(agent="support-agent", user="cfo@example.com")
+
+EXPIRES = datetime(2026, 12, 1, tzinfo=UTC)
+PARENT_EXPIRES = datetime(2027, 1, 1, tzinfo=UTC)
+
+
+class _Clock:
+    """Static: it moves only when a test moves it, so an expiry boundary is exact."""
+
+    def __init__(self) -> None:
+        self.now = datetime(2026, 9, 3, 10, 12, 1, tzinfo=UTC)
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, delta: timedelta) -> None:
+        self.now += delta
+
+
+class _Recorder:
+    """An `EventSink` that keeps what it was handed (SPEC-v0.2 §4.1)."""
+
+    def __init__(self) -> None:
+        self.events: list = []
+        self.receipts: list = []
+
+    def on_event(self, event) -> None:
+        self.events.append(event)
+
+    def on_receipt(self, receipt) -> None:
+        self.receipts.append(receipt)
+
+
+@pytest.fixture
+def clock():
+    return _Clock()
+
+
+@pytest.fixture
+def store(clock):
+    return InMemoryStateStore(clock=clock)
+
+
+@pytest.fixture(params=["in-memory", "sqlite"])
+def either_store(request, tmp_path, clock):
+    """Both shipped stores, one test body: §5.2's table lands in each (SPEC-v0.1 §5.3)."""
+    made = (
+        InMemoryStateStore(clock=clock)
+        if request.param == "in-memory"
+        else SQLiteStateStore(tmp_path / "state.db", clock=clock)
+    )
+    yield made
+    made.close()
+
+
+def _document(grants: str = FINANCE, *, depth: str = "", actions: str = ACTIONS) -> str:
+    return f"{V3}\nauthority:\n{depth}  grants:\n{grants}{actions}"
+
+
+def _control(document, store, clock, *, sinks=(), environment="production"):
+    """One document, both loaders — the shape `Control.from_file` builds (§4.8)."""
+    return Control(
+        Policy.from_yaml(document),
+        store,
+        authority=Authority.from_yaml(document),
+        clock=clock,
+        sinks=sinks,
+        environment=environment,
+    )
+
+
+def _constraints(mapping):
+    return parse_conditions(mapping, where="<test>")
+
+
+def _child(**overrides) -> Grant:
+    """A grant narrower than `head-of-finance` on every dimension at once (T75)."""
+    fields = {
+        "id": "",
+        "subject": Subject(agent="finance-agent", user="cfo@example.com"),
+        "actions": ("stripe.refund",),
+        "resources": ("payment:EU-4*",),
+        "constraints": _constraints({"amount_gte": 0, "amount_lte": 2500000}),
+        "environments": ("production",),
+        "expires_at": EXPIRES,
+        "delegable": True,
+    }
+    fields.update(overrides)
+    return Grant(**fields)
+
+
+def _ops_child(**overrides) -> Grant:
+    fields = {
+        "id": "",
+        "subject": Subject(agent="deploy-agent", user="ops@example.com"),
+        "actions": ("deploy.rollout",),
+        "resources": ("service:EU-4*",),
+        "constraints": _constraints(
+            {
+                "replicas_gte": 0,
+                "replicas_lte": 10,
+                "tier_eq": "standard",
+                "region_neq": "us-east-1",
+                "cluster_in": ["eu-1", "eu-2"],
+            }
+        ),
+        "environments": ("production",),
+        "expires_at": EXPIRES,
+        "delegable": False,
+    }
+    fields.update(overrides)
+    return Grant(**fields)
+
+
+def _action(**overrides) -> Action:
+    fields = {
+        "name": "stripe.refund",
+        "arguments": {"amount": 1000, "payment_id": "EU-42"},
+        "principal": FINANCE_AGENT,
+        "resource": "payment:EU-42",
+        "environment": "production",
+    }
+    fields.update(overrides)
+    return Action(**fields)
+
+
+def _types(store, action_id=None):
+    return [
+        str(event.type)
+        for event in store.events()
+        if action_id is None or event.action_id == action_id
+    ]
+
+
+def _data(store, type_):
+    return [dict(event.data) for event in store.events() if event.type is type_]
+
+
+def _denial(control, action) -> AuthorityDenied:
+    with pytest.raises(AuthorityDenied) as raised:
+        control.execute(action, lambda: "executed")
+    return raised.value
+
+
+# --- T75: a contained child is accepted -------------------------------------------------
+
+
+def test_t75_a_contained_child_is_accepted(either_store, clock):
+    """T75 — narrower on every dimension at once, and the record lands in either store."""
+    recorder = _Recorder()
+    control = _control(_document(), either_store, clock, sinks=[recorder])
+
+    delegation = control.delegate("head-of-finance", _child(), by=CFO)
+
+    assert delegation.delegation_id.startswith("dlg_")
+    assert len(delegation.delegation_id) == len("dlg_") + 32
+    assert int(delegation.delegation_id[4:], 16) >= 0
+    assert delegation.parent_id == "head-of-finance"
+    assert delegation.depth == 1
+    assert delegation.created_via == "api"
+    assert delegation.created_by == CFO
+    # §5.2 — `grant.id` for a delegation *is* its delegation_id: one namespace, both kinds.
+    assert delegation.grant.id == delegation.delegation_id
+
+    stored = either_store.get_delegation(delegation.delegation_id)
+    assert stored is not None
+    assert stored.parent_id == "head-of-finance"
+    assert stored.depth == 1
+    assert stored.created_by_agent == "human-cfo"
+    assert stored.created_by_user == "cfo@example.com"
+    assert stored.revoked_at is None
+
+    # §7 / T75 — the event reaches a registered sink, not merely the `events` table.
+    created = [event for event in recorder.events if event.type is EventType.DELEGATION_CREATED]
+    assert len(created) == 1
+    assert created[0].action_id is None
+    assert created[0].event_id is not None
+    assert created[0].data["delegation_id"] == delegation.delegation_id
+    assert created[0].data["parent_id"] == "head-of-finance"
+    assert created[0].data["depth"] == 1
+    assert created[0].data["created_by_agent"] == "human-cfo"
+    assert created[0].data["created_by_user"] == "cfo@example.com"
+    assert created[0].data["created_via"] == "api"
+
+
+def test_t75_the_delegation_authorizes_an_action_within_its_limits(store, clock):
+    """T75 — and authority names the delegation and its depth (§7)."""
+    control = _control(_document(), store, clock)
+    delegation = control.delegate("head-of-finance", _child(), by=CFO)
+
+    receipt = control.execute(_action(), lambda: "refunded")
+
+    assert receipt.decision_reason != AUTHORITY_GRANT  # §4.6 — the policy reason ties
+    resolved = _data(store, EventType.AUTHORITY_RESOLVED)
+    assert resolved == [
+        {
+            "reason": AUTHORITY_GRANT,
+            "grant_id": delegation.delegation_id,
+            "delegation_id": delegation.delegation_id,
+            "depth": 1,
+        }
+    ]
+
+
+def test_t75_a_grant_carrying_an_id_is_refused(store, clock):
+    """T75 — the id is assigned, not chosen (§5.2)."""
+    control = _control(_document(), store, clock)
+    with pytest.raises(InvalidArgument, match="assigned"):
+        control.delegate("head-of-finance", _child(id="chosen-by-the-caller"), by=CFO)
+    assert store.delegations(include_revoked=True) == ()
+
+
+def test_t75_creation_is_not_idempotent(store, clock):
+    """T75 — two identical calls make two records, each revocable on its own (§5.2)."""
+    control = _control(_document(), store, clock)
+    first = control.delegate("head-of-finance", _child(), by=CFO)
+    second = control.delegate("head-of-finance", _child(), by=CFO)
+
+    assert first.delegation_id != second.delegation_id
+    assert len(store.delegations(include_revoked=True)) == 2
+    assert len(_data(store, EventType.DELEGATION_CREATED)) == 2
+
+
+# --- T75b: only the parent's subject may delegate ----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "by",
+    [
+        pytest.param(Principal(agent="someone-else", user="cfo@example.com"), id="another-agent"),
+        pytest.param(Principal(agent="human-cfo"), id="no-user"),
+        pytest.param(Principal(agent="human-cfo", user="intern@example.com"), id="another-user"),
+    ],
+)
+def test_t75b_only_the_parents_subject_may_delegate(store, clock, by):
+    """T75b — you may only delegate authority you hold, including the `user` rule (§5.3 r4)."""
+    control = _control(_document(), store, clock)
+
+    with pytest.raises(AuthorityEscalation) as raised:
+        control.delegate("head-of-finance", _child(), by=by)
+
+    assert raised.value.reason == NOT_THE_SUBJECT
+    assert store.delegations(include_revoked=True) == ()
+    rejected = _data(store, EventType.DELEGATION_REJECTED)
+    assert rejected == [{"reason": NOT_THE_SUBJECT, "parent_id": "head-of-finance"}]
+
+
+# --- T76: each containment dimension, violated alone --------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("dimension", "overrides"),
+    [
+        ("actions", {"actions": ("**",)}),
+        ("resources", {"resources": ("payment:*",)}),
+        ("environments", {"environments": ("production", "dev")}),
+        ("expires_at", {"expires_at": datetime(2027, 6, 1, tzinfo=UTC)}),
+        ("subject", {"subject": Subject(agent="*", user="cfo@example.com")}),
+        ("subject", {"subject": Subject(user="cfo@example.com")}),
+        ("subject", {"subject": Subject(agent="finance-agent")}),
+        (
+            "constraints",
+            {"constraints": _constraints({"amount_gte": 0, "amount_lte": 20000000})},
+        ),
+        (
+            "constraints",
+            {"constraints": _constraints({"amount_gte": -1, "amount_lte": 2500000})},
+        ),
+    ],
+)
+def test_t76_each_dimension_violated_alone(store, clock, dimension, overrides):
+    """T76 — one dimension at a time, everything else contained (§5.4)."""
+    control = _control(_document(), store, clock)
+
+    with pytest.raises(AuthorityEscalation) as raised:
+        control.delegate("head-of-finance", _child(**overrides), by=CFO)
+
+    assert raised.value.reason == CONTAINMENT
+    assert raised.value.dimension == dimension
+    assert store.delegations(include_revoked=True) == ()
+    assert _data(store, EventType.DELEGATION_REJECTED) == [
+        {"reason": CONTAINMENT, "parent_id": "head-of-finance", "dimension": dimension}
+    ]
+
+
+@pytest.mark.parametrize(
+    "loosened",
+    [
+        pytest.param({"replicas_lte": 200}, id="lte-raised"),
+        pytest.param({"replicas_gte": -5}, id="gte-lowered"),
+        pytest.param({"tier_eq": "premium"}, id="eq-changed"),
+        pytest.param({"region_neq": "eu-west-1"}, id="neq-changed"),
+        pytest.param({"cluster_in": ["eu-1", "eu-2", "us-1"]}, id="in-widened"),
+    ],
+)
+def test_t76_each_constraint_operator_loosened_alone(store, clock, loosened):
+    """T76 — the operand-strictness table of §5.4, one operator at a time."""
+    control = _control(_document(FINANCE + OPS), store, clock)
+    base = {
+        "replicas_gte": 0,
+        "replicas_lte": 10,
+        "tier_eq": "standard",
+        "region_neq": "us-east-1",
+        "cluster_in": ["eu-1", "eu-2"],
+    }
+    child = _ops_child(constraints=_constraints({**base, **loosened}))
+
+    with pytest.raises(AuthorityEscalation) as raised:
+        control.delegate("ops-lead", child, by=OPS_LEAD)
+
+    assert raised.value.reason == CONTAINMENT
+    assert raised.value.dimension == "constraints"
+    assert store.delegations(include_revoked=True) == ()
+
+
+def test_t76_a_child_may_add_a_constraint_its_parent_does_not_have(store, clock):
+    """§5.4 — narrowing is the point; only loosening and omission are refused."""
+    control = _control(_document(FINANCE + OPS), store, clock)
+    child = _ops_child(
+        constraints=_constraints(
+            {
+                "replicas_gte": 0,
+                "replicas_lte": 10,
+                "tier_eq": "standard",
+                "region_neq": "us-east-1",
+                "cluster_in": ["eu-1"],
+                "batch_lte": 4,
+            }
+        )
+    )
+    assert control.delegate("ops-lead", child, by=OPS_LEAD).depth == 1
+
+
+# --- T76b: the creation-time rules that are not containment -------------------------------
+
+
+def test_t76b_rule_0_an_expired_credential_mints_nothing(store, clock):
+    """T76b — the rule that matters: an expired `by` may not create authority (§5.3 r0)."""
+    control = _control(_document(), store, clock)
+    expired = Principal(
+        agent="human-cfo",
+        user="cfo@example.com",
+        expires_at=clock.now - timedelta(minutes=5),
+    )
+
+    try:
+        delegation = control.delegate("head-of-finance", _child(), by=expired)
+    except IdentityError:
+        pass
+    else:
+        raise AssertionError(
+            "SPEC-v0.3 §5.3 rule 0: an expired credential minted "
+            f"{delegation.delegation_id}, which is permanent, unexpiring authority created "
+            "by a principal whose every proposed action is refused"
+        )
+
+    assert store.delegations(include_revoked=True) == ()
+    assert _data(store, EventType.DELEGATION_REJECTED) == [
+        {"reason": PRINCIPAL_EXPIRED, "parent_id": "head-of-finance"}
+    ]
+
+
+def test_t76b_rule_1_an_unknown_parent(store, clock):
+    control = _control(_document(), store, clock)
+    with pytest.raises(AuthorityEscalation) as raised:
+        control.delegate("no-such-grant", _child(), by=CFO)
+    assert raised.value.reason == UNKNOWN_PARENT
+    assert store.delegations(include_revoked=True) == ()
+    assert _data(store, EventType.DELEGATION_REJECTED) == [
+        {"reason": UNKNOWN_PARENT, "parent_id": "no-such-grant"}
+    ]
+
+
+def test_t76b_rule_1_a_revoked_parent_is_not_a_live_delegation(store, clock):
+    """§5.3 rule 1 — "a root grant or a *live* delegation"; a revoked one is neither."""
+    control = _control(_document(), store, clock)
+    parent = control.delegate("head-of-finance", _child(), by=CFO)
+    control.revoke(parent.delegation_id, by="cli:local")
+
+    with pytest.raises(AuthorityEscalation) as raised:
+        control.delegate(
+            parent.delegation_id,
+            _child(subject=Subject(agent="support-agent", user="cfo@example.com")),
+            by=FINANCE_AGENT,
+        )
+    assert raised.value.reason == UNKNOWN_PARENT
+
+
+def test_t76b_rule_2_a_parent_that_is_not_delegable(store, clock):
+    control = _control(_document(FINANCE + LOCKED), store, clock)
+    with pytest.raises(AuthorityEscalation) as raised:
+        control.delegate(
+            "locked-grant",
+            _child(resources=None, expires_at=None, delegable=False),
+            by=CFO,
+        )
+    assert raised.value.reason == PARENT_NOT_DELEGABLE
+    assert _data(store, EventType.DELEGATION_REJECTED) == [
+        {"reason": PARENT_NOT_DELEGABLE, "parent_id": "locked-grant"}
+    ]
+
+
+def test_t76b_rule_3_an_expired_parent(store, clock):
+    control = _control(_document(), store, clock)
+    clock.advance(PARENT_EXPIRES - clock.now + timedelta(seconds=1))
+
+    with pytest.raises(AuthorityEscalation) as raised:
+        control.delegate("head-of-finance", _child(), by=CFO)
+    assert raised.value.reason == PARENT_NOT_VALID
+
+
+def test_t76b_rule_3_a_parent_whose_own_parent_is_revoked(store, clock):
+    control = _control(_document(), store, clock)
+    first = control.delegate("head-of-finance", _child(), by=CFO)
+    second = control.delegate(
+        first.delegation_id,
+        _child(subject=Subject(agent="support-agent", user="cfo@example.com")),
+        by=FINANCE_AGENT,
+    )
+    control.revoke(first.delegation_id)
+
+    with pytest.raises(AuthorityEscalation) as raised:
+        control.delegate(
+            second.delegation_id,
+            _child(subject=Subject(agent="ledger-agent", user="cfo@example.com")),
+            by=SUPPORT_AGENT,
+        )
+    assert raised.value.reason == PARENT_NOT_VALID
+    assert store.get_delegation(second.delegation_id) is not None
+
+
+def test_t76b_rule_3_an_ancestor_that_is_no_longer_delegable(store, clock):
+    """§5.3 rule 3 covers `delegable` across the whole chain, not just the parent."""
+    control = _control(_document(), store, clock)
+    first = control.delegate("head-of-finance", _child(), by=CFO)
+
+    narrowed = _control(
+        _document(FINANCE.replace("delegable: true", "delegable: false")), store, clock
+    )
+    with pytest.raises(AuthorityEscalation) as raised:
+        narrowed.delegate(
+            first.delegation_id,
+            _child(subject=Subject(agent="support-agent", user="cfo@example.com")),
+            by=FINANCE_AGENT,
+        )
+    assert raised.value.reason == PARENT_NOT_VALID
+
+
+def test_t76b_rule_5_depth_is_walked_not_read(tmp_path, clock):
+    """T76b — a chain whose stored `depth` column says otherwise is still too deep (§5.5)."""
+    store = SQLiteStateStore(tmp_path / "state.db", clock=clock)
+    control = _control(_document(), store, clock)
+    chain = _chain(control, depth=3)
+    _rewrite(store, chain[-1].delegation_id, depth=0)
+
+    with pytest.raises(AuthorityEscalation) as raised:
+        control.delegate(
+            chain[-1].delegation_id,
+            _child(subject=Subject(agent="agent-4", user="cfo@example.com")),
+            by=Principal(agent="agent-3", user="cfo@example.com"),
+        )
+    assert raised.value.reason == MAX_DEPTH
+    store.close()
+
+
+@pytest.mark.parametrize(
+    ("reason", "parent"),
+    [
+        (UNKNOWN_PARENT, "no-such-grant"),
+        (PARENT_NOT_DELEGABLE, "locked-grant"),
+    ],
+)
+def test_t76b_no_dimension_where_no_row_failed(store, clock, reason, parent):
+    """§7 — `dimension` is present *only* for a §5.3 rule-6 containment refusal."""
+    control = _control(_document(FINANCE + LOCKED), store, clock)
+    with pytest.raises(AuthorityEscalation) as raised:
+        control.delegate(parent, _child(resources=None, expires_at=None, delegable=False), by=CFO)
+    assert raised.value.reason == reason
+    assert raised.value.dimension is None
+    assert "dimension" not in _data(store, EventType.DELEGATION_REJECTED)[0]
+
+
+# --- T77: valid at creation, invalid later -------------------------------------------------
+
+
+def test_t77_a_parent_that_expires_after_creation(store, clock):
+    """T77 — the check is at evaluation, and it does not rewrite the record (§5.6 r3)."""
+    control = _control(_document(), store, clock)
+    delegation = control.delegate("head-of-finance", _child(), by=CFO)
+    before = store.get_delegation(delegation.delegation_id)
+
+    clock.advance(PARENT_EXPIRES - clock.now + timedelta(seconds=1))
+    denied = _denial(control, _action())
+
+    assert denied.reason == AUTHORITY_ESCALATION
+    assert _data(store, EventType.AUTHORITY_DENIED)[-1]["expired_parent_id"] == "head-of-finance"
+    assert store.get_delegation(delegation.delegation_id) == before
+
+
+def test_t77b_a_narrowed_parent_narrows_its_children(store, clock):
+    """T77b — the file half: narrowing a root grant narrows everything beneath it.
+
+    The acting principal holds two grants at once — the root grant, whose subject is
+    `agent: "*"` acting for this human, and the delegation. That is what makes both halves of
+    T77b observable from one configuration: after the edit the delegation is no longer
+    contained, so it denies with `authority_escalation`, while the narrowed root grant still
+    authorizes what fits inside it (§4.6: holding two permissions is never worse than one).
+    """
+    wide = """
+    - id: alices-agents
+      subject: { agent: "*", user: "alice@example.com" }
+      actions: ["stripe.**"]
+      constraints: { amount_lte: 100000 }
+      expires_at: "2027-01-01T00:00:00+00:00"
+      delegable: true
+"""
+    alice = Principal(agent="orchestrator", user="alice@example.com")
+    control = _control(_document(wide), store, clock)
+    child = Grant(
+        id="",
+        subject=Subject(agent="finance-agent", user="alice@example.com"),
+        actions=("stripe.refund",),
+        constraints=_constraints({"amount_lte": 25000}),
+        expires_at=EXPIRES,
+    )
+    control.delegate("alices-agents", child, by=alice)
+
+    narrowed = _control(
+        _document(wide.replace("amount_lte: 100000", "amount_lte: 5000")), store, clock
+    )
+    acting = Principal(agent="finance-agent", user="alice@example.com")
+
+    denied = _denial(
+        narrowed, _action(principal=acting, arguments={"amount": 10000}, resource=None)
+    )
+    assert denied.reason == AUTHORITY_ESCALATION
+    assert _data(store, EventType.AUTHORITY_DENIED)[-1]["dimension"] == "constraints"
+
+    narrowed.execute(
+        _action(principal=acting, arguments={"amount": 4000}, resource=None), lambda: "refunded"
+    )
+    assert _data(store, EventType.AUTHORITY_RESOLVED)[-1]["grant_id"] == "alices-agents"
+
+
+def test_t77b_a_parent_that_is_no_longer_delegable_stops_its_children(store, clock):
+    """T77b — §5.6 rule 6, which rule 4 would never see: `delegable` is not a §5.4 row."""
+    control = _control(_document(), store, clock)
+    control.delegate("head-of-finance", _child(), by=CFO)
+
+    stopped = _control(
+        _document(FINANCE.replace("delegable: true", "delegable: false")), store, clock
+    )
+    denied = _denial(stopped, _action())
+
+    assert denied.reason == AUTHORITY_ESCALATION
+    denial = _data(store, EventType.AUTHORITY_DENIED)[-1]
+    assert "dimension" not in denial
+    assert "missing_parent_id" not in denial
+
+
+def test_t77c_a_deleted_parent_is_not_no_authority(store, clock):
+    """T77c — the reason distinguishes a broken chain from a principal who never had one."""
+    control = _control(_document(), store, clock)
+    chain = _chain(control, depth=2)
+
+    emptied = _control(f"{V3}\nauthority:\n  grants: []\n{ACTIONS}", store, clock)
+    denied = _denial(emptied, _action(principal=Principal(agent="agent-2", user="cfo@example.com")))
+
+    assert denied.reason == AUTHORITY_ESCALATION
+    assert denied.reason != "no_authority"
+    assert denied.delegation_id == chain[-1].delegation_id
+    assert _data(store, EventType.AUTHORITY_DENIED)[-1]["missing_parent_id"] == "head-of-finance"
+
+
+def test_t77d_a_cyclic_chain_is_unreadable(tmp_path, clock):
+    """T77d — a cycle is a hand-edited store, not an ordinary escalation (§5.5)."""
+    store = SQLiteStateStore(tmp_path / "state.db", clock=clock)
+    control = _control(_document(), store, clock)
+    chain = _chain(control, depth=2)
+    # Two rows that are each other's parent, reachable only with sqlite3 and a text editor.
+    _rewrite(store, chain[0].delegation_id, parent_id=chain[1].delegation_id)
+
+    denied = _denial(control, _action(principal=Principal(agent="agent-2", user="cfo@example.com")))
+
+    assert denied.reason == AUTHORITY_UNREADABLE
+    assert _data(store, EventType.AUTHORITY_DENIED)[-1]["cycle_at"] == chain[1].delegation_id
+    store.close()
+
+
+def test_t77d_an_over_deep_chain_is_an_escalation(store, clock):
+    """T77d — the other half, asserted by `data` as well as by reason (§5.5)."""
+    control = _control(_document(), store, clock)
+    _chain(control, depth=3)
+
+    lowered = _control(_document(depth="  max_delegation_depth: 2\n"), store, clock)
+    denied = _denial(lowered, _action(principal=Principal(agent="agent-3", user="cfo@example.com")))
+
+    assert denied.reason == AUTHORITY_ESCALATION
+    assert _data(store, EventType.AUTHORITY_DENIED)[-1]["depth_exceeded"] == 3
+
+
+def test_t77d_a_delegation_id_outside_the_namespace_is_unreadable(store, clock):
+    """T77d / §5.2 — a row whose id is not `dlg_` + 32 hex is a corrupted record.
+
+    The `grant_json` here is **well formed and contained**, deliberately. A row carrying junk
+    would be refused by the parse anyway, so the id check would be a subsumed guard that no
+    test could tell had run. With this row, removing the namespace check does not change the
+    reason — it authorizes the action, which is what §5.2's "a hand-inserted row named
+    `head-of-finance` would shadow the root grant of that name" is warning about.
+    """
+    control = _control(_document(), store, clock)
+    store.put_delegation(
+        DelegationRecord(
+            delegation_id="head-of-finance",
+            parent_id="head-of-finance",
+            depth=1,
+            grant_json=grant_to_json(_child()),
+            created_by_agent="human-cfo",
+            created_by_user="cfo@example.com",
+            created_via="api",
+            created_at=clock.now,
+        )
+    )
+    denied = _denial(control, _action())
+    assert denied.reason == AUTHORITY_UNREADABLE
+
+
+def test_put_delegation_is_never_an_upsert(either_store, clock):
+    """§5.2, §5.7 — an upsert on an existing id would clear `revoked_at`: `unrevoke` by
+    another door, in a release that says there is no such thing."""
+    control = _control(_document(), either_store, clock)
+    delegation = control.delegate("head-of-finance", _child(), by=CFO)
+    control.revoke(delegation.delegation_id, by="incident")
+
+    with pytest.raises(InvalidArgument, match="already exists"):
+        either_store.put_delegation(delegation.to_record())
+
+    assert either_store.get_delegation(delegation.delegation_id).revoked_at is not None
+
+
+def test_t77d_an_unreadable_grant_is_never_skipped(store, clock):
+    """§4.6 — the permissive reading is the one an implementer reaches for naturally."""
+    control = _control(_document(), store, clock)
+    store.put_delegation(
+        DelegationRecord(
+            delegation_id=f"dlg_{'a' * 32}",
+            parent_id="head-of-finance",
+            depth=1,
+            grant_json="{not json at all",
+            created_by_agent="human-cfo",
+            created_by_user="cfo@example.com",
+            created_via="api",
+            created_at=clock.now,
+        )
+    )
+    denied = _denial(control, _action(principal=CFO, arguments={"amount": 1000}))
+    assert denied.reason == AUTHORITY_UNREADABLE
+
+
+# --- T78: a revoked parent denies -----------------------------------------------------------
+
+
+def test_t78_a_revoked_parent_denies_its_grandchild(store, clock):
+    """T78 — revocation is transitive by structure: a chain of any depth, cut by one write."""
+    recorder = _Recorder()
+    control = _control(_document(), store, clock, sinks=[recorder])
+    chain = _chain(control, depth=3)
+
+    control.revoke(chain[1].delegation_id, by="cli:local")
+
+    revoked = [event for event in recorder.events if event.type is EventType.DELEGATION_REVOKED]
+    assert len(revoked) == 1
+    assert revoked[0].action_id is None
+    assert revoked[0].data == {
+        "delegation_id": chain[1].delegation_id,
+        "revoked_by": "cli:local",
+    }
+
+    denied = _denial(control, _action(principal=Principal(agent="agent-3", user="cfo@example.com")))
+    assert denied.reason == AUTHORITY_REVOKED
+
+    # Re-revoking is idempotent: it appends no second event and raises nothing.
+    control.revoke(chain[1].delegation_id, by="cli:local")
+    assert len(_data(store, EventType.DELEGATION_REVOKED)) == 1
+
+
+def test_t78_revoking_an_unknown_delegation_refuses(store, clock):
+    control = _control(_document(), store, clock)
+    with pytest.raises(InvalidArgument):
+        control.revoke(f"dlg_{'0' * 32}")
+    assert _data(store, EventType.DELEGATION_REVOKED) == []
+
+
+# --- T79: depth beyond the maximum ----------------------------------------------------------
+
+
+def test_t79_depth_beyond_the_maximum_is_rejected(store, clock):
+    """T79 — one long-lived Control, so a check that only ran at construction fails red."""
+    control = _control(_document(), store, clock)
+    chain = _chain(control, depth=3)
+    assert [link.depth for link in chain] == [1, 2, 3]
+
+    with pytest.raises(AuthorityEscalation) as raised:
+        control.delegate(
+            chain[-1].delegation_id,
+            _child(subject=Subject(agent="agent-4", user="cfo@example.com")),
+            by=Principal(agent="agent-3", user="cfo@example.com"),
+        )
+    assert raised.value.reason == MAX_DEPTH
+    assert len(store.delegations(include_revoked=True)) == 3
+
+
+def test_t79_a_lowered_maximum_denies_an_existing_chain(store, clock):
+    control = _control(_document(), store, clock)
+    _chain(control, depth=3)
+
+    lowered = _control(_document(depth="  max_delegation_depth: 2\n"), store, clock)
+    denied = _denial(lowered, _action(principal=Principal(agent="agent-3", user="cfo@example.com")))
+    assert denied.reason == AUTHORITY_ESCALATION
+
+
+def test_t79_zero_refuses_every_creation(store, clock):
+    control = _control(_document(depth="  max_delegation_depth: 0\n"), store, clock)
+    with pytest.raises(AuthorityEscalation) as raised:
+        control.delegate("head-of-finance", _child(), by=CFO)
+    assert raised.value.reason == MAX_DEPTH
+    assert store.delegations(include_revoked=True) == ()
+
+
+# --- T80: the signature scenario ------------------------------------------------------------
+
+
+@pytest.fixture
+def signature(store, clock):
+    """€100,000 delegable → finance agent €25,000 → support agent €2,000 (§5.6)."""
+    control = _control(_document(), store, clock)
+    finance = control.delegate(
+        "head-of-finance",
+        _child(constraints=_constraints({"amount_gte": 0, "amount_lte": 2500000})),
+        by=CFO,
+    )
+    support = control.delegate(
+        finance.delegation_id,
+        _child(
+            subject=Subject(agent="support-agent", user="cfo@example.com"),
+            constraints=_constraints({"amount_gte": 0, "amount_lte": 200000}),
+            delegable=False,
+        ),
+        by=FINANCE_AGENT,
+    )
+    return control, finance, support
+
+
+def test_t80_fifty_thousand_euros_is_denied(signature, store):
+    """T80 — the support agent asks for €50,000 and the remote is never called."""
+    control, _, support = signature
+    calls: list[str] = []
+
+    denied = _denial(
+        control,
+        _action(principal=SUPPORT_AGENT, arguments={"amount": 5000000, "payment_id": "EU-42"}),
+    )
+
+    assert denied.reason == AUTHORITY_CONSTRAINT
+    assert denied.grant_id == support.delegation_id
+    assert calls == []
+    assert EventType.POLICY_EVALUATED not in [event.type for event in store.events()]
+
+
+def test_t80_fifteen_hundred_euros_reaches_policy(signature, store):
+    """T80 — €1,500 passes authority; policy then decides how much autonomy it has."""
+    control, _, support = signature
+    action = _action(principal=SUPPORT_AGENT, arguments={"amount": 150000, "payment_id": "EU-42"})
+
+    with pytest.raises(ApprovalRequired):
+        control.execute(action, lambda: "refunded")
+
+    assert _data(store, EventType.AUTHORITY_RESOLVED)[-1] == {
+        "reason": AUTHORITY_GRANT,
+        "grant_id": support.delegation_id,
+        "delegation_id": support.delegation_id,
+        "depth": 2,
+    }
+    assert "POLICY_EVALUATED" in _types(store, action.action_id)
+
+
+def test_t80_the_finance_agent_may_not_delegate_more_than_it_holds(signature, store):
+    """T80 — the containment guard: €50,000 under a €25,000 parent (§5.3 rule 6)."""
+    control, finance, _ = signature
+
+    with pytest.raises(AuthorityEscalation) as raised:
+        control.delegate(
+            finance.delegation_id,
+            _child(
+                subject=Subject(agent="support-agent", user="cfo@example.com"),
+                constraints=_constraints({"amount_gte": 0, "amount_lte": 5000000}),
+                delegable=False,
+            ),
+            by=FINANCE_AGENT,
+        )
+
+    assert raised.value.reason == CONTAINMENT
+    assert raised.value.dimension == "constraints"
+    assert len(store.delegations(include_revoked=True)) == 2
+
+
+def test_t80_the_support_agent_may_not_delegate_at_all(signature, store):
+    """T80 — a different guard, asserted separately so neither stands in for the other."""
+    control, _, support = signature
+
+    with pytest.raises(AuthorityEscalation) as raised:
+        control.delegate(
+            support.delegation_id,
+            _child(
+                subject=Subject(agent="intern-agent", user="cfo@example.com"),
+                constraints=_constraints({"amount_gte": 0, "amount_lte": 1000}),
+                delegable=False,
+            ),
+            by=SUPPORT_AGENT,
+        )
+
+    assert raised.value.reason == PARENT_NOT_DELEGABLE
+    assert len(store.delegations(include_revoked=True)) == 2
+
+
+# --- T80b: authority across an action already under way ---------------------------------------
+
+
+def test_t80b_an_outcome_is_committed_even_after_the_chain_is_revoked(signature, store, clock):
+    """T80b — the effect has already happened at the remote (§5.6.1, row 1).
+
+    Refusing the write would strand it in `AMBIGUOUS` for an authorization reason, which is
+    what `v0.1 §5.5` exists to prevent.
+    """
+    control, finance, _ = signature
+    action = _action(principal=SUPPORT_AGENT, arguments={"amount": 1000, "payment_id": "EU-42"})
+
+    def executor() -> str:
+        control.revoke(finance.delegation_id, by="incident")
+        return "refunded"
+
+    receipt = control.execute(action, executor, effect_key="refund:EU-42")
+
+    assert receipt.result is ReceiptResult.COMMITTED
+    assert store.get_effect("refund:EU-42").state is EffectState.COMMITTED
+
+
+def test_t80b_a_lease_extension_is_refused_and_the_record_lapses(signature, store, clock):
+    """T80b — an extension asks to keep holding a reservation the chain no longer authorizes.
+
+    Refused, and the record is deliberately not moved: the lease lapses and it becomes
+    `AMBIGUOUS` by the ordinary path of `v0.1 §5.3 E3`, which is the safe state reached without
+    inventing one. Without this, §5.7's "a chain of any depth is cut by one write" is false for
+    exactly the actions in flight when an operator hits the switch.
+    """
+    control, finance, _ = signature
+    action = _action(principal=SUPPORT_AGENT, arguments={"amount": 1000, "payment_id": "EU-42"})
+
+    def executor() -> str:
+        control.revoke(finance.delegation_id, by="incident")
+        raise Suspended("opaque-state-from-the-server")
+
+    with pytest.raises(AuthorityDenied) as raised:
+        control.execute(action, executor, effect_key="refund:EU-42", lease=timedelta(minutes=1))
+
+    assert raised.value.reason == AUTHORITY_REVOKED
+    assert store.get_effect("refund:EU-42").state is EffectState.EXECUTING
+
+    # The lapse is the ordinary path of `v0.1 §5.3 E3` and owes nothing to authority, so it is
+    # asserted against the store: a second `execute` would be refused by the revoked chain
+    # first and could not tell anyone whether the record had moved.
+    clock.advance(timedelta(minutes=2))
+    with pytest.raises(AmbiguousEffect):
+        store.reserve_effect("refund:EU-42", "act_another")
+
+
+def test_t80b_resume_records_the_denial_and_does_not_re_decide(signature, store, clock):
+    """T80b — §5.6.1 row 3: the reservation is held and the remote may already be acting.
+
+    The resumed leg is the only receipt an MCP multi round-trip or ACS action ever gets (§8.3),
+    so it carries the combined §4.6 decision rather than a bare policy reason.
+    """
+    control, finance, _ = signature
+    action = _action(principal=SUPPORT_AGENT, arguments={"amount": 1000, "payment_id": "EU-42"})
+
+    with pytest.raises(Suspended):
+        control.execute(
+            action,
+            lambda: (_ for _ in ()).throw(Suspended("continue-me")),
+            effect_key="refund:EU-42",
+        )
+    control.revoke(finance.delegation_id, by="incident")
+
+    receipt = control.resume("continue-me", lambda: "refunded")
+
+    assert receipt.result is ReceiptResult.COMMITTED
+    assert receipt.decision is Decision.DENY
+    assert receipt.decision_reason == AUTHORITY_REVOKED
+    assert _data(store, EventType.AUTHORITY_DENIED)[-1]["reason"] == AUTHORITY_REVOKED
+
+
+# --- §5.7's two CLI commands ------------------------------------------------------------------
+
+
+CLI_DOCUMENT = _document()
+
+CLI_GRANT = """
+subject: { agent: "finance-agent", user: "cfo@example.com" }
+actions: ["stripe.refund"]
+resources: ["payment:EU-4*"]
+constraints: { amount_gte: 0, amount_lte: 2500000 }
+environments: ["production"]
+expires_at: "2026-12-01T00:00:00+00:00"
+delegable: true
+"""
+
+
+@pytest.fixture
+def cli_workspace(tmp_path, monkeypatch):
+    (tmp_path / "ctrlrun.yaml").write_text(CLI_DOCUMENT, encoding="utf-8")
+    (tmp_path / "grant.yaml").write_text(CLI_GRANT, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("CTRLRUN_CONFIG", raising=False)
+    monkeypatch.delenv("CTRLRUN_STATE", raising=False)
+    return tmp_path
+
+
+def _cli(*arguments):
+    return CliRunner().invoke(main, list(arguments))
+
+
+def _created_id(workspace) -> str:
+    result = _cli(
+        "delegate",
+        "--parent",
+        "head-of-finance",
+        "--file",
+        "grant.yaml",
+        "--as",
+        "human-cfo/cfo@example.com",
+        "--json",
+    )
+    assert result.exit_code == 0, result.output
+    return str(json.loads(result.output)["delegation_id"])
+
+
+def test_the_cli_records_created_via_cli(cli_workspace):
+    """T75b — `--as` is an assertion, and §5.2's column is what says so."""
+    delegation_id = _created_id(cli_workspace)
+
+    store = SQLiteStateStore(cli_workspace / ".ctrlrun" / "state.db")
+    try:
+        record = store.get_delegation(delegation_id)
+        assert record is not None
+        assert record.created_via == "cli"
+        assert record.created_by_agent == "human-cfo"
+        assert record.created_by_user == "cfo@example.com"
+    finally:
+        store.close()
+
+    written = [
+        json.loads(line)
+        for line in (cli_workspace / ".ctrlrun" / "events.jsonl").read_text().splitlines()
+    ]
+    assert written[-1]["type"] == "DELEGATION_CREATED"
+    assert written[-1]["action_id"] is None
+    assert written[-1]["data"]["created_via"] == "cli"
+
+
+def test_the_cli_refuses_a_delegator_the_parent_does_not_admit(cli_workspace):
+    """T75b, at the CLI: §5.3 rule 4 is checked here too, and the exit is non-zero."""
+    result = _cli(
+        "delegate",
+        "--parent",
+        "head-of-finance",
+        "--file",
+        "grant.yaml",
+        "--as",
+        "someone-else",
+    )
+    assert result.exit_code != 0
+    assert NOT_THE_SUBJECT in result.output
+
+
+def test_the_cli_refuses_a_grant_document_carrying_an_id(cli_workspace):
+    """§5.2 — the id is assigned, not chosen, and the `--file` path says so at load."""
+    (cli_workspace / "grant.yaml").write_text(f"id: chosen\n{CLI_GRANT}", encoding="utf-8")
+    result = _cli(
+        "delegate",
+        "--parent",
+        "head-of-finance",
+        "--file",
+        "grant.yaml",
+        "--as",
+        "human-cfo/cfo@example.com",
+    )
+    assert result.exit_code != 0
+    assert "assigned, not chosen" in result.output
+
+
+def test_ctrlrun_revoke_is_idempotent_and_refuses_an_unknown_id(cli_workspace):
+    """T78, at the CLI: `DELEGATION_REVOKED` once, exit 0 twice, and an unknown id is not 0."""
+    delegation_id = _created_id(cli_workspace)
+
+    first = _cli("revoke", delegation_id)
+    second = _cli("revoke", delegation_id)
+    unknown = _cli("revoke", f"dlg_{'0' * 32}")
+
+    assert first.exit_code == 0
+    assert second.exit_code == 0
+    assert "already revoked" in second.output
+    assert unknown.exit_code != 0
+    assert unknown.stdout == ""
+
+    written = [
+        json.loads(line)
+        for line in (cli_workspace / ".ctrlrun" / "events.jsonl").read_text().splitlines()
+    ]
+    revoked = [line for line in written if line["type"] == "DELEGATION_REVOKED"]
+    assert len(revoked) == 1
+    assert revoked[0]["data"] == {"delegation_id": delegation_id, "revoked_by": "cli:local"}
+
+
+# --- T81: omission is not "unlimited" -------------------------------------------------------
+
+
+OMISSION = """
+    - id: bounded
+      subject: { agent: "human-cfo", user: "cfo@example.com" }
+      actions: ["stripe.**"]
+      resources: ["payment:EU-*"]
+      constraints: { amount_lte: 25000 }
+      environments: ["production"]
+      expires_at: "2027-01-01T00:00:00+00:00"
+      delegable: true
+"""
+
+
+def _omitting(**overrides) -> Grant:
+    fields = {
+        "id": "",
+        "subject": Subject(agent="finance-agent", user="cfo@example.com"),
+        "actions": ("stripe.refund",),
+        "resources": ("payment:EU-4*",),
+        "constraints": _constraints({"amount_lte": 20000}),
+        "environments": ("production",),
+        "expires_at": EXPIRES,
+    }
+    fields.update(overrides)
+    return Grant(**fields)
+
+
+@pytest.mark.parametrize(
+    ("dimension", "overrides"),
+    [
+        ("constraints", {"constraints": {}}),
+        ("resources", {"resources": None}),
+        ("environments", {"environments": None}),
+        ("expires_at", {"expires_at": None}),
+        ("subject", {"subject": Subject(agent="finance-agent")}),
+        ("subject", {"subject": Subject(user="cfo@example.com")}),
+    ],
+)
+def test_t81_omission_is_not_unlimited(store, clock, dimension, overrides):
+    """T81 — the one that matters: a child that drops a dimension is rejected, not inherited.
+
+    Not accepted-and-inherited, and not accepted-and-unconstrained. A child that silently
+    inherited would look, in the file and in the receipt, like a child that was authorized for
+    what it says. The last two rows are the cases where an omitted key means "anyone" rather
+    than "nothing" (§5.4).
+    """
+    control = _control(_document(OMISSION), store, clock)
+
+    try:
+        delegation = control.delegate("bounded", _omitting(**overrides), by=CFO)
+    except AuthorityEscalation as raised:
+        assert raised.reason == CONTAINMENT
+        assert raised.dimension == dimension
+    else:
+        raise AssertionError(
+            f"SPEC-v0.3 §5.4: a child omitting {dimension!r} under a parent that constrains it "
+            f"was created as {delegation.delegation_id}; omission never means unlimited"
+        )
+
+    assert store.delegations(include_revoked=True) == ()
+
+
+# --- helpers that build chains and edit the store by hand ------------------------------------
+
+
+def _chain(control: Control, *, depth: int) -> list[Delegation]:
+    """A chain of `depth` delegations beneath `head-of-finance`, agent-1 … agent-N."""
+    links: list[Delegation] = []
+    parent_id = "head-of-finance"
+    by = CFO
+    for level in range(1, depth + 1):
+        agent = f"agent-{level}"
+        links.append(
+            control.delegate(
+                parent_id,
+                _child(subject=Subject(agent=agent, user="cfo@example.com")),
+                by=by,
+            )
+        )
+        parent_id = links[-1].delegation_id
+        by = Principal(agent=agent, user="cfo@example.com")
+    return links
+
+
+def _rewrite(store: SQLiteStateStore, delegation_id: str, **columns) -> None:
+    """Edit a `delegations` row directly, the way §5.5 says an attacker would."""
+    assignments = ", ".join(f"{column}=?" for column in columns)
+    connection = sqlite3.connect(store.path)
+    try:
+        connection.execute(
+            f"UPDATE delegations SET {assignments} WHERE delegation_id=?",
+            (*columns.values(), delegation_id),
+        )
+        connection.commit()
+    finally:
+        connection.close()

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -953,7 +953,7 @@ def test_an_empty_CTRLRUN_CONFIG_is_refused(workspace, monkeypatch):
 
 
 def test_the_cli_offers_exactly_the_commands_the_spec_freezes():
-    """SPEC-v0.1 §8, plus what SPEC-v0.2 §11 adds."""
+    """SPEC-v0.1 §8, plus what SPEC-v0.2 §11 and SPEC-v0.3 §11 add."""
     assert set(main.commands) == {
         "init",
         "demo",
@@ -964,6 +964,9 @@ def test_the_cli_offers_exactly_the_commands_the_spec_freezes():
         "resolve",
         "inspect",
         "gateway",
+        # SPEC-v0.3 §5.7 — build-list item 3. `stats` and `verify` land with item 4.
+        "delegate",
+        "revoke",
     }
 
 
@@ -973,6 +976,8 @@ def test_the_cli_offers_exactly_the_commands_the_spec_freezes():
         ("receipts", {"--last", "--json"}),
         ("effects", {"--state"}),
         ("resolve", {"--committed", "--failed"}),
+        ("delegate", {"--parent", "--file", "--as", "--json"}),
+        ("revoke", {"--by"}),
     ],
 )
 def test_each_command_offers_the_options_the_spec_freezes(command, options):
@@ -986,7 +991,7 @@ def test_each_command_offers_the_options_the_spec_freezes(command, options):
     assert options <= declared
 
 
-@pytest.mark.parametrize("arguments", [("approve",), ("deny",), ("resolve",)])
+@pytest.mark.parametrize("arguments", [("approve",), ("deny",), ("resolve",), ("revoke",)])
 def test_the_commands_that_name_a_thing_require_it(workspace, arguments):
     assert _cli(*arguments).exit_code != 0
 

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -7,16 +7,23 @@ never a failed action.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 
 from ctrlrun import (
     ApprovalRequired,
+    Authority,
     Control,
+    Grant,
     InMemoryStateStore,
     MissingDependency,
     NotExecuted,
     Policy,
+    Principal,
+    Subject,
     context,
+    parse_conditions,
     protect,
 )
 
@@ -41,6 +48,23 @@ actions:
       - when: { amount_lte: 5000 }
         decision: approve
       - decision: deny
+"""
+
+
+#: SPEC-v0.3 §7 — a document with an `authority:` section, so the delegation events exist.
+AUTHORITY_DOCUMENT = """
+schema: ctrlrun.policy/v3
+authority:
+  grants:
+    - id: head-of-support
+      subject: { agent: "support-lead", user: "alice@example.com" }
+      actions: ["stripe.**"]
+      constraints: { amount_lte: 5000 }
+      expires_at: "2027-01-01T00:00:00+00:00"
+      delegable: true
+actions:
+  stripe.refund:
+    decision: allow
 """
 
 
@@ -522,3 +546,43 @@ def test_T30_a_missing_otel_extra_raises_MissingDependency(monkeypatch):
 
     assert "pip install 'ctrlrun[otel]'" in str(raised.value)
     assert not isinstance(raised.value, ImportError)
+
+
+# --- SPEC-v0.3 §7: an action-less event gets a standalone span -------------------------
+
+
+@pytest.mark.authority
+def test_a_delegation_event_becomes_a_standalone_span(store, exporter):
+    """SPEC-v0.3 §7 — the v0.2 sink would look for a span it will never find and drop these.
+
+    The three `DELEGATION_*` types carry `action_id: null`, so `_span_for` returns `None` for
+    every one of them and an operator whose evidence pipeline is OTel would watch a delegation
+    chain appear and be revoked with nothing in the trace. The highest-privilege operations in
+    the release must not be the only ones missing from the export path.
+    """
+    export, provider = exporter
+    control = Control(
+        Policy.from_yaml(AUTHORITY_DOCUMENT),
+        store,
+        authority=Authority.from_yaml(AUTHORITY_DOCUMENT),
+        sinks=[OTelEventSink(tracer_provider=provider)],
+    )
+    delegation = control.delegate(
+        "head-of-support",
+        Grant(
+            id="",
+            subject=Subject(agent="refund-agent", user="alice@example.com"),
+            actions=("stripe.refund",),
+            constraints=parse_conditions({"amount_lte": 500}, where="<test>"),
+            expires_at=datetime(2026, 12, 1, tzinfo=UTC),
+        ),
+        by=Principal(agent="support-lead", user="alice@example.com"),
+    )
+    control.revoke(delegation.delegation_id, by="cli:local")
+
+    names = [span.name for span in _spans(export)]
+    assert names == ["DELEGATION_CREATED", "DELEGATION_REVOKED"]
+    created, revoked = (_attrs(span) for span in _spans(export))
+    assert created["ctrlrun.delegation_id"] == delegation.delegation_id
+    assert created["ctrlrun.parent_id"] == "head-of-support"
+    assert revoked["ctrlrun.delegation_id"] == delegation.delegation_id


### PR DESCRIPTION
Build-list item 3. SPEC-v0.3 §5.

A principal holding a `delegable` grant can create a narrower one at runtime and revoke it again — `Control.delegate` / `Control.revoke`, `ctrlrun delegate` / `ctrlrun revoke`. Containment is structural and checked in two places: §5.3's six rules at creation, in the order the specification lists them, and §5.6's six rules on every evaluation, walking the chain to its root again. A check performed only at creation would leave every delegation exactly as wide as the file used to be.

**Omission never means unlimited.** A child that drops a dimension its parent constrains is rejected — including the subject: a delegation may carry no wildcard, may not omit `agent`, and may not drop a `user` its parent named, because each hands the grant to a wider population rather than a narrower one.

**Revocation is transitive by structure.** Nothing is rewritten and no children are visited; a chain of any depth is cut by one write. Depth is recomputed by walking, never read from the stored column; the walk is bounded and refuses a chain that revisits an id, and the two refusals are separately observable.

Storage is a new `delegations` table in both stores, so no existing table gains a column and v0.3 still needs no migration story. `put_delegation` is an `INSERT` and never an upsert — an upsert on an existing id would clear `revoked_at`, which is `unrevoke` by another door. `Event.action_id` becomes `str | None` for the three delegation event types, and `OTelEventSink` emits a standalone span for each rather than dropping them.

## Independent review

Run in a separate session against the spec and every caller of the changed code, per the project's rule for items touching authorization. It found one authorization defect, fixed in the second commit:

**A completed chain's depth was never compared to the maximum.** `_walk` returns on reaching a root grant *before* it consults its bound, so a chain that completes in one step was measured against nothing — §5.6 rule 5 was reading `depth_exceeded` off the walk, which only truncation sets. `max_delegation_depth: 0`, which §5.5 offers as the way to switch delegation off, therefore left every existing depth-1 delegation authorizing while appearing to work, because deeper chains truncate and deny. Rule 5 now compares the walked depth outright, and the walk's bound — now behaviourally subsumed — is tested for what it still does: how many parents it reads.

Also fixed: an unreadable row raised with a literal `"<grant>"` placeholder instead of its id, so a corrupt row denied every action while the evidence could not say which row (and §13 ships no way to list delegations); and a stored `actions` was coerced rather than refused, turning `"refund"` into six single-character patterns.

Four checks had no test — `created_via`, rule 3's unwalkable-chain branch, rule 3's ancestor-expiry check, and the two above — so no mutation run could tell they were load-bearing. Rule 3's ancestor-expiry check turns out **not** to be subsumed by §5.4's `expires_at` row once a root grant's expiry is edited forward, since that breaks the implication the row relies on; there is now a test for exactly that shape.

## Two things for the maintainer, recorded in the spec rather than decided here

- **§4.6's blast radius.** One unreadable `delegations` row denies every action for every principal, root-grant holders included. `ctrlrun revoke` cannot clear it — it refuses the row for the same reason evaluation does, and revoking would not help since evaluation enumerates revoked rows too. Recovery is deleting the row with `sqlite3`. This is the fail-closed direction §4.6 asks for, so item 3 ships it and documents it; a relaxation (skipping a row that is *both* revoked and unreadable, which can never contribute a pass) would be a §4.6 amendment, not a delegation change.
- **§5.3 rule 4 has no evaluation-time counterpart.** A writer to the `delegations` table can mint a fully-contained delegation from any `delegable` root grant to an agent of its choosing without ever holding it. Bounded in population, not in powers; store write access is out of scope per the threat model. Stated because §5.6's list of six rules is where a reader would look for "you may only delegate authority you hold".

## Verification

- 1614 tests pass. 76 new in `tests/test_delegation.py` (T75–T81, T75b, T76b, T77b–d, T80b), plus a standalone-span test in `tests/test_otel.py`.
- `mypy --strict src/` and `ruff check` clean. `ctrlrun demo` runs in 0.12s.
- **Mutation table: 41 rows, all red.** Every §5.4 dimension broken alone, every §5.3 and §5.6 rule removed alone, plus the store's atomicity and never-an-upsert claims. Three rows came back wrong across the runs and each was a real test defect, now fixed: the `dlg_` namespace check was subsumed by a parse failure in its own test; "never an upsert" had no test at all; and the `actions` coercion test used a string containing `.`, which the pattern grammar refuses anyway — the test passed while exercising nothing.
