### PR TITLE
item 4: observe mode and `ctrlrun stats`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,50 @@ shipped, and the only thing in the tree today is the contract.
 
 ### Added
 
+- **Observe mode** (build-list item 4, SPEC-v0.3 §6). A top-level `mode: observe` runs every
+  real decision against real traffic and records what *would* have been blocked, without
+  blocking anything: no `ActionDenied`, no `AuthorityDenied`, no `ApprovalRequired`, no
+  `DuplicateEffect`. `Control.execute` returns a receipt whose `result` is `observed`, whose
+  `execution` is what the executor actually did, and whose `would_have` says what enforce mode
+  would have reached and what it would have done with it. It is the rollout path, and it is
+  **not a dry run**: it executes, effects land at remotes, and the records of them are real.
+- **One switch, and it governs the process.** `mode:` is top level and nothing else — inside an
+  action, a rule, a grant or the `authority:` section it is a load error naming the rule, and
+  so is a value that is not exactly `observe` or `enforce`. A partially-enforced configuration
+  is the failure mode that rule exists to prevent. Absent means `enforce`; `mode:` needs
+  `schema: ctrlrun.policy/v3`, because a reader that ignored it would enforce a configuration
+  that was deployed to observe.
+- **Observe mode still refuses what it cannot describe.** A missing principal, a provider that
+  raises, an unresolvable effect key, an argument an Action cannot represent, and a delegation
+  that would escalate are refused in both modes: the first four are wiring bugs that would run
+  an action CTRLRun could not describe, and the fifth is an act of authority rather than a
+  decision about an action. It asks no human either — a policy reaching `approve` records
+  `approval_required` and runs, creating no request and appending no `APPROVAL_REQUESTED` —
+  and it never calls the `reconcile` hook, whose `"committed"` answer would move a record a
+  human may still be adjudicating.
+- **A refused reservation writes no effect record.** The record belongs to the attempt that
+  holds the key, and observe mode does not make a second attempt its owner: a record already
+  `AMBIGUOUS` stays `AMBIGUOUS`. The refusal is on the receipt instead, as
+  `would_have.blocked_reason`. The gateway's v0.2 §6.10 pre-check is skipped in observe mode
+  for the same reason — it refuses calls before `Control.execute` is reached, and a gateway
+  that kept it would enforce three rows in the one mode that enforces none of them.
+- **`ctrlrun stats`**, counting from the local store and nothing else — no network, no
+  aggregation service, no upload. Would-have-denied broken down by reason, would-have-needed-
+  approval, would-have-been-blocked broken down by duplicate and ambiguous, and ambiguous
+  outcomes. `--since` takes an ISO-8601 timestamp with an offset or `30m`/`24h`/`7d` and
+  compares `finished_at` inclusively; `--json` emits the same numbers under
+  `schema: ctrlrun.stats/v1`. In enforce mode it reports what actually happened and **reports
+  less**, saying so in its footer rather than printing a line the receipts cannot substantiate.
+- **The observe banner.** `OBSERVE MODE — nothing is enforced`, to stderr, before anything
+  else, on every invocation of every command that loads the operator's policy — `gateway`,
+  `stats`, `delegate`, `revoke`, `verify`. To stderr so a `--json` stdout stays parseable. The
+  evidence commands (`receipts`, `effects`, `inspect`, `resolve`, `approve`, `deny`) do not
+  print it and do not load a policy at all: reading evidence must not depend on the
+  configuration that produced it.
+- **`ctrlrun verify`** as a stub that prints to stderr that verification lands in 0.4 and exits
+  **2**. It runs nothing, checks nothing, and claims nothing. It exists because observe mode's
+  whole purpose is to lead somewhere, and the command an operator reaches for next should not
+  be a `No such command` error that suggests they mistyped.
 - **Delegation with attenuation** (build-list item 3, SPEC-v0.3 §5). A principal who holds a
   `delegable` grant can create a narrower one at runtime — `Control.delegate`, `ctrlrun
   delegate` — and revoke it — `Control.revoke`, `ctrlrun revoke`. A delegated grant is valid
@@ -124,6 +168,14 @@ shipped, and the only thing in the tree today is the contract.
 - **A repeated identity header is refused** — `-41007`, HTTP 403, upstream untouched. A
   `Mapping` holds one value per name, so something had to decide what two become, and under
   authority that decision picks the principal.
+- **BREAKING for a reader: `ReceiptResult` gains `observed`.** `Receipt.from_dict` parses
+  `result` into a closed `StrEnum` and `SQLiteStateStore` reads every stored receipt through
+  it, so a CTRLRun ≤ 0.2 process running `ctrlrun receipts` or `ctrlrun inspect` against a
+  store an 0.3 **observe-mode** process wrote raises on the unknown value. Two processes
+  sharing one store is the intended deployment: **upgrade every reader before switching any
+  writer to `mode: observe`.** An enforce-mode 0.3 writer emits no `observed` receipt and is
+  safe to mix. An external reader that keys on `result` must read `execution` too, or it
+  counts every observed execution as if nothing ran.
 - **`ctrlrun.receipt/v2` and `ctrlrun.inspection/v2`.** The receipt carries the whole principal
   and reserves `execution` and `would_have` as `null` until observe mode fills them, so the
   shape a reader parses settles once rather than changing twice under one version string. The

--- a/src/ctrlrun/authority.py
+++ b/src/ctrlrun/authority.py
@@ -38,7 +38,13 @@ import yaml
 
 from .action import Action, Principal
 from .errors import AuthorityEscalation, IdentityError, InvalidArgument, PolicyError
-from .policy import SUPPORTED_SCHEMAS, Condition, parse_conditions, require_v3
+from .policy import (
+    SUPPORTED_SCHEMAS,
+    Condition,
+    parse_conditions,
+    reject_nested_mode,
+    require_v3,
+)
 from .policy import _equal as _type_strict_equal
 from .state import DelegationRecord, StateStore
 
@@ -1171,6 +1177,10 @@ def _from_section(section: object, source: str) -> Authority:
         raise PolicyError(
             f"{where}: must be a mapping with a 'grants' key, got {_type_name(section)}"
         )
+    # §6.1 — `mode:` is top level and nothing else, and this loader owns the two nestings
+    # inside an `authority:` section: the `--authority` document of §8.3 never reaches the
+    # policy loader at all.
+    reject_nested_mode(section, where)
     _reject_unknown_keys(section, _AUTHORITY_KEYS, where)
     depth = section.get("max_delegation_depth", DEFAULT_MAX_DELEGATION_DEPTH)
     if not isinstance(depth, int) or isinstance(depth, bool) or depth < 0:
@@ -1231,6 +1241,7 @@ _UNASSIGNED: Final = "unassigned"
 def _parse_grant(entry: object, where: str, *, unassigned: bool = False) -> Grant:
     if not isinstance(entry, Mapping):
         raise PolicyError(f"{where}: a grant must be a mapping, got {_type_name(entry)}")
+    reject_nested_mode(entry, where)
     _reject_unknown_keys(entry, _GRANT_KEYS, where)
     grant_id = entry.get("id")
     if not isinstance(grant_id, str) or not grant_id:

--- a/src/ctrlrun/cli/main.py
+++ b/src/ctrlrun/cli/main.py
@@ -12,9 +12,9 @@ agent is waiting on in another shell.
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Final
 
@@ -26,13 +26,30 @@ from ..authority import Delegation, grant_from_yaml
 from ..control import DEFAULT_STATE_DIR, Control, state_path
 from ..effect import RESOLVED_BY_HUMAN, EffectRecord, EffectState
 from ..errors import AuthorityEscalation, CTRLRunError
-from ..policy import DEFAULT_POLICY_FILENAME
-from ..receipt import Event, EventType, Receipt, iso_timestamp
+from ..policy import DEFAULT_POLICY_FILENAME, OBSERVE, Decision, Policy
+from ..receipt import (
+    BLOCKED_APPROVAL_REQUIRED,
+    BLOCKED_BY_STATE,
+    Event,
+    EventType,
+    Receipt,
+    ReceiptResult,
+    iso_timestamp,
+)
 from ..state import RESOLUTIONS, SQLiteStateStore
 from .demo import run_demo
 
 #: Who the CLI records as the answer's author. Free text in v0.1 (SPEC-v0.1 §4.1).
 CLI_APPROVER: Final = "cli:local"
+
+#: SPEC-v0.3 §6.5 — printed to stderr, before anything else, by every command that loads the
+#: operator's policy, on every invocation. To stderr so a `--json` stdout stays
+#: machine-readable and a pipeline cannot silently swallow it; on every invocation because a
+#: deployment that has been observing for six months is exactly the one this line is for.
+OBSERVE_BANNER: Final = "OBSERVE MODE — nothing is enforced"
+
+#: SPEC-v0.3 §6.4 — one `ctrlrun stats --json` document.
+STATS_SCHEMA: Final = "ctrlrun.stats/v1"
 
 #: SPEC-v0.2 §5 — the schema of one `ctrlrun inspect --json` document.
 #: SPEC-v0.3 §12.2 — v2 where the header block gained the principal's issuer, expiry and
@@ -82,6 +99,23 @@ actions:
 def _store() -> SQLiteStateStore:
     """Open the store this working tree's agents use (SPEC-v0.1 §8)."""
     return SQLiteStateStore(state_path())
+
+
+def _loaded_policy() -> Policy:
+    """Load the operator's policy, printing the observe banner first (SPEC-v0.3 §6.5).
+
+    Only the commands that already need the policy call this — `gateway`, `stats`,
+    `delegate`, `revoke` and `verify`. `receipts`, `inspect` and the rest deliberately do
+    not: `state_path()` finds the store without loading a policy, and making an evidence
+    command load one would turn a malformed policy into a failure of the evidence.
+
+    Where the policy cannot be loaded the `PolicyError` propagates and no banner is printed,
+    because there is no mode to report.
+    """
+    policy = Policy.from_file()
+    if policy.mode == OBSERVE:
+        click.echo(OBSERVE_BANNER, err=True)
+    return policy
 
 
 def _fail(exc: CTRLRunError) -> click.ClickException:
@@ -456,6 +490,173 @@ def _approval_dict(record: ApprovalRecord) -> dict[str, Any]:
 
 
 @main.command()
+@click.option(
+    "--since",
+    default=None,
+    help="Count only receipts finished at or after this: an ISO-8601 timestamp with an "
+    "offset, or <n>m / <n>h / <n>d.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit one JSON object instead.")
+def stats(since: str | None, as_json: bool) -> None:
+    """Count what this store's receipts say, from the local store and nothing else.
+
+    No network, no aggregation service, no upload: this reads the SQLite file the process it
+    is diagnosing has been writing (SPEC-v0.3 §6.4).
+    """
+    policy = _loaded_policy()
+    boundary = _since(since)
+    try:
+        counted = [
+            receipt
+            for receipt in _store().receipts()
+            if boundary is None or receipt.finished_at >= boundary
+        ]
+    except CTRLRunError as exc:
+        raise _fail(exc) from exc
+    document = _stats_document(counted, mode=policy.mode, boundary=boundary)
+    if as_json:
+        click.echo(json.dumps(document, ensure_ascii=False, indent=2))
+        return
+    for line in _stats_lines(document):
+        click.echo(line)
+
+
+def _since(argument: str | None) -> datetime | None:
+    """Parse `--since` into an inclusive lower bound on `finished_at` (SPEC-v0.3 §6.4).
+
+    Absolute ISO-8601 **with an offset**, or a relative `<n><unit>` where the unit is exactly
+    one of `m`, `h` or `d`. No months, no weeks, no bare numbers: `2mo` and `1w` are ambiguous
+    enough that guessing one would silently report the wrong window, which is worse than
+    refusing.
+    """
+    if argument is None:
+        return None
+    text = argument.strip()
+    if text and text[-1] in _RELATIVE_UNITS and text[:-1].isdigit() and int(text[:-1]) > 0:
+        return datetime.now(UTC) - timedelta(**{_RELATIVE_UNITS[text[-1]]: int(text[:-1])})
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        parsed = None
+    if parsed is None or parsed.tzinfo is None:
+        raise click.UsageError(
+            f"--since {argument!r} is not a window this command accepts. Give an ISO-8601 "
+            "timestamp with an offset (2026-09-01T00:00:00Z), or one of <n>m, <n>h, <n>d "
+            "(30m, 24h, 7d). No months, no weeks, and no bare numbers"
+        )
+    return parsed
+
+
+#: The three relative units of §6.4, and the `timedelta` keyword each names.
+_RELATIVE_UNITS: Final[Mapping[str, str]] = {"m": "minutes", "h": "hours", "d": "days"}
+
+
+def _stats_document(
+    counted: list[Receipt], *, mode: str, boundary: datetime | None
+) -> dict[str, Any]:
+    """The numbers of §6.4, from `would_have` in observe mode and from `result` in enforce.
+
+    The two are deliberately different shapes. An enforce-mode receipt carries no
+    counterfactual and no structured `blocked_reason` — a `blocked` receipt keeps the
+    duplicate/ambiguous distinction only inside `error` as exception text (v0.1 §6.1) — so
+    the command reports what it can substantiate and says in its footer what it cannot.
+    """
+    finished = [receipt.finished_at for receipt in counted]
+    document: dict[str, Any] = {
+        "schema": STATS_SCHEMA,
+        "mode": mode,
+        "since": None if boundary is None else iso_timestamp(boundary),
+        "from": iso_timestamp(min(finished)) if finished else None,
+        "to": iso_timestamp(max(finished)) if finished else None,
+        "actions": len(counted),
+    }
+    if mode != OBSERVE:
+        refused = [r for r in counted if r.result is ReceiptResult.DENIED]
+        document["denied"] = len(refused)
+        document["denied_by_reason"] = _tally(r.decision_reason for r in refused)
+        document["ambiguous_outcomes"] = len(
+            [r for r in counted if r.result is ReceiptResult.AMBIGUOUS]
+        )
+        return document
+    # Every observe-mode number comes off `would_have`, so the counterfactuals are pulled out
+    # once. A receipt with none was written by one of §6.2's still-refuses rows: the action was
+    # genuinely stopped and there is nothing counterfactual to count.
+    counterfactuals = [r.would_have for r in counted if r.would_have is not None]
+    denied = [w for w in counterfactuals if w.decision is Decision.DENY]
+    blocked = [w for w in counterfactuals if w.blocked_reason in BLOCKED_BY_STATE]
+    document["would_have_been_denied"] = len(denied)
+    document["denied_by_reason"] = _tally(w.blocked_reason or w.reason for w in denied)
+    document["would_have_needed_approval"] = len(
+        [w for w in counterfactuals if w.blocked_reason == BLOCKED_APPROVAL_REQUIRED]
+    )
+    document["would_have_been_blocked"] = len(blocked)
+    document["blocked_by_reason"] = _tally(w.blocked_reason for w in blocked)
+    document["ambiguous_outcomes"] = len(
+        [r for r in counted if r.execution is ReceiptResult.AMBIGUOUS]
+    )
+    return document
+
+
+def _tally(reasons: Iterable[str | None]) -> dict[str, int]:
+    """Counts by reason, largest first, then alphabetically so the output is stable."""
+    counts: dict[str, int] = {}
+    for reason in reasons:
+        counts[str(reason)] = counts.get(str(reason), 0) + 1
+    return dict(sorted(counts.items(), key=lambda pair: (-pair[1], pair[0])))
+
+
+def _stats_lines(document: Mapping[str, Any]) -> list[str]:
+    """§6.4's report. Every number comes from the document, so `--json` cannot disagree."""
+    window = f"{document['from'] or '-'} .. {document['to'] or '-'}"
+    lines = [f"CTRLRun — {window}   ({document['mode']} mode)", ""]
+    lines.append(_stat("actions", document["actions"]))
+    if document["mode"] == OBSERVE:
+        lines.append(_stat("would have been denied", document["would_have_been_denied"]))
+        lines += _breakdown(document["denied_by_reason"])
+        lines.append(_stat("would have needed approval", document["would_have_needed_approval"]))
+        lines.append(_stat("would have been blocked", document["would_have_been_blocked"]))
+        lines += _breakdown(document["blocked_by_reason"])
+    else:
+        lines.append(_stat("denied", document["denied"]))
+        lines += _breakdown(document["denied_by_reason"])
+    lines.append(_stat("ambiguous outcomes", document["ambiguous_outcomes"]))
+    lines.append("")
+    if document["mode"] != OBSERVE:
+        # §6.4 — say what is missing rather than print a line the receipts cannot substantiate.
+        lines.append(
+            "An enforce-mode receipt carries no structured blocked_reason, so the duplicate "
+            "and ambiguous breakdown is not reported."
+        )
+    lines.append("Actions still awaiting a human have no receipt yet and are not counted.")
+    return lines
+
+
+def _stat(label: str, count: int) -> str:
+    return f"{label:<30}{count:>6}"
+
+
+def _breakdown(counts: Mapping[str, int]) -> list[str]:
+    return [f"   {reason:<27}{count:>6}" for reason, count in counts.items()]
+
+
+@main.command()
+def verify() -> None:
+    """Not yet: verification of an evidence file lands in v0.4.
+
+    It exists here because observe mode's whole purpose is to lead somewhere, and the command
+    an operator reaches for next should not be a `No such command` error that suggests they
+    mistyped (SPEC-v0.3 §6.5). It runs nothing, checks nothing, and claims nothing.
+    """
+    _loaded_policy()
+    click.echo(
+        "ctrlrun verify lands in 0.4. It does not exist yet: nothing was checked and nothing "
+        "is claimed about this store.",
+        err=True,
+    )
+    raise SystemExit(2)
+
+
+@main.command()
 @click.option("--parent", required=True, help="The grant or delegation being narrowed.")
 @click.option(
     "--file",
@@ -484,6 +685,7 @@ def delegate(parent: str, grant_file: Path, as_who: str, as_json: bool) -> None:
     if not agent:
         raise click.UsageError("--as needs an agent name: AGENT or AGENT/USER")
     try:
+        _loaded_policy()
         control = Control.from_file()
         grant = grant_from_yaml(grant_file.read_text(encoding="utf-8"), source=str(grant_file))
         created = control._delegate(
@@ -515,6 +717,7 @@ def revoke(delegation_id: str, by: str) -> None:
     already-revoked delegation is idempotent and exits 0.
     """
     try:
+        _loaded_policy()
         control = Control.from_file()
         before = control.store.get_delegation(delegation_id)
         control.revoke(delegation_id, by=by)
@@ -621,7 +824,11 @@ def gateway(
     try:
         from ..gateway import serve
 
-        _announce_actions_without_an_effect()
+        # §6.5 — before anything else this command prints. The removed-flag guard above is a
+        # usage error and runs first deliberately: it must not depend on a policy being
+        # loadable, or a gateway started in a directory with no policy would report the wrong
+        # problem.
+        _announce_actions_without_an_effect(_loaded_policy())
         serve(
             upstream=upstream,
             alias=alias,
@@ -649,16 +856,13 @@ def gateway(
         click.echo("")
 
 
-def _announce_actions_without_an_effect() -> None:
+def _announce_actions_without_an_effect(policy: Policy) -> None:
     """SPEC-v0.2 §3.2 — print the actions with no `effect:` at startup.
 
     A write with no effect key is exactly the configuration this product exists to prevent,
     and it should be visible on the line that starts the process rather than discovered in a
     receipt three weeks later.
     """
-    from ..policy import Policy
-
-    policy = Policy.from_file()
     keyless = sorted(name for name in policy.actions if policy.effect_template(name) is None)
     if not keyless:
         return

--- a/src/ctrlrun/control.py
+++ b/src/ctrlrun/control.py
@@ -29,6 +29,7 @@ from .approval import (
 )
 from .authority import Authority, AuthorityResult, Delegation, Grant, _optional_from_yaml
 from .effect import (
+    COMMITTED_EFFECT,
     DEFAULT_LEASE,
     RECONCILED_STATES,
     RECONCILED_UNKNOWN,
@@ -57,14 +58,20 @@ from .errors import (
     Suspended,
 )
 from .identity import IdentityContext, IdentityProvider
-from .policy import Decision, Evaluation, Policy, discover_policy_path
+from .policy import OBSERVE, Decision, Evaluation, Policy, discover_policy_path
 from .receipt import (
+    BLOCKED_AMBIGUOUS,
+    BLOCKED_APPROVAL_MISMATCH,
+    BLOCKED_APPROVAL_REQUIRED,
+    BLOCKED_DUPLICATE,
+    BLOCKED_IN_PROGRESS,
     Event,
     EventSink,
     EventType,
     JSONLEventSink,
     Receipt,
     ReceiptResult,
+    _WouldHave,
     iso_timestamp,
     new_receipt_id,
 )
@@ -160,6 +167,41 @@ def with_approval(request_id: str) -> Iterator[None]:
         _PRESENTED_APPROVAL.reset(token)
 
 
+class _Observation:
+    """One observe-mode action's counterfactual, assembled as it is evaluated (§6.3).
+
+    Mutable and short-lived: `Control.execute` makes one per call, every check that would
+    have stopped the action writes to it, and it is frozen into a `_WouldHave` on the receipt.
+    A holder rather than a return value because the checks are spread across `execute`,
+    `_observe_secure` and `_outcome`, and threading four extra values through all three would
+    put the same fact in three signatures.
+
+    `block()` keeps the **first** reason, because the checks run in the order enforce mode
+    runs them and enforce mode stops at the first: a later refusal is one enforce mode would
+    never have reached.
+    """
+
+    __slots__ = ("blocked_reason", "decision", "reason")
+
+    def __init__(self) -> None:
+        self.decision = Decision.ALLOW
+        self.reason = ""
+        self.blocked_reason: str | None = None
+
+    def decided(self, evaluation: Evaluation) -> None:
+        self.decision = evaluation.decision
+        self.reason = evaluation.reason
+
+    def block(self, reason: str) -> None:
+        if self.blocked_reason is None:
+            self.blocked_reason = reason
+
+    def frozen(self) -> _WouldHave:
+        return _WouldHave(
+            decision=self.decision, reason=self.reason, blocked_reason=self.blocked_reason
+        )
+
+
 class _Reconciler:
     """One attempt's right to ask a `reconcile` hook, spent at most once (SPEC-v0.2 §2.3).
 
@@ -242,6 +284,10 @@ class Control:
         self._identity = identity
         self._authority = authority
         self._environment = _resolve_environment(environment, policy)
+        #: SPEC-v0.3 §6.1 — one switch, read once, governing the process. Not a parameter:
+        #: the mode belongs to the configuration an operator deployed, and a Control that
+        #: could be handed a different one would be a per-caller opt-out of enforcement.
+        self._observing = policy.mode == OBSERVE
         #: SPEC-v0.3 §3.2 — the provider-versus-context warning is emitted at most once per
         #: Control. A warning that repeats per call is a warning nobody reads.
         self._warned_about_principal = False
@@ -503,6 +549,9 @@ class Control:
         reconciler = _reconciler(reconcile, reconcile_eagerly, "execute")
 
         started_at = self._clock()
+        # SPEC-v0.3 §6.2 — the counterfactual for an observed run, or `None` in enforce mode.
+        # Every branch below reads it to choose between refusing and recording.
+        observation = _Observation() if self._observing else None
         self._append(
             EventType.ACTION_PROPOSED, action, {"action_hash": action.action_hash}, effect_key
         )
@@ -511,10 +560,21 @@ class Control:
             # attribute the refusal to, so unlike a call outside context() it is recorded; and
             # it is refused before the approval gate, because a decision that can never be
             # honoured must not spend a human's attention.
+            expired = Evaluation(Decision.DENY, PRINCIPAL_EXPIRED)
+            if observation is not None:
+                # §6.2's first bullet — evaluated and recorded, not enforced. Authority and
+                # policy stay unevaluated, because enforce mode stops here and observe mode
+                # records what enforce mode *would have reached*, not a deeper answer it
+                # never gets to.
+                observation.decided(expired)
+                observation.block(PRINCIPAL_EXPIRED)
+                return self._observed(
+                    action, expired, executor, effect_key, started_at, observation, reconciler, held
+                )
             self._append(EventType.ACTION_DENIED, action, {"reason": PRINCIPAL_EXPIRED}, effect_key)
             self._record(
                 action,
-                Evaluation(Decision.DENY, PRINCIPAL_EXPIRED),
+                expired,
                 ReceiptResult.DENIED,
                 started_at,
                 effect_key=effect_key,
@@ -528,6 +588,29 @@ class Control:
         result = self._authority_result(action)
         if result is not None:
             if not result.passed:
+                if observation is not None:
+                    # §6.2 — `AUTHORITY_DENIED` is appended exactly as in enforce mode,
+                    # including §4.3's rule that a denial by authority skips policy. What is
+                    # *not* appended is `ACTION_DENIED`: the action ran.
+                    denial = Evaluation(Decision.DENY, result.reason)
+                    self._append(
+                        EventType.AUTHORITY_DENIED,
+                        action,
+                        self._authority_data(result),
+                        effect_key,
+                    )
+                    observation.decided(denial)
+                    observation.block(result.reason)
+                    return self._observed(
+                        action,
+                        denial,
+                        executor,
+                        effect_key,
+                        started_at,
+                        observation,
+                        reconciler,
+                        held,
+                    )
                 self._refuse_authority(action, result, started_at, effect_key)
             self._append(
                 EventType.AUTHORITY_RESOLVED, action, self._authority_data(result), effect_key
@@ -539,8 +622,30 @@ class Control:
             {"decision": str(evaluation.decision), "reason": evaluation.reason},
             effect_key,
         )
+        if observation is not None:
+            observation.decided(evaluation)
 
         if evaluation.decision is Decision.DENY:
+            if observation is not None:
+                # SPEC: §6.3 lists `unknown_action` and `no_matching_rule` among
+                # `blocked_reason`'s values and stops there, but a policy also denies by a
+                # `rule[N]` and by a bare `decision`. The reading taken is the uniform one —
+                # a denial's `blocked_reason` **is** its `decision_reason` — because that is
+                # what makes §6.3's two named values right, and inventing a `policy_denied`
+                # bucket for the other two would leave `ctrlrun stats` unable to say which
+                # rule an operator should look at. The vocabulary stays closed per document:
+                # every value is a reason some check actually produced.
+                observation.block(evaluation.reason)
+                return self._observed(
+                    action,
+                    evaluation,
+                    executor,
+                    effect_key,
+                    started_at,
+                    observation,
+                    reconciler,
+                    held,
+                )
             self._append(EventType.ACTION_DENIED, action, {"reason": evaluation.reason}, effect_key)
             self._record(
                 action, evaluation, ReceiptResult.DENIED, started_at, effect_key=effect_key
@@ -549,6 +654,10 @@ class Control:
                 f"{action.name} denied: {evaluation.reason}",
                 reason=evaluation.reason,
                 action_id=action.action_id,
+            )
+        if observation is not None:
+            return self._observed(
+                action, evaluation, executor, effect_key, started_at, observation, reconciler, held
             )
         approval, reservation = self._secure(
             action, evaluation, started_at, effect_key, held, reconciler
@@ -568,8 +677,162 @@ class Control:
                 raise
         self._append(EventType.EXECUTION_STARTED, action, {}, effect_key, approval=approval)
         return self._outcome(
-            action, evaluation, executor, effect_key, attempt, approval, started_at, reconciler
+            action,
+            evaluation,
+            executor,
+            effect_key,
+            attempt,
+            approval,
+            started_at,
+            reconciler,
+            held_key=effect_key,
         )
+
+    # --- observe mode (SPEC-v0.3 §6) ----------------------------------------------------
+
+    def _observed(
+        self,
+        action: Action,
+        evaluation: Evaluation,
+        executor: Callable[[], Any],
+        effect_key: str | None,
+        started_at: datetime,
+        observation: _Observation,
+        reconciler: _Reconciler,
+        lease: timedelta,
+    ) -> Receipt:
+        """Run an action observe mode has finished deciding about (SPEC-v0.3 §6.2).
+
+        Reached from four places in `execute` — an expired principal, an authority denial, a
+        policy denial, and a decision that would have let the action through — because all
+        four execute in observe mode and only the counterfactual differs. The reservation is
+        attempted from every one of them: observe mode *executes*, and an attempt that runs
+        an effect must own its key where it can.
+        """
+        approval, reservation = self._observe_secure(
+            action, evaluation, effect_key, lease, observation
+        )
+        held_key = None if reservation is None else effect_key
+        attempt = 1 if reservation is None else reservation.attempt
+        if held_key is not None:
+            try:
+                self._store.begin_execution(held_key, action.action_id)
+            except (DuplicateEffect, AmbiguousEffect) as refused:
+                # The key was taken from under this attempt between winning it and starting.
+                # Nothing is refused here, so the attempt goes on to run holding nothing —
+                # and §6.2's rule applies: the record belongs to whoever holds the key.
+                self._append(
+                    EventType.EFFECT_RESERVATION_REFUSED,
+                    action,
+                    _refusal_data(refused),
+                    effect_key,
+                )
+                observation.block(_blocked_by(refused))
+                held_key = None
+        self._append(EventType.EXECUTION_STARTED, action, {}, effect_key, approval=approval)
+        return self._outcome(
+            action,
+            evaluation,
+            executor,
+            effect_key,
+            attempt,
+            approval,
+            started_at,
+            reconciler,
+            held_key=held_key,
+            observation=observation,
+        )
+
+    def _observe_secure(
+        self,
+        action: Action,
+        evaluation: Evaluation,
+        effect_key: str | None,
+        lease: timedelta,
+        observation: _Observation,
+    ) -> tuple[Approval | None, Reservation | None]:
+        """Attempt what `_secure` takes, record every refusal, and hold nothing it lost.
+
+        A separate implementation from `_secure` rather than a flag through it, because the
+        two differ in almost every branch: this one writes no receipt, raises nothing, and
+        never reconciles. It can only ever end up holding **less** than `_secure` would, so
+        the fail-closed direction is preserved by construction.
+
+        Two things it deliberately does not do (SPEC-v0.3 §6.2):
+
+        - **It creates no approval request.** A policy reaching `approve` with nothing
+          presented is recorded and the action runs. Paging a human about an action that is
+          about to execute regardless of the answer produces a queue, not evidence.
+        - **It never calls the `reconcile` hook.** The blocking trigger of `v0.2 §2.3` fires
+          when an `AMBIGUOUS` record refuses a reservation; here that refusal is ignored, so
+          there is nothing being unblocked — and the hook's `"committed"` answer would move a
+          record a human may still be adjudicating.
+        """
+        approval_id = None
+        if evaluation.decision is Decision.APPROVE:
+            approval_id = _PRESENTED_APPROVAL.get(None)
+            if approval_id is None:
+                observation.block(BLOCKED_APPROVAL_REQUIRED)
+        if approval_id is None and effect_key is None:
+            return None, None
+        try:
+            approval, reservation = self._take(action, approval_id, effect_key, lease)
+        except (DuplicateEffect, AmbiguousEffect) as refused:
+            observation.block(_blocked_by(refused))
+            self._append(
+                EventType.EFFECT_RESERVATION_REFUSED,
+                action,
+                _refusal_data(refused),
+                effect_key,
+                approval_id=approval_id,
+            )
+            return None, None
+        except ApprovalMismatch as mismatch:
+            # A *presented* approval that does not authorize this action. §6.2 lists
+            # `ApprovalMismatch` among the exceptions observe mode does not raise, so it is
+            # recorded and the action runs; the approval is left unconsumed either way.
+            observation.block(BLOCKED_APPROVAL_MISMATCH)
+            self._append(
+                EventType.APPROVAL_INVALIDATED,
+                action,
+                {"reason": mismatch.reason, "action_hash": action.action_hash},
+                effect_key,
+                approval_id=approval_id,
+            )
+            return None, None
+        except ActionDenied as denied:
+            # The store raises this where the record says a human refused the approval that
+            # was presented. §4.2 makes that a denial of the action, and the reason is the
+            # one `_secure` records; observe mode records it and runs.
+            observation.block(denied.reason)
+            self._append(
+                EventType.APPROVAL_DENIED,
+                action,
+                {"approver": self._approver_of(approval_id)},
+                effect_key,
+                approval_id=approval_id,
+            )
+            return None, None
+        if approval is not None:
+            self._append(
+                EventType.APPROVAL_CONSUMED,
+                action,
+                {"approver": approval.approver},
+                effect_key,
+                approval_id=approval.approval_id,
+            )
+        if reservation is not None:
+            self._append(
+                EventType.EFFECT_RESERVED,
+                action,
+                {
+                    "attempt": reservation.attempt,
+                    "lease_expires_at": iso_timestamp(reservation.lease_expires_at),
+                },
+                effect_key,
+                approval=approval,
+            )
+        return approval, reservation
 
     def resume(self, continuation: str, executor: Callable[[], Any]) -> Receipt:
         """Finish an action a `Suspended` executor left open (SPEC-v0.2 §6.9).
@@ -619,6 +882,17 @@ class Control:
                 EventType.AUTHORITY_DENIED, action, self._authority_data(result), held.effect_key
             )
             evaluation = Evaluation(Decision.DENY, result.reason)
+        # SPEC-v0.3 §6.3 — a resumption in observe mode gets the same `observed` receipt its
+        # first leg did. It is the *only* receipt an MCP multi round-trip ever gets (§8.3), so
+        # a resumed leg reporting `committed` under a mode that enforces nothing would put the
+        # one piece of evidence for that action in the wrong vocabulary. The reservation was
+        # taken on the first leg and is still held, so nothing is blocked here.
+        observation: _Observation | None = None
+        if self._observing:
+            observation = _Observation()
+            observation.decided(evaluation)
+            if evaluation.decision is Decision.DENY:
+                observation.block(evaluation.reason)
         return self._outcome(
             action,
             evaluation,
@@ -628,6 +902,8 @@ class Control:
             None,
             started_at,
             _Reconciler(None, False),
+            held_key=held.effect_key,
+            observation=observation,
         )
 
     def _outcome(
@@ -640,12 +916,25 @@ class Control:
         approval: Approval | None,
         started_at: datetime,
         reconciler: _Reconciler,
+        *,
+        held_key: str | None,
+        observation: _Observation | None = None,
     ) -> Receipt:
         """Run the executor and record what happened (SPEC-v0.1 §5.5).
 
         The single implementation of the asymmetry: `NotExecuted` is the only outcome that
         maps to `FAILED`, `Suspended` records no outcome at all, and everything else is
         `AMBIGUOUS`. `execute` and `resume` both come through here, so the two cannot drift.
+
+        `effect_key` names the key on every event and on the receipt; `held_key` is the key
+        this attempt actually **reserved**, and the only one it may write an outcome to. They
+        differ in exactly one case: an observe-mode attempt whose reservation was refused
+        (SPEC-v0.3 §6.2). The record belongs to the attempt that holds the key, and observe
+        mode does not make a second attempt its owner — `commit_effect` and its siblings admit
+        only the holder (v0.1 §5.3 E1), and a record in `AMBIGUOUS` is a human's to move.
+
+        `observation` turns every terminal receipt below into an `observed` one carrying what
+        the executor did and what enforce mode would have done (§6.3).
         """
         try:
             result = executor()
@@ -653,21 +942,25 @@ class Control:
             # SPEC-v0.2 §6.9 — no outcome, no receipt: the remote has not said what happened
             # and this attempt is not finished. Handled above the generic branch precisely so
             # it cannot be mistaken for one.
-            self._suspend(action, effect_key, suspension, approval)
+            #
+            # SPEC-v0.3 §6.2 — with no reservation held there is no lease to extend and no
+            # continuation to hold, which is §6.9.3's no-effect-key path reached for a
+            # different reason. `held_key` says so.
+            self._suspend(action, held_key, suspension, approval)
             raise
         except NotExecuted as exc:
-            if effect_key is not None:
+            if held_key is not None:
                 # SPEC §5.5 — the executor asserted the remote side did nothing, so this is
                 # the one outcome that leaves the key retryable (§5.4).
                 try:
-                    self._store.fail_effect(effect_key, action.action_id, str(exc))
+                    self._store.fail_effect(held_key, action.action_id, str(exc))
                 except (DuplicateEffect, AmbiguousEffect) as refused:
                     # SPEC: §5.2 — the record moved on while the executor ran: this attempt's
                     # lease lapsed and another declared the effect AMBIGUOUS, which only a
                     # human moves it out of. The store's refusal is what propagates, not the
                     # NotExecuted: an agent that caught that would retry a key it lost.
                     self._unrecorded(
-                        action, evaluation, started_at, effect_key, attempt, refused, approval
+                        action, evaluation, started_at, held_key, attempt, refused, approval
                     )
                     raise
             self._append(
@@ -686,6 +979,7 @@ class Control:
                 approval=approval,
                 effect_key=effect_key,
                 attempt=attempt,
+                observation=observation,
             )
             raise
         except BaseException as exc:
@@ -695,9 +989,9 @@ class Control:
             # is a regression, not a cleanup.
             error = f"{type(exc).__name__}: {exc}"
             recorded = effect_key is None
-            if effect_key is not None:
+            if held_key is not None:
                 try:
-                    self._store.mark_ambiguous(effect_key, action.action_id, error)
+                    self._store.mark_ambiguous(held_key, action.action_id, error)
                     recorded = True
                 except (DuplicateEffect, AmbiguousEffect) as refused:
                     # Recording an unknown outcome must never mask the exception that caused
@@ -728,18 +1022,19 @@ class Control:
                 approval=approval,
                 effect_key=effect_key,
                 attempt=attempt,
+                observation=observation,
             )
             raise
-        if effect_key is not None:
+        if held_key is not None:
             try:
-                self._store.commit_effect(effect_key, action.action_id, result)
+                self._store.commit_effect(held_key, action.action_id, result)
             except (DuplicateEffect, AmbiguousEffect) as refused:
                 # SPEC: §5.2 — the executor returned, but the key is no longer this attempt's
                 # to commit: the lease lapsed and the record is AMBIGUOUS until a human says
                 # otherwise. What happened at the remote is now as unknown as a timeout, so
                 # the attempt is recorded `ambiguous` rather than committed.
                 self._unrecorded(
-                    action, evaluation, started_at, effect_key, attempt, refused, approval
+                    action, evaluation, started_at, held_key, attempt, refused, approval
                 )
                 raise
         self._append(EventType.EXECUTION_COMMITTED, action, {}, effect_key, approval=approval)
@@ -751,6 +1046,7 @@ class Control:
             approval=approval,
             effect_key=effect_key,
             attempt=attempt,
+            observation=observation,
         )
 
     def _suspend(
@@ -1303,7 +1599,13 @@ class Control:
         approver: str | None = None,
         effect_key: str | None = None,
         attempt: int = 1,
+        observation: _Observation | None = None,
     ) -> Receipt:
+        # SPEC-v0.3 §6.3 — one place turns a terminal outcome into an observed receipt, so
+        # `result`, `execution` and `would_have` cannot disagree about the same action. The
+        # still-refuses rows of §6.2 pass no observation and keep their `denied` receipt with
+        # both new fields null, which is what makes "would_have present on every observed run
+        # and absent on every refused one" true in both directions.
         receipt = Receipt(
             receipt_id=new_receipt_id(),
             action_id=action.action_id,
@@ -1319,7 +1621,9 @@ class Control:
             approver=approval.approver if approval is not None else approver,
             effect_key=effect_key,
             attempt=attempt,
-            result=result,
+            result=ReceiptResult.OBSERVED if observation is not None else result,
+            execution=None if observation is None else result,
+            would_have=None if observation is None else observation.frozen(),
             started_at=started_at,
             finished_at=self._clock(),
             error=error,
@@ -1404,6 +1708,18 @@ def _refusal_data(refused: DuplicateEffect | AmbiguousEffect) -> dict[str, str]:
     if isinstance(refused, DuplicateEffect):
         return {"reason": "duplicate", "state": refused.state}
     return {"reason": "ambiguous"}
+
+
+def _blocked_by(refused: DuplicateEffect | AmbiguousEffect) -> str:
+    """The same refusal in `would_have.blocked_reason`'s vocabulary (SPEC-v0.3 §6.3).
+
+    `duplicate` and `in_progress` are kept apart because one says the effect happened and the
+    other says another attempt holds the key right now — a rollout report that merged them
+    would count a contended key as a repeated payment.
+    """
+    if isinstance(refused, AmbiguousEffect):
+        return BLOCKED_AMBIGUOUS
+    return BLOCKED_DUPLICATE if refused.state == COMMITTED_EFFECT else BLOCKED_IN_PROGRESS
 
 
 def _optional_authority(source: str) -> Authority | None:

--- a/src/ctrlrun/gateway/server.py
+++ b/src/ctrlrun/gateway/server.py
@@ -37,6 +37,7 @@ from ..errors import (
     NotExecuted,
     Suspended,
 )
+from ..policy import OBSERVE
 from ..receipt import Receipt
 from .mcp import DEFAULT_MAX_BODY_BYTES, ParsedRequest, Refusal, parse_request
 from .outcome import (
@@ -515,7 +516,13 @@ class Gateway:
         approval = None
         if self._control.policy.evaluate(action).decision.value == "approve":
             approval = self._control.store.find_granted_approval(action.action_hash)
-            if approval is None:
+            if approval is None and self._control.policy.mode != OBSERVE:
+                # SPEC-v0.3 §6.2 — §6.10's pre-check exists to spare a human, and it spares
+                # them by *refusing* the call. Observe mode troubles no human and refuses
+                # nothing about an action: a gateway that kept this would enforce three of
+                # §9's ⚠ rows in the one mode that enforces none of them, and an operator
+                # measuring what enforcement would cost would be reading a number the
+                # gateway had already changed.
                 refusal = self._before_asking_a_human(action, effect_key, request_id)
                 if refusal is not None:
                     return refusal

--- a/src/ctrlrun/policy.py
+++ b/src/ctrlrun/policy.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Final
+from typing import Any, Final, Literal
 
 import yaml
 
@@ -43,6 +43,13 @@ POLICY_SCHEMA_V3: Final = "ctrlrun.policy/v3"
 #: All of them, newest last, for the message an unknown schema produces.
 SUPPORTED_SCHEMAS: Final = (POLICY_SCHEMA, POLICY_SCHEMA_V2, POLICY_SCHEMA_V3)
 
+#: SPEC-v0.3 §6.1 — the two values of the top-level `mode:` key, and nothing else. Absent
+#: means `enforce`: the fail-closed default, so a document that predates the key enforces.
+MODE_KEY: Final = "mode"
+OBSERVE: Final = "observe"
+ENFORCE: Final = "enforce"
+POLICY_MODES: Final = (OBSERVE, ENFORCE)
+
 CONFIG_ENV_VAR: Final = "CTRLRUN_CONFIG"
 DEFAULT_POLICY_FILENAME: Final = "ctrlrun.yaml"
 
@@ -63,15 +70,16 @@ _OPERATORS: Final = ("eq", "neq", "in", *_NUMERIC_COMPARE)
 #: Longest first, so `amount_neq` reads as (amount, neq) and never as (amount_n, eq).
 _OPERATORS_BY_LENGTH: Final = tuple(sorted(_OPERATORS, key=len, reverse=True))
 
-_TOP_LEVEL_KEYS: Final = frozenset({"schema", "actions", "environment", "authority"})
+_TOP_LEVEL_KEYS: Final = frozenset({"schema", "actions", "environment", "authority", "mode"})
 
 #: SPEC-v0.3 §12.1 — the top-level keys that need `ctrlrun.policy/v3`, and what an older
-#: reader would do with each if it ignored one. `mode:` joins them with build-list item 4.
+#: reader would do with each if it ignored one.
 _V3_TOP_LEVEL_KEYS: Final[Mapping[str, str]] = {
     "environment": ("an older reader would ignore it and put every action in the wrong deployment"),
     "authority": (
         "an older reader would ignore it and run every action with no authority check at all"
     ),
+    "mode": ("an older reader would enforce a configuration that was deployed to observe"),
 }
 _RULE_KEYS: Final = frozenset({"when", "decision"})
 
@@ -267,6 +275,11 @@ class Policy:
     #: through to "production". Policy itself never reads it — the environment is not a
     #: condition (`environment` is a reserved argument name) — it is carried for `Control`.
     environment: str | None = None
+    #: SPEC-v0.3 §6.1 — `observe` or `enforce`, top-level and nothing else. Policy itself
+    #: never reads it either: observe mode changes what `Control` *does* with a decision, not
+    #: which decision is reached, and an evaluator that knew the mode would be a second place
+    #: for the two to disagree.
+    mode: Literal["observe", "enforce"] = ENFORCE
 
     @classmethod
     def from_file(cls, path: str | os.PathLike[str] | None = None) -> Policy:
@@ -319,6 +332,7 @@ class Policy:
             raise PolicyError(
                 f"{source}: 'environment' must be a non-empty string, got {_type_name(environment)}"
             )
+        mode = _parse_mode(document, source)
         actions: dict[str, _ActionPolicy] = {}
         for name, entry in entries.items():
             if not isinstance(name, str) or not name:
@@ -329,6 +343,7 @@ class Policy:
             source=source,
             schema=str(schema),
             environment=environment if isinstance(environment, str) else None,
+            mode=mode,
         )
 
     def effect_template(self, action_name: str) -> str | None:
@@ -387,6 +402,45 @@ def require_v3(document: Mapping[Any, Any], schema: str, source: str) -> None:
             )
 
 
+def _parse_mode(document: Mapping[Any, Any], source: str) -> Literal["observe", "enforce"]:
+    """The top-level `mode:`, or the fail-closed default (SPEC-v0.3 §6.1).
+
+    The value MUST be exactly `observe` or `enforce`. `true`, `off` and `0` are not aliases
+    for either: a switch that governs whether *anything* is enforced is set deliberately or
+    not at all, and YAML would otherwise read `mode: off` as the boolean `False`, which names
+    neither mode.
+    """
+    if MODE_KEY not in document:
+        return ENFORCE
+    value = document[MODE_KEY]
+    if value not in POLICY_MODES:
+        raise PolicyError(
+            f"{source}: 'mode' must be exactly {OBSERVE!r} or {ENFORCE!r}, got {value!r}. "
+            "There is one switch and it governs the process (SPEC-v0.3 §6.1)"
+        )
+    return OBSERVE if value == OBSERVE else ENFORCE
+
+
+def reject_nested_mode(mapping: Mapping[Any, Any], where: str) -> None:
+    """Refuse a `mode:` anywhere but the top level of the policy document (SPEC-v0.3 §6.1).
+
+    The closed key sets of `v0.1 §3.1` would already refuse it as unknown, wherever they
+    reach. This runs first and for its *message*: "unknown key 'mode'" reads as "CTRLRun has
+    no such setting", and the author who wrote it here believes they have observed one action
+    while enforcing the rest. A partially-enforced configuration is the failure mode the
+    top-level-only rule exists to prevent, so the error says which rule was broken.
+
+    Shared with `authority.py`, which owns the two nestings inside an `authority:` section and
+    parses documents the policy loader never reads (§4.8).
+    """
+    if MODE_KEY in mapping:
+        raise PolicyError(
+            f"{where}: 'mode' is top level and nothing else (SPEC-v0.3 §6.1). A configuration "
+            "where some actions are observed and some are enforced is one where nobody can say "
+            "whether an action was permitted or merely watched; move it beside 'schema:'"
+        )
+
+
 def parse_conditions(mapping: Mapping[Any, Any], *, where: str) -> Mapping[str, Condition]:
     """Parse a `when:`-shaped mapping into conditions, keyed by the raw condition key.
 
@@ -414,6 +468,7 @@ def _parse_entry(entry: object, where: str, schema: str) -> _ActionPolicy:
         raise PolicyError(
             f"{where}: entry must be a mapping with 'decision' or 'rules', got {_type_name(entry)}"
         )
+    reject_nested_mode(entry, where)
     _reject_unknown_keys(entry, _ENTRY_KEYS, where)
     _reject_v2_keys_under_v1(entry, where, schema)
     has_decision = "decision" in entry
@@ -516,6 +571,7 @@ def _parse_decision(value: object, where: str) -> Decision:
 def _parse_rule(rule: object, where: str) -> _Rule:
     if not isinstance(rule, Mapping):
         raise PolicyError(f"{where}: a rule must be a mapping, got {_type_name(rule)}")
+    reject_nested_mode(rule, where)
     _reject_unknown_keys(rule, _RULE_KEYS, where)
     if "decision" not in rule:
         raise PolicyError(f"{where}: a rule must have a 'decision'")

--- a/src/ctrlrun/receipt.py
+++ b/src/ctrlrun/receipt.py
@@ -23,10 +23,9 @@ from typing import Any, Final, Protocol
 from .action import Principal
 from .policy import Decision
 
-#: SPEC-v0.3 §12.2. The bump lands with build-list item 1, because that is when the first v2
-#: field appears — the principal's claims, issuer and expiry. `execution` and `would_have` are
-#: carried as `null` from here and populated by observe mode in item 4, so the shape a reader
-#: parses is settled once rather than changing twice under one version string.
+#: SPEC-v0.3 §12.2. The bump landed with build-list item 1, because that is when the first v2
+#: field appeared — the principal's claims, issuer and expiry. `execution` and `would_have`
+#: joined them in item 4, under the same version string, so a reader parses one shape.
 RECEIPT_SCHEMA: Final = "ctrlrun.receipt/v2"
 
 #: The two files of SPEC-v0.1 §6, written beside the state database.
@@ -34,6 +33,28 @@ RECEIPTS_FILENAME: Final = "receipts.jsonl"
 EVENTS_FILENAME: Final = "events.jsonl"
 
 _ID_HEX_BYTES: Final = 16  # "ctr_" + 32 hex chars
+
+#: SPEC-v0.3 §6.3 — the part of `would_have.blocked_reason`'s closed vocabulary that names
+#: something other than a decision. The rest of it is decision reasons, reused verbatim:
+#: `principal_expired`, `unknown_action`, `no_matching_rule`, a `rule[N]`, and §4.3's six
+#: authority denials. It is closed because §6.4 buckets counts on it, and a bucketed count
+#: over a string nobody constrained is a report that quietly stops adding up.
+BLOCKED_APPROVAL_REQUIRED: Final = "approval_required"
+BLOCKED_APPROVAL_MISMATCH: Final = "approval_mismatch"
+BLOCKED_DUPLICATE: Final = "duplicate"
+BLOCKED_IN_PROGRESS: Final = "in_progress"
+BLOCKED_AMBIGUOUS: Final = "ambiguous"
+
+#: The four that mean "the effect state or a presented approval would have stopped it", as
+#: opposed to a decision that would have. `ctrlrun stats` counts them as one line (§6.4).
+BLOCKED_BY_STATE: Final = frozenset(
+    {
+        BLOCKED_APPROVAL_MISMATCH,
+        BLOCKED_DUPLICATE,
+        BLOCKED_IN_PROGRESS,
+        BLOCKED_AMBIGUOUS,
+    }
+)
 
 
 def new_receipt_id() -> str:
@@ -62,9 +83,11 @@ def _principal_dict(principal: Principal) -> dict[str, Any]:
 
 
 class ReceiptResult(StrEnum):
-    """The terminal outcome recorded on a receipt (SPEC-v0.1 §6.1).
+    """The terminal outcome recorded on a receipt (SPEC-v0.1 §6.1, SPEC-v0.3 §6.3).
 
-    `BLOCKED` covers duplicate, ambiguous-retry and approval-mismatch refusals.
+    `BLOCKED` covers duplicate, ambiguous-retry and approval-mismatch refusals. `OBSERVED`
+    is the observe-mode result, and it is not in v0.1 §6.1's set — which is why the receipt
+    schema bumped to v2 (§12.2) and why every reader upgrades before any writer switches.
     """
 
     COMMITTED = "committed"
@@ -72,6 +95,10 @@ class ReceiptResult(StrEnum):
     AMBIGUOUS = "ambiguous"
     DENIED = "denied"
     BLOCKED = "blocked"
+    #: SPEC-v0.3 §6.3 — every receipt an observe-mode run *observed*, including the ones
+    #: nothing would have blocked. What the executor actually did is on `execution`; what
+    #: enforce mode would have done is on `would_have`.
+    OBSERVED = "observed"
 
 
 class EventType(StrEnum):
@@ -150,6 +177,41 @@ class Event:
 
 
 @dataclass(frozen=True)
+class _WouldHave:
+    """What enforce mode would have done with an observed action (SPEC-v0.3 §6.3).
+
+    Private, like `policy._ActionPolicy`, because SPEC-v0.3 §11 freezes `Receipt.would_have`
+    and not a type name for it: the shape a reader parses is the JSON object, and adding a
+    public class here would be an addition to a frozen surface.
+
+    `decision` and `reason` are the combined §4.6 result — what enforce mode would have
+    *reached*. `blocked_reason` is what would have been *done* with it, and is `None` where
+    the action would have run unimpeded. The pair is not a duplicate: "the policy said allow
+    and the effect was already committed" is a real and common answer, and a single field
+    could not hold both halves.
+    """
+
+    decision: Decision
+    reason: str
+    blocked_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decision": str(self.decision),
+            "reason": self.reason,
+            "blocked_reason": self.blocked_reason,
+        }
+
+    @classmethod
+    def from_dict(cls, document: Mapping[str, Any]) -> _WouldHave:
+        return cls(
+            decision=Decision(document["decision"]),
+            reason=document["reason"],
+            blocked_reason=document.get("blocked_reason"),
+        )
+
+
+@dataclass(frozen=True)
 class Receipt:
     """Portable evidence of one action that reached a terminal state (SPEC-v0.1 §6.1)."""
 
@@ -171,6 +233,15 @@ class Receipt:
     effect_key: str | None = None
     attempt: int = 1
     error: str | None = None
+    #: SPEC-v0.3 §6.3 — what the executor actually did, in observe mode: `committed`,
+    #: `failed` or `ambiguous`, or `None` where it never ran. Always `None` in enforce mode,
+    #: where `result` already carries it; duplicating it would give two fields that can
+    #: disagree.
+    execution: ReceiptResult | None = None
+    #: The counterfactual, present on every observed run and absent on every refused one
+    #: (§6.3). That is what keeps "never infer from the absence of a field" true in both
+    #: directions.
+    would_have: _WouldHave | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """The receipt as plain JSON-serializable data, in the field order of SPEC §6.1."""
@@ -191,9 +262,8 @@ class Receipt:
             "effect_key": self.effect_key,
             "attempt": self.attempt,
             "result": str(self.result),
-            # SPEC-v0.3 §6.3 — `null` in enforce mode, which is every mode until item 4.
-            "execution": None,
-            "would_have": None,
+            "execution": None if self.execution is None else str(self.execution),
+            "would_have": None if self.would_have is None else self.would_have.to_dict(),
             "error": self.error,
             "started_at": iso_timestamp(self.started_at),
             "finished_at": iso_timestamp(self.finished_at),
@@ -232,6 +302,16 @@ class Receipt:
             effect_key=document["effect_key"],
             attempt=document["attempt"],
             result=ReceiptResult(document["result"]),
+            # `.get` again: a 0.2 receipt carries neither key, and must parse back rather
+            # than raise (§12.2).
+            execution=(
+                None if document.get("execution") is None else ReceiptResult(document["execution"])
+            ),
+            would_have=(
+                None
+                if document.get("would_have") is None
+                else _WouldHave.from_dict(document["would_have"])
+            ),
             error=document["error"],
             started_at=datetime.fromisoformat(document["started_at"]),
             finished_at=datetime.fromisoformat(document["finished_at"]),

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -964,9 +964,12 @@ def test_the_cli_offers_exactly_the_commands_the_spec_freezes():
         "resolve",
         "inspect",
         "gateway",
-        # SPEC-v0.3 §5.7 — build-list item 3. `stats` and `verify` land with item 4.
+        # SPEC-v0.3 §5.7 — build-list item 3.
         "delegate",
         "revoke",
+        # SPEC-v0.3 §6.4, §6.5 — build-list item 4.
+        "stats",
+        "verify",
     }
 
 

--- a/tests/test_observe.py
+++ b/tests/test_observe.py
@@ -1,0 +1,1208 @@
+"""Observe mode and `ctrlrun stats`. Build-list item 4; SPEC-v0.3 §6.
+
+The acceptance tests are T82 to T87. Four sentences run through all of them:
+
+**Everything is evaluated, nothing about an action is enforced, everything is recorded**
+(§6.2). T82 asserts both halves in one test, so "observe executes" cannot pass by the action
+having been allowed.
+
+**Observe mode is not a dry run** (§6.6). It executes, effects land at remotes, and the
+records of them are real — which is why T83 asserts that a *refused* reservation writes no
+effect record, and why T87 asserts the store survives the switch to enforce untouched.
+
+**There is one switch and it governs the process** (§6.1). A `mode:` anywhere but the top
+level is a load error naming the path, and T84 walks every nesting the document has.
+
+**A rollout mode that pages a human is a queue that fills up** (§6.2). T82c asserts the
+absence of the request, the absence of the event, and the executor having run anyway.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from click.testing import CliRunner
+
+from ctrlrun import (
+    Action,
+    ActionDenied,
+    AmbiguousEffect,
+    ApprovalRequired,
+    Control,
+    DuplicateEffect,
+    EffectKeyError,
+    EffectState,
+    IdentityError,
+    InMemoryStateStore,
+    Policy,
+    PolicyError,
+    Principal,
+    SQLiteStateStore,
+    context,
+    protect,
+)
+from ctrlrun.authority import Authority, grant_from_yaml
+from ctrlrun.cli.main import OBSERVE_BANNER, STATS_SCHEMA, main
+from ctrlrun.errors import AuthorityEscalation
+from ctrlrun.policy import ENFORCE, OBSERVE
+from ctrlrun.receipt import (
+    BLOCKED_AMBIGUOUS,
+    BLOCKED_APPROVAL_REQUIRED,
+    BLOCKED_DUPLICATE,
+    BLOCKED_IN_PROGRESS,
+    Receipt,
+    ReceiptResult,
+)
+
+V3 = "schema: ctrlrun.policy/v3\n"
+
+ACTIONS = """
+actions:
+  stripe.refund:
+    rules:
+      - when: { amount_lte: 50000 }
+        decision: allow
+      - when: { amount_lte: 5000000 }
+        decision: approve
+      - decision: deny
+  customer.read:
+    decision: allow
+"""
+
+DELEGABLE = """
+authority:
+  grants:
+    - id: head-of-support
+      subject: { agent: "support-agent", user: "alice@example.com" }
+      actions: ["stripe.refund"]
+      constraints: { amount_lte: 200000 }
+      delegable: true
+      expires_at: "2027-01-01T00:00:00Z"
+"""
+
+
+class _Clock:
+    """Static: it moves only when a test moves it, so an expiry boundary is exact."""
+
+    def __init__(self) -> None:
+        self.now = datetime(2026, 9, 3, 10, 12, 1, tzinfo=UTC)
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, delta: timedelta) -> None:
+        self.now += delta
+
+
+@pytest.fixture
+def clock():
+    return _Clock()
+
+
+@pytest.fixture
+def store(clock):
+    return InMemoryStateStore(clock=clock)
+
+
+class _Executor:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self):
+        self.calls += 1
+        return "ok"
+
+
+def _explode():
+    raise TimeoutError("the remote never answered")
+
+
+def _document(mode: str = OBSERVE, actions: str = ACTIONS, authority: str = "") -> str:
+    return f"{V3}mode: {mode}\n{authority}{actions}"
+
+
+def _control(document, store, clock, **kwargs):
+    authority = Authority.from_yaml(document) if "authority:" in document else None
+    return Control(
+        Policy.from_yaml(document),
+        store,
+        authority=authority,
+        clock=clock,
+        environment="production",
+        **kwargs,
+    )
+
+
+def _action(**overrides):
+    fields = {
+        "name": "stripe.refund",
+        "arguments": {"amount": 1000, "payment_id": "EU-42"},
+        "principal": Principal(agent="support-agent", user="alice@example.com"),
+        "resource": "payment:EU-42",
+        "environment": "production",
+    }
+    fields.update(overrides)
+    return Action(**fields)
+
+
+def _types(store):
+    return [str(event.type) for event in store.events()]
+
+
+# --- T82: observe executes what enforce would deny (§6.2, §6.3) -------------------------
+
+
+def test_T82_observe_executes_what_enforce_would_deny(store, clock):
+    """Both halves in one test: the same document under `mode: enforce` raises and does not
+    run, so "observe executes" cannot pass by the action having been allowed."""
+    denied = _action(arguments={"amount": 90000000, "payment_id": "EU-44"})
+
+    observing = _control(_document(OBSERVE), store, clock)
+    watched = _Executor()
+    receipt = observing.execute(denied, watched, "refund:EU-44")
+
+    assert watched.calls == 1
+    assert receipt.result is ReceiptResult.OBSERVED
+    assert receipt.execution is ReceiptResult.COMMITTED
+    assert receipt.would_have is not None
+    assert receipt.would_have.decision.value == "deny"
+    assert receipt.would_have.reason == receipt.decision_reason
+    assert receipt.would_have.blocked_reason == receipt.decision_reason
+
+    enforcing = _control(_document(ENFORCE), InMemoryStateStore(clock=clock), clock)
+    refused = _Executor()
+    with pytest.raises(ActionDenied):
+        enforcing.execute(denied, refused, "refund:EU-44")
+
+    assert refused.calls == 0
+
+
+def test_T82_an_observed_receipt_nothing_would_have_blocked_still_says_observed(store, clock):
+    """§6.3 — `result` is "observed" for every receipt an observe-mode run observed, so a
+    reader never infers from the absence of a field that a receipt describes an unenforced
+    run. `blocked_reason` is the field that says nothing intervened."""
+    control = _control(_document(OBSERVE), store, clock)
+
+    receipt = control.execute(_action(), _Executor(), "refund:EU-42")
+
+    assert receipt.result is ReceiptResult.OBSERVED
+    assert receipt.execution is ReceiptResult.COMMITTED
+    assert receipt.would_have is not None
+    assert receipt.would_have.decision.value == "allow"
+    assert receipt.would_have.blocked_reason is None
+
+
+def test_T82_the_observed_receipt_round_trips_through_json(store, clock):
+    """§12.2 — `observed` is not in v0.1 §6.1's set of results, and `execution` and
+    `would_have` are new keys. A receipt that cannot be read back is not evidence."""
+    control = _control(_document(OBSERVE), store, clock)
+
+    receipt = control.execute(
+        _action(arguments={"amount": 90000000, "payment_id": "EU-44"}), _Executor(), None
+    )
+    document = json.loads(receipt.to_json())
+
+    assert document["schema"] == "ctrlrun.receipt/v2"
+    assert document["result"] == "observed"
+    assert document["execution"] == "committed"
+    assert document["would_have"]["decision"] == "deny"
+    assert Receipt.from_json(receipt.to_json()).to_dict() == document
+    assert store.receipts()[-1].to_dict() == document
+
+
+def test_T82_a_receipt_written_before_v0_3_still_parses(store, clock):
+    """`execution` and `would_have` are absent from every receipt 0.2 wrote (§12.2)."""
+    control = _control(_document(ENFORCE), store, clock)
+    document = control.execute(_action(), _Executor(), None).to_dict()
+    del document["execution"]
+    del document["would_have"]
+
+    older = Receipt.from_dict(document)
+
+    assert older.execution is None
+    assert older.would_have is None
+
+
+def test_T82_enforce_mode_writes_neither_new_field(store, clock):
+    """§6.3 — in enforce mode `execution` is always null: `result` already carries it, and
+    duplicating it would give two fields that can disagree."""
+    control = _control(_document(ENFORCE), store, clock)
+
+    receipt = control.execute(_action(), _Executor(), "refund:EU-42")
+
+    assert receipt.execution is None
+    assert receipt.would_have is None
+    assert json.loads(receipt.to_json())["would_have"] is None
+
+
+def test_T82_an_absent_mode_key_is_enforce(store, clock):
+    """§6.1 — the fail-closed default, so a document predating the key enforces."""
+    control = _control(V3 + ACTIONS, store, clock)
+
+    assert control.policy.mode == ENFORCE
+    with pytest.raises(ActionDenied):
+        control.execute(
+            _action(arguments={"amount": 90000000, "payment_id": "EU-44"}), _Executor(), None
+        )
+
+
+@pytest.mark.authority
+def test_T82_authority_is_evaluated_in_full_and_recorded_not_enforced(store, clock):
+    """§6.2 — AUTHORITY_DENIED is appended exactly as in enforce mode, including §4.3's rule
+    that a denial by authority skips policy. ACTION_DENIED is not: the action ran."""
+    authority = """
+authority:
+  grants:
+    - id: reads-only
+      subject: { agent: "support-agent" }
+      actions: ["customer.read"]
+"""
+    control = _control(_document(OBSERVE, authority=authority), store, clock)
+    executor = _Executor()
+
+    receipt = control.execute(_action(), executor, "refund:EU-42")
+
+    assert executor.calls == 1
+    assert receipt.result is ReceiptResult.OBSERVED
+    assert receipt.would_have is not None
+    assert receipt.would_have.blocked_reason == "no_authority"
+    assert "AUTHORITY_DENIED" in _types(store)
+    assert "POLICY_EVALUATED" not in _types(store)
+    assert "ACTION_DENIED" not in _types(store)
+
+
+@pytest.mark.authority
+def test_T82_a_grant_that_passes_still_appends_authority_resolved(store, clock):
+    control = _control(_document(OBSERVE, authority=DELEGABLE), store, clock)
+
+    receipt = control.execute(_action(), _Executor(), "refund:EU-42")
+
+    assert receipt.would_have is not None
+    assert receipt.would_have.blocked_reason is None
+    assert "AUTHORITY_RESOLVED" in _types(store)
+    assert "POLICY_EVALUATED" in _types(store)
+
+
+def test_T82_an_expired_principal_is_recorded_and_not_enforced(store, clock):
+    """§6.2's first bullet — `principal_expired` is evaluated and recorded, not enforced.
+    Enforce mode raises `IdentityError` here and never runs the executor."""
+    expired = _action(
+        principal=Principal(agent="support-agent", expires_at=clock.now - timedelta(minutes=1))
+    )
+    executor = _Executor()
+
+    receipt = _control(_document(OBSERVE), store, clock).execute(expired, executor, None)
+
+    assert executor.calls == 1
+    assert receipt.would_have is not None
+    assert receipt.would_have.blocked_reason == "principal_expired"
+    assert receipt.would_have.decision.value == "deny"
+
+    with pytest.raises(IdentityError):
+        _control(_document(ENFORCE), InMemoryStateStore(clock=clock), clock).execute(
+            expired, _Executor(), None
+        )
+
+
+# --- T82b: what observe mode still refuses (§6.2) --------------------------------------
+
+
+def test_T82b_no_principal_is_refused_under_observe(store, clock):
+    """§6.2 — there is no Action to observe and nothing to attribute a receipt to. The shape
+    matches enforce mode's exactly: no receipt, no events."""
+    executor = _Executor()
+
+    @protect("stripe.refund", control=_control(_document(OBSERVE), store, clock))
+    def refund(amount: int, payment_id: str):
+        return executor()
+
+    with pytest.raises(ActionDenied) as refused:
+        refund(amount=1000, payment_id="EU-42")
+
+    assert refused.value.reason == "no_principal"
+    assert executor.calls == 0
+    assert store.events() == ()
+    assert store.receipts() == ()
+
+
+def test_T82b_a_raising_identity_provider_is_refused_under_observe(store, clock):
+    """§6.2 — the same row: no principal was produced, so there is nothing to observe."""
+
+    class _Refusing:
+        def resolve(self, identity_context):
+            raise IdentityError("the credential was rejected")
+
+    executor = _Executor()
+    control = _control(_document(OBSERVE), store, clock, identity=_Refusing())
+
+    @protect("stripe.refund", control=control)
+    def refund(amount: int, payment_id: str):
+        return executor()
+
+    with context("support-agent"), pytest.raises(IdentityError):
+        refund(amount=1000, payment_id="EU-42")
+
+    assert executor.calls == 0
+    assert store.events() == ()
+    assert store.receipts() == ()
+
+
+def test_T82b_an_unresolvable_effect_key_is_refused_under_observe(store, clock):
+    """§6.2 — the action has no identity, so "would it have been a duplicate" has no answer.
+    Recorded exactly as enforce mode records it, and the receipt carries no counterfactual
+    because the action genuinely was stopped (§6.3)."""
+    executor = _Executor()
+    control = _control(_document(OBSERVE), store, clock)
+
+    @protect("stripe.refund", effect="refund:{missing}", control=control)
+    def refund(amount: int, payment_id: str):
+        return executor()
+
+    with context("support-agent"), pytest.raises(EffectKeyError):
+        refund(amount=1000, payment_id="EU-42")
+
+    assert executor.calls == 0
+    assert _types(store) == ["ACTION_PROPOSED", "ACTION_DENIED"]
+    receipt = store.receipts()[-1]
+    assert receipt.result is ReceiptResult.DENIED
+    assert receipt.execution is None
+    assert receipt.would_have is None
+
+
+def test_T82b_an_unrepresentable_argument_is_refused_under_observe(tmp_path, clock):
+    """§6.2 — the Action cannot be constructed, so there is nothing to observe. Asserted
+    through the gateway, because that is the only path that reaches v0.2 §6.6."""
+    from ctrlrun.gateway.server import Gateway, GatewayConfig
+
+    forwarded: list[bytes] = []
+
+    def forwarder(body, headers, *, fresh):
+        forwarded.append(body)
+        return None, b"{}", 200, {}
+
+    document = (
+        f"{V3}mode: observe\n"
+        "actions:\n"
+        "  mcp.acme.create_refund:\n"
+        "    decision: allow\n"
+        '    effect: "refund:{payment_id}"\n'
+    )
+    store = SQLiteStateStore(tmp_path / "state.db", clock=clock)
+    control = Control(Policy.from_yaml(document), store, clock=clock, environment="production")
+    gateway = Gateway(
+        GatewayConfig(
+            upstream="http://127.0.0.1:1/mcp", alias="acme", principal_header="X-Agent", port=0
+        ),
+        control,
+        forwarder,
+    )
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "create_refund", "arguments": {"payment_id": "p1", "amount": 20.0}},
+        }
+    ).encode()
+
+    response = gateway.handle(
+        body,
+        {"content-type": "application/json", "accept": "application/json", "x-agent": "bot"},
+    )
+
+    assert response.status == 400
+    assert json.loads(response.body)["error"]["data"]["error"] == "ctrlrun.unrepresentable_argument"
+    assert forwarded == []
+    receipt = store.receipts()[-1]
+    assert receipt.result is ReceiptResult.DENIED
+    assert receipt.would_have is None
+    store.close()
+
+
+def _gateway(tmp_path, clock, mode, actions, observations):
+    """One `Gateway` over an in-process forwarder, so `handle()` is the whole harness."""
+    from ctrlrun.gateway.server import Gateway, GatewayConfig
+
+    forwarded: list[bytes] = []
+
+    def forwarder(body, headers, *, fresh):
+        forwarded.append(body)
+        return observations.pop(0), b'{"jsonrpc":"2.0","id":1,"result":{"content":[]}}', 200, {}
+
+    document = f"{V3}mode: {mode}\n{actions}"
+    store = SQLiteStateStore(tmp_path / "state.db", clock=clock)
+    control = Control(Policy.from_yaml(document), store, clock=clock, environment="production")
+    config = GatewayConfig(
+        upstream="http://127.0.0.1:1/mcp", alias="acme", principal_header="X-Agent", port=0
+    )
+    return Gateway(config, control, forwarder), store, forwarded
+
+
+def _tools_call(payment_id="p1", amount=200000):
+    return json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "create_refund",
+                "arguments": {"payment_id": payment_id, "amount": amount},
+            },
+        }
+    ).encode()
+
+
+GATEWAY_ACTIONS = """
+actions:
+  mcp.acme.create_refund:
+    decision: approve
+    effect: "refund:{payment_id}"
+"""
+
+
+@pytest.mark.parametrize("mode", [OBSERVE, ENFORCE])
+def test_T82_the_gateway_enforces_nothing_in_observe_mode(tmp_path, clock, mode):
+    """v0.2 §6.10's pre-check refuses a `tools/call` before `Control.execute` is reached — a
+    denied request, a committed key, an ambiguous one. Three of §9's ⚠ rows, enforced by the
+    gateway rather than by the kernel, so §6.1's one switch has to reach them too."""
+    from ctrlrun.gateway.outcome import UpstreamResult
+
+    observed = [UpstreamResult(result_type="content"), UpstreamResult(result_type="content")]
+    gateway, store, forwarded = _gateway(tmp_path, clock, mode, GATEWAY_ACTIONS, observed)
+    store.reserve_effect("refund:p1", "act_earlier", timedelta(minutes=5))
+    store.begin_execution("refund:p1", "act_earlier")
+    store.commit_effect("refund:p1", "act_earlier", None)
+    headers = {"content-type": "application/json", "accept": "application/json", "x-agent": "bot"}
+
+    response = gateway.handle(_tools_call(), headers)
+
+    if mode == OBSERVE:
+        assert forwarded, "the gateway refused a call in observe mode"
+        assert response.status == 200
+        assert store.receipts()[-1].result is ReceiptResult.OBSERVED
+        # The approval gate is the first thing enforce mode would have stopped at, and
+        # `blocked_reason` keeps the first reason: a later refusal is one enforce mode would
+        # never have reached. The committed key is why the pre-check would have refused.
+        assert store.receipts()[-1].would_have.blocked_reason == BLOCKED_APPROVAL_REQUIRED
+        assert store.get_effect("refund:p1").action_id == "act_earlier"
+    else:
+        assert forwarded == []
+        assert json.loads(response.body)["error"]["code"] == -41004
+    store.close()
+
+
+@pytest.mark.authority
+def test_T82b_an_escalating_delegation_is_refused_under_observe(store, clock):
+    """§6.2 — a delegation is a durable authority record, not a decision about an action.
+    No row is written, and T87 makes records created under observe survive the switch."""
+    control = _control(_document(OBSERVE, authority=DELEGABLE), store, clock)
+    escalating = grant_from_yaml(
+        """
+subject: { agent: "support-agent", user: "alice@example.com" }
+actions: ["stripe.refund"]
+constraints: { amount_lte: 900000 }
+expires_at: "2026-12-01T00:00:00Z"
+"""
+    )
+
+    with pytest.raises(AuthorityEscalation) as refused:
+        control.delegate(
+            "head-of-support",
+            escalating,
+            by=Principal(agent="support-agent", user="alice@example.com"),
+        )
+
+    assert refused.value.reason == "containment"
+    assert store.delegations(include_revoked=True) == ()
+    assert "DELEGATION_REJECTED" in _types(store)
+    assert "DELEGATION_CREATED" not in _types(store)
+
+
+# --- T82c: observe mode asks no human (§6.2) -------------------------------------------
+
+
+def test_T82c_observe_mode_asks_no_human(store, clock):
+    needs_a_human = _action(arguments={"amount": 100000, "payment_id": "EU-43"})
+    control = _control(_document(OBSERVE), store, clock)
+    executor = _Executor()
+
+    try:
+        receipt = control.execute(needs_a_human, executor, "refund:EU-43")
+    except ApprovalRequired as pending:  # pragma: no cover - the raise is the failure
+        raise AssertionError(
+            f"observe mode created approval request {pending.request_id}; SPEC-v0.3 §6.2 "
+            "forbids paging a human about an action it is about to execute regardless"
+        ) from pending
+
+    assert executor.calls == 1
+    assert receipt.result is ReceiptResult.OBSERVED
+    assert receipt.would_have is not None
+    assert receipt.would_have.decision.value == "approve"
+    assert receipt.would_have.blocked_reason == BLOCKED_APPROVAL_REQUIRED
+    assert store.approvals_for(needs_a_human.action_hash) == ()
+    assert "APPROVAL_REQUESTED" not in _types(store)
+
+
+def test_T82c_enforce_mode_still_asks(store, clock):
+    """The control: without it, an `execute` that never reached the approval gate at all
+    would satisfy the test above."""
+    control = _control(_document(ENFORCE), store, clock)
+
+    with pytest.raises(ApprovalRequired):
+        control.execute(
+            _action(arguments={"amount": 100000, "payment_id": "EU-43"}), _Executor(), None
+        )
+
+    assert "APPROVAL_REQUESTED" in _types(store)
+
+
+# --- T83: a duplicate is recorded and still runs (§6.2, §6.3) --------------------------
+
+
+def test_T83_a_duplicate_is_recorded_and_still_runs(store, clock):
+    control = _control(_document(OBSERVE), store, clock)
+    executor = _Executor()
+
+    control.execute(_action(), executor, "refund:EU-42")
+    before = store.get_effect("refund:EU-42")
+    second = control.execute(_action(), executor, "refund:EU-42")
+    after = store.get_effect("refund:EU-42")
+
+    assert executor.calls == 2
+    assert second.would_have is not None
+    assert second.would_have.blocked_reason == BLOCKED_DUPLICATE
+    # §6.3 — `execution` describes the executor, which ran and returned. It is not a claim
+    # about the effect record, which this attempt never held.
+    assert second.execution is ReceiptResult.COMMITTED
+    assert (after.state, after.attempt, after.action_id) == (
+        before.state,
+        before.attempt,
+        before.action_id,
+    )
+
+
+def test_T83_a_refused_reservation_never_touches_the_store_record(store, clock, monkeypatch):
+    """§6.2's first reason, isolated. `commit_effect` and its siblings admit only the holder
+    (v0.1 §5.3 E1), so an attempt that wrote here would be refused by the store — which means
+    a test asserting only the record's final state cannot tell the two defences apart. This
+    one asserts the store was never asked."""
+    asked: list[tuple[str, str]] = []
+
+    for name in ("begin_execution", "commit_effect", "fail_effect", "mark_ambiguous"):
+        original = getattr(InMemoryStateStore, name)
+
+        def recording(self, effect_key, action_id, *args, _name=name, _original=original, **kw):
+            asked.append((_name, action_id))
+            return _original(self, effect_key, action_id, *args, **kw)
+
+        monkeypatch.setattr(InMemoryStateStore, name, recording)
+
+    control = _control(_document(OBSERVE), store, clock)
+    executor = _Executor()
+    control.execute(_action(), executor, "refund:EU-42")
+    first = {action_id for _, action_id in asked}
+    second = control.execute(_action(), executor, "refund:EU-42")
+
+    assert executor.calls == 2
+    assert second.would_have.blocked_reason == BLOCKED_DUPLICATE
+    assert {action_id for _, action_id in asked} == first, (
+        "observe mode asked the store to move a record its attempt never reserved"
+    )
+
+
+def test_T83_an_ambiguous_record_is_recorded_and_left_ambiguous(store, clock):
+    """§6.2 — a record already in AMBIGUOUS would be moved to COMMITTED by a machine, and
+    v0.1 §5.2 reserves that for a human. The `else` branch fails the test."""
+    control = _control(_document(OBSERVE), store, clock)
+
+    with pytest.raises(TimeoutError):
+        control.execute(_action(), _explode, "refund:EU-42")
+    assert store.get_effect("refund:EU-42").state is EffectState.AMBIGUOUS
+
+    executor = _Executor()
+    second = control.execute(_action(), executor, "refund:EU-42")
+
+    assert executor.calls == 1
+    assert second.would_have is not None
+    assert second.would_have.blocked_reason == BLOCKED_AMBIGUOUS
+    record = store.get_effect("refund:EU-42")
+    if record.state is not EffectState.AMBIGUOUS:
+        raise AssertionError(
+            f"observe mode moved an AMBIGUOUS record to {record.state}; SPEC-v0.3 §6.2 "
+            "reserves that for a human and for the reconcile hook, and observe mode is neither"
+        )
+
+
+def test_T83_the_reconcile_hook_is_never_called_in_observe_mode(store, clock):
+    """§6.2 — its blocking trigger fires when an AMBIGUOUS record refuses a reservation; in
+    observe mode that refusal is ignored, so there is nothing being unblocked."""
+    control = _control(_document(OBSERVE), store, clock)
+    asked: list[str] = []
+
+    def reconcile(effect_key):
+        asked.append(effect_key)
+        return "committed"
+
+    with pytest.raises(TimeoutError):
+        control.execute(_action(), _explode, "refund:EU-42")
+
+    executor = _Executor()
+    second = control.execute(_action(), executor, "refund:EU-42", reconcile=reconcile)
+
+    assert asked == []
+    assert executor.calls == 1
+    assert second.would_have is not None
+    assert second.would_have.blocked_reason == BLOCKED_AMBIGUOUS
+    assert store.get_effect("refund:EU-42").state is EffectState.AMBIGUOUS
+    assert "RECONCILIATION_STARTED" not in _types(store)
+
+
+def test_T83_the_same_hook_is_called_in_enforce_mode(store, clock):
+    """The control for the test above: the hook has to be one the real code would call."""
+    control = _control(_document(ENFORCE), store, clock)
+    asked: list[str] = []
+
+    def reconcile(effect_key):
+        asked.append(effect_key)
+        return "unknown"
+
+    with pytest.raises(TimeoutError):
+        control.execute(_action(), _explode, "refund:EU-42")
+    with pytest.raises(AmbiguousEffect):
+        control.execute(_action(), _Executor(), "refund:EU-42", reconcile=reconcile)
+
+    assert asked == ["refund:EU-42"]
+
+
+def test_T83_enforce_mode_still_refuses_the_duplicate(store, clock):
+    """The control: without it, a `_secure` that never reserved anything would satisfy the
+    two observe tests above."""
+    control = _control(_document(ENFORCE), store, clock)
+    executor = _Executor()
+
+    control.execute(_action(), executor, "refund:EU-42")
+    with pytest.raises(DuplicateEffect):
+        control.execute(_action(), executor, "refund:EU-42")
+
+    assert executor.calls == 1
+
+
+def test_T83_a_key_another_attempt_holds_is_recorded_as_in_progress(store, clock):
+    """§6.3's vocabulary keeps `duplicate` and `in_progress` apart, because one says the
+    effect happened and the other says another attempt holds the key right now."""
+    control = _control(_document(OBSERVE), store, clock)
+    store.reserve_effect("refund:EU-42", "act_someone_else", timedelta(minutes=5))
+    executor = _Executor()
+
+    receipt = control.execute(_action(), executor, "refund:EU-42")
+
+    assert executor.calls == 1
+    assert receipt.would_have is not None
+    assert receipt.would_have.blocked_reason == BLOCKED_IN_PROGRESS
+    record = store.get_effect("refund:EU-42")
+    assert (record.state, record.action_id) == (EffectState.RESERVED, "act_someone_else")
+
+
+def test_T83_an_executor_that_fails_on_a_held_key_still_writes_the_record(store, clock):
+    """§6.2 — where the reservation *succeeded*, the outcome maps through v0.1 §5.5 unchanged
+    and this attempt's effect record is written. Observe mode records what happened."""
+    control = _control(_document(OBSERVE), store, clock)
+
+    with pytest.raises(TimeoutError):
+        control.execute(_action(), _explode, "refund:EU-42")
+
+    assert store.get_effect("refund:EU-42").state is EffectState.AMBIGUOUS
+    receipt = store.receipts()[-1]
+    assert receipt.result is ReceiptResult.OBSERVED
+    assert receipt.execution is ReceiptResult.AMBIGUOUS
+
+
+# --- T84: `mode` is top-level only (§6.1) ----------------------------------------------
+
+
+NESTED = {
+    "action entry": V3
+    + """
+actions:
+  stripe.refund:
+    mode: observe
+    decision: allow
+""",
+    "rule": V3
+    + """
+actions:
+  stripe.refund:
+    rules:
+      - when: { amount_lte: 100 }
+        mode: observe
+        decision: allow
+""",
+    "grant": V3
+    + """
+authority:
+  grants:
+    - id: g
+      mode: observe
+      subject: { agent: "a" }
+      actions: ["stripe.refund"]
+"""
+    + ACTIONS,
+    "authority section": V3
+    + """
+authority:
+  mode: observe
+  grants: []
+"""
+    + ACTIONS,
+}
+
+
+@pytest.mark.parametrize("where", sorted(NESTED))
+def test_T84_mode_is_refused_anywhere_but_the_top_level(where, tmp_path):
+    """`Control.from_file` is the load: it runs both loaders over the same document, which is
+    the only place all four nestings are read (§4.8)."""
+    (tmp_path / "ctrlrun.yaml").write_text(NESTED[where])
+
+    with pytest.raises(PolicyError) as refused:
+        Control.from_file(tmp_path / "ctrlrun.yaml")
+
+    assert "ctrlrun.yaml" in str(refused.value)
+    assert "'mode'" in str(refused.value)
+    assert "top level" in str(refused.value)
+
+
+@pytest.mark.parametrize("where", ["action entry", "rule"])
+def test_T84_the_policy_loader_owns_the_two_nestings_inside_actions(where):
+    with pytest.raises(PolicyError) as refused:
+        Policy.from_yaml(NESTED[where], source="policy.yaml")
+
+    assert "policy.yaml" in str(refused.value)
+    assert "top level" in str(refused.value)
+
+
+@pytest.mark.parametrize("where", ["grant", "authority section"])
+def test_T84_the_authority_loader_owns_the_two_inside_the_section(where):
+    """§4.8 — the `authority:` section is parsed by `authority.py` on the `--authority` path,
+    which the policy loader never reads. The guard exists on both, not on whichever runs
+    first."""
+    with pytest.raises(PolicyError) as refused:
+        Authority.from_yaml(NESTED[where], source="policy.yaml")
+
+    assert "top level" in str(refused.value)
+
+
+def test_T84_mode_is_refused_in_a_standalone_authority_document():
+    """§8.3 — an `--authority` document carries `schema` and `authority` and nothing else."""
+    document = V3 + "mode: observe\nauthority:\n  grants: []\n"
+
+    with pytest.raises(PolicyError) as refused:
+        Authority.from_yaml(document, source="authority.yaml", standalone=True)
+
+    assert "authority.yaml" in str(refused.value)
+    assert "mode" in str(refused.value)
+
+
+@pytest.mark.parametrize("value", ["true", '"off"', "0", '"Observe"', '"enforced"', "null", "[]"])
+def test_T84_mode_must_be_exactly_observe_or_enforce(value):
+    with pytest.raises(PolicyError) as refused:
+        Policy.from_yaml(f"{V3}mode: {value}\n{ACTIONS}", source="policy.yaml")
+
+    assert "observe" in str(refused.value) and "enforce" in str(refused.value)
+
+
+@pytest.mark.parametrize("mode", [OBSERVE, ENFORCE])
+def test_T84_both_accepted_values_load(mode):
+    assert Policy.from_yaml(f"{V3}mode: {mode}\n{ACTIONS}").mode == mode
+
+
+def test_T84_mode_needs_schema_v3():
+    """§12.1 — a reader that ignored `mode: observe` would enforce a configuration that was
+    deployed to observe."""
+    with pytest.raises(PolicyError) as refused:
+        Policy.from_yaml("schema: ctrlrun.policy/v2\nmode: observe\n" + ACTIONS)
+
+    assert "ctrlrun.policy/v3" in str(refused.value)
+
+
+def test_T84_a_mistyped_mode_key_is_caught_by_the_closed_top_level_key_set():
+    with pytest.raises(PolicyError, match="Mode"):
+        Policy.from_yaml(f"{V3}Mode: observe\n{ACTIONS}")
+
+
+# --- T85: the banner, and `ctrlrun verify` (§6.5) --------------------------------------
+
+#: §6.5's two columns, by name. v0.3 moves no command across the line.
+LOADS_THE_POLICY = ("gateway", "stats", "delegate", "revoke", "verify")
+DOES_NOT = ("init", "demo", "approve", "deny", "receipts", "effects", "resolve", "inspect")
+
+#: Enough arguments for each command to reach its body. Several exit non-zero against an
+#: empty store, which is the point: the banner is printed before anything else.
+ARGUMENTS = {
+    "gateway": ("--upstream", "http://127.0.0.1:1/mcp", "--alias", "acme", "--principal", "bot"),
+    "stats": (),
+    "delegate": ("--parent", "head-of-support", "--file", "grant.yaml", "--as", "bot"),
+    "revoke": ("dlg_00000000000000000000000000000000",),
+    "verify": (),
+    "init": (),
+    "demo": (),
+    "approve": ("apr_0",),
+    "deny": ("apr_0",),
+    "receipts": (),
+    "effects": (),
+    "resolve": ("k", "--committed"),
+    "inspect": ("act_0",),
+}
+
+
+@pytest.fixture
+def cli(tmp_path, monkeypatch):
+    """A working directory, and a `serve()` that records instead of listening."""
+    import ctrlrun.gateway as gateway_module
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CTRLRUN_STATE", str(tmp_path / "state.db"))
+    monkeypatch.setattr(gateway_module, "serve", lambda **kwargs: None)
+    (tmp_path / "grant.yaml").write_text('subject: { agent: "bot" }\nactions: ["customer.read"]\n')
+    return tmp_path
+
+
+def _write_policy(directory, mode):
+    (directory / "ctrlrun.yaml").write_text(_document(mode))
+
+
+def _run(*arguments):
+    return CliRunner().invoke(main, list(arguments))
+
+
+@pytest.fixture
+def loads(monkeypatch):
+    """Records every `Policy.from_file`, so "does this command load the policy" is answered
+    by the call and not by string-matching output a command happened not to print."""
+    calls: list[str] = []
+    original = Policy.from_file
+
+    def recording(*args, **kwargs):
+        calls.append("loaded")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(Policy, "from_file", recording)
+    return calls
+
+
+@pytest.mark.parametrize("command", LOADS_THE_POLICY)
+def test_T85_every_command_that_loads_the_policy_prints_the_banner(cli, command, loads):
+    _write_policy(cli, OBSERVE)
+    observed = _run(command, *ARGUMENTS[command])
+
+    _write_policy(cli, ENFORCE)
+    enforced = _run(command, *ARGUMENTS[command])
+
+    assert loads, f"{command} never loaded the policy at all"
+    assert OBSERVE_BANNER in observed.stderr, observed.output
+    assert OBSERVE_BANNER not in observed.stdout
+    assert OBSERVE_BANNER not in enforced.output
+
+
+@pytest.mark.parametrize("command", DOES_NOT)
+def test_T85_no_other_command_prints_the_banner_or_loads_the_policy(cli, command, loads):
+    """The right-hand column is not an oversight: reading evidence must not depend on the
+    configuration that produced it, so these work with no policy file at all. Asserted on the
+    load itself — the test above proves the recorder sees one when it happens."""
+    _write_policy(cli, OBSERVE)
+    with_policy = _run(command, *ARGUMENTS[command])
+
+    (cli / "ctrlrun.yaml").unlink()
+    without = _run(command, *ARGUMENTS[command])
+
+    assert loads == [], f"{command} loaded the operator's policy"
+    assert OBSERVE_BANNER not in with_policy.output
+    assert OBSERVE_BANNER not in without.output
+
+
+def test_T85_the_banner_keeps_json_stdout_parseable(cli):
+    _write_policy(cli, OBSERVE)
+
+    result = _run("stats", "--json")
+
+    assert OBSERVE_BANNER in result.stderr
+    assert json.loads(result.stdout)["schema"] == STATS_SCHEMA
+
+
+@pytest.mark.parametrize("mode", [OBSERVE, ENFORCE])
+def test_T85_verify_exits_2_naming_v0_4(cli, mode):
+    _write_policy(cli, mode)
+
+    result = _run("verify")
+
+    assert result.exit_code == 2
+    assert "0.4" in result.stderr
+    assert result.stdout == ""
+
+
+def test_T85_a_policy_that_cannot_be_loaded_exits_non_zero_without_a_banner(cli):
+    """§6.5 — the banner is not printed, because there is no mode to report."""
+    (cli / "ctrlrun.yaml").write_text("schema: nope\n")
+
+    result = _run("stats")
+
+    assert result.exit_code != 0
+    assert OBSERVE_BANNER not in result.output
+
+
+# --- T86: `ctrlrun stats` (§6.4) -------------------------------------------------------
+
+
+def _seed(store, clock, *, observe=True):
+    """Receipts with known shapes, one per line of §6.4's report."""
+    control = Control(
+        Policy.from_yaml(_document(OBSERVE if observe else ENFORCE)),
+        store,
+        clock=clock,
+        environment="production",
+    )
+    executor = _Executor()
+
+    def run(action, effect_key, refusal):
+        if observe:
+            control.execute(action, executor, effect_key)
+            return
+        with pytest.raises(refusal):
+            control.execute(action, executor, effect_key)
+
+    control.execute(_action(arguments={"amount": 10, "payment_id": "A"}), executor, "k:A")
+    for suffix in ("B", "C"):
+        run(
+            _action(arguments={"amount": 90000000, "payment_id": suffix}),
+            f"k:{suffix}",
+            ActionDenied,
+        )
+    run(
+        _action(name="stripe.chargeback", arguments={"amount": 1, "payment_id": "D"}),
+        "k:D",
+        ActionDenied,
+    )
+    run(_action(arguments={"amount": 100000, "payment_id": "E"}), "k:E", ApprovalRequired)
+    run(_action(arguments={"amount": 10, "payment_id": "A"}), "k:A", DuplicateEffect)
+    with pytest.raises(TimeoutError):
+        control.execute(_action(arguments={"amount": 10, "payment_id": "F"}), _explode, "k:F")
+
+
+@pytest.fixture
+def seeded(cli, clock):
+    _write_policy(cli, OBSERVE)
+    store = SQLiteStateStore(cli / "state.db", clock=clock)
+    _seed(store, clock)
+    store.close()
+    return cli
+
+
+def test_T86_stats_counts_what_observe_mode_recorded(seeded):
+    result = _run("stats")
+    document = json.loads(_run("stats", "--json").stdout)
+
+    assert result.exit_code == 0, result.output
+    assert document["mode"] == "observe"
+    assert document["actions"] == 7
+    assert document["would_have_been_denied"] == 3
+    assert document["denied_by_reason"]["unknown_action"] == 1
+    assert sum(document["denied_by_reason"].values()) == 3
+    assert document["would_have_needed_approval"] == 1
+    assert document["would_have_been_blocked"] == 1
+    assert document["blocked_by_reason"] == {"duplicate": 1}
+    assert document["ambiguous_outcomes"] == 1
+    assert "would have been denied" in result.stdout
+    assert "unknown_action" in result.stdout
+    assert "(observe mode)" in result.stdout
+
+
+def test_T86_the_json_matches_the_human_output_number_for_number(seeded):
+    human = _run("stats").stdout
+    document = json.loads(_run("stats", "--json").stdout)
+
+    for key in (
+        "actions",
+        "would_have_been_denied",
+        "would_have_needed_approval",
+        "would_have_been_blocked",
+        "ambiguous_outcomes",
+    ):
+        assert str(document[key]) in human, key
+    for reason, count in document["denied_by_reason"].items():
+        assert reason in human
+        assert str(count) in human
+
+
+def test_T86_enforce_mode_reports_less_and_says_so(cli, clock):
+    _write_policy(cli, ENFORCE)
+    store = SQLiteStateStore(cli / "state.db", clock=clock)
+    _seed(store, clock, observe=False)
+    store.close()
+
+    result = _run("stats")
+    document = json.loads(_run("stats", "--json").stdout)
+
+    assert document["mode"] == "enforce"
+    assert "would_have_been_blocked" not in document
+    assert "blocked_by_reason" not in document
+    assert document["denied"] == 3
+    assert document["ambiguous_outcomes"] == 1
+    assert "would have been" not in result.stdout
+    assert "blocked_reason" in result.stdout
+
+
+@pytest.mark.parametrize("since", ["24h", "7d", "30m", "2026-09-03T00:00:00+00:00"])
+def test_T86_an_accepted_since_window_parses(seeded, since):
+    assert _run("stats", "--since", since).exit_code == 0, since
+
+
+@pytest.mark.parametrize(
+    "since",
+    # `2026-09-03T00:00:00` parses perfectly well and carries no offset. Comparing it with a
+    # timezone-aware `finished_at` raises, so §6.4 requires one and this asserts the refusal.
+    ["1w", "2mo", "5", "yesterday", "24 h", "-1h", "0h", "", "2026-09-03T00:00:00"],
+)
+def test_T86_an_unaccepted_since_exits_non_zero_naming_the_forms(seeded, since):
+    result = _run("stats", "--since", since)
+
+    assert result.exit_code != 0, since
+    assert "ISO-8601" in result.output
+    assert "30m" in result.output
+
+
+def test_T86_since_filters_on_finished_at_and_the_boundary_is_included(seeded):
+    store = SQLiteStateStore(seeded / "state.db")
+    boundary = max(receipt.finished_at for receipt in store.receipts())
+    store.close()
+
+    everything = json.loads(_run("stats", "--json").stdout)
+    on_it = json.loads(_run("stats", "--since", boundary.isoformat(), "--json").stdout)
+    after = json.loads(
+        _run("stats", "--since", (boundary + timedelta(seconds=1)).isoformat(), "--json").stdout
+    )
+
+    assert everything["actions"] == 7
+    assert on_it["actions"] == 7
+    assert after["actions"] == 0
+
+
+def test_T86_an_empty_store_prints_zeros_and_exits_zero(cli):
+    _write_policy(cli, OBSERVE)
+
+    result = _run("stats")
+    document = json.loads(_run("stats", "--json").stdout)
+
+    assert result.exit_code == 0, result.output
+    assert document["actions"] == 0
+    assert "0" in result.stdout
+
+
+def test_T86_stats_says_that_actions_awaiting_a_human_are_not_counted(seeded):
+    assert "awaiting a human" in _run("stats").stdout
+
+
+def test_T86_stats_reaches_no_network(seeded, monkeypatch):
+    """§6.4 — from the local store and nothing else. A claim about the environment is a claim
+    until something takes the network away."""
+
+    def refuse(*args, **kwargs):
+        raise AssertionError("ctrlrun stats opened a socket")
+
+    monkeypatch.setattr(socket, "socket", refuse)
+    monkeypatch.setattr(socket, "create_connection", refuse)
+    monkeypatch.setattr(socket, "getaddrinfo", refuse)
+
+    result = _run("stats")
+
+    assert result.exit_code == 0, result.output
+
+
+# --- T87: observe → enforce needs no migration (§6.6) ----------------------------------
+
+
+@pytest.mark.authority
+def test_T87_a_store_written_under_observe_is_read_by_an_enforcing_control(tmp_path, clock):
+    """One store, one file, one edited line. Every table opens, the effect committed under
+    observe is refused as a duplicate under enforce, and the delegation still evaluates."""
+    policy = tmp_path / "ctrlrun.yaml"
+    store = SQLiteStateStore(tmp_path / "state.db", clock=clock)
+
+    def control_for(mode):
+        policy.write_text(_document(mode, authority=DELEGABLE))
+        text = policy.read_text()
+        return Control(
+            Policy.from_yaml(text),
+            store,
+            authority=Authority.from_yaml(text),
+            clock=clock,
+            environment="production",
+        )
+
+    observing = control_for(OBSERVE)
+    delegated = observing.delegate(
+        "head-of-support",
+        grant_from_yaml(
+            """
+subject: { agent: "support-agent", user: "alice@example.com" }
+actions: ["stripe.refund"]
+constraints: { amount_lte: 1000 }
+expires_at: "2026-12-01T00:00:00Z"
+"""
+        ),
+        by=Principal(agent="support-agent", user="alice@example.com"),
+    )
+    observing.execute(_action(), _Executor(), "refund:EU-42")
+
+    enforcing = control_for(ENFORCE)
+
+    assert store.get_delegation(delegated.delegation_id) is not None
+    assert enforcing.evaluate(_action()).decision.value == "allow"
+    assert store.receipts()[0].result is ReceiptResult.OBSERVED
+    with pytest.raises(DuplicateEffect):
+        enforcing.execute(_action(), _Executor(), "refund:EU-42")
+    store.close()
+
+
+@pytest.mark.authority
+def test_T87_a_delegation_created_under_observe_is_enforced_after_the_switch(tmp_path, clock):
+    """The other half: the record survives, and it also still *binds*. A delegated grant
+    capped at 1000 refuses 2000 the moment the switch is thrown."""
+    policy = tmp_path / "ctrlrun.yaml"
+    store = SQLiteStateStore(tmp_path / "state.db", clock=clock)
+
+    def control_for(mode):
+        policy.write_text(_document(mode, authority=DELEGABLE))
+        text = policy.read_text()
+        return Control(
+            Policy.from_yaml(text),
+            store,
+            authority=Authority.from_yaml(text),
+            clock=clock,
+            environment="production",
+        )
+
+    control_for(OBSERVE).delegate(
+        "head-of-support",
+        grant_from_yaml(
+            """
+subject: { agent: "junior-agent", user: "alice@example.com" }
+actions: ["stripe.refund"]
+constraints: { amount_lte: 1000 }
+expires_at: "2026-12-01T00:00:00Z"
+"""
+        ),
+        by=Principal(agent="support-agent", user="alice@example.com"),
+    )
+    junior = Principal(agent="junior-agent", user="alice@example.com")
+    enforcing = control_for(ENFORCE)
+
+    assert enforcing.evaluate(_action(principal=junior)).decision.value == "allow"
+    assert (
+        enforcing.evaluate(
+            _action(principal=junior, arguments={"amount": 2000, "payment_id": "EU-42"})
+        ).decision.value
+        == "deny"
+    )
+    store.close()


### PR DESCRIPTION
Build-list item 4. SPEC-v0.3 §6. Tests T82–T87 (plus T82b, T82c) in `tests/test_observe.py`.

## What it does

A top-level `mode: observe` runs every real decision against real traffic and records what *would* have been blocked, without blocking anything. `Control.execute` returns a receipt rather than raising: `result: "observed"`, `execution` for what the executor actually did, `would_have` for what enforce mode would have reached and what it would have done with it.

It is **not a dry run**. It executes, effects land at remotes, and the records of them are real (§6.6).

## Three things it deliberately does not do

- **It creates no approval request.** A policy reaching `approve` records `approval_required` and the action runs. Paging a human about an action that executes regardless of the answer produces a queue, not evidence. (T82c)
- **It writes no effect record for a reservation it lost.** A record already `AMBIGUOUS` stays `AMBIGUOUS` — v0.1 §5.2 reserves that move for a human. T83 asserts the store was never *asked*, not merely that the state is unchanged: `commit_effect` refuses a non-holder anyway, so a test on the final state alone cannot tell the two defences apart.
- **It never calls the `reconcile` hook.** Its blocking trigger fires when an `AMBIGUOUS` record refuses a reservation; here that refusal is ignored, so nothing is being unblocked.

## Five it still refuses, in both modes (§6.2)

No principal · a provider that raises · an unresolvable effect key · an unrepresentable argument (through the gateway) · a delegation that would escalate. The first four are wiring bugs that would run an action CTRLRun could not describe; the fifth is an act of authority rather than a decision about an action.

## One switch, and it governs the process

`mode:` inside an action entry, a rule, a grant or the `authority:` section is a load error naming the rule — not "unknown key 'mode'", which reads as "CTRLRun has no such setting" to an author who believes they have observed one action while enforcing the rest. Both loaders own their nestings, because the `--authority` document of §8.3 never reaches the policy loader.

## CLI

- `ctrlrun stats` — from the local store and nothing else, bucketing on `would_have.blocked_reason`. `--since` takes ISO-8601 **with an offset** or `30m`/`24h`/`7d`, inclusive at the boundary; `--json` under `ctrlrun.stats/v1`. In enforce mode it reports what happened and reports *less*, saying so in its footer rather than printing a line the receipts cannot substantiate.
- The `OBSERVE MODE — nothing is enforced` banner, to stderr, before anything else, on every invocation of `gateway`, `stats`, `delegate`, `revoke`, `verify`. T85 asserts it **on the `Policy.from_file` call**, so a right-column command that loads one and happens not to print cannot pass, and the left-column test proves the recorder sees a load when it happens.
- `ctrlrun verify` — a stub that exits 2 naming 0.4. Runs nothing, checks nothing, claims nothing.

## One thing outside §6 that observe mode reached into

The gateway's v0.2 §6.10 pre-check refuses a `tools/call` before `Control.execute` is reached — a denied request, a committed key, an ambiguous one. Three of §9's ⚠ rows, enforced by the gateway rather than by the kernel, so an operator measuring what enforcement would cost was reading a number the gateway had already changed. It is skipped in observe mode, tested in both.

## Mutation table

25 rows, every one red. Two came back green on the first pass and both were real gaps rather than equivalent mutants:

| | Mutation | Result |
|---|---|---|
| M1 | `mode: observe` is ignored | RED — 14 failures |
| M2 | the mode value is not validated (`mode: true` loads) | RED |
| M3 | an absent mode defaults to observe | RED — 277 failures across the suite |
| M4 | a nested `mode:` is not refused | RED |
| M5 | `mode:` does not need schema v3 | RED |
| M6 | observe mode creates the approval request anyway | RED — T82c |
| M7 | observe mode writes the effect record it did not reserve | **first GREEN** — masked by `begin_execution` also refusing a non-holder; now RED against a test that asserts the store was never asked |
| M8 | the reconcile hook runs in observe mode | RED — with the enforce-mode control proving the hook would otherwise be called |
| M9 | `duplicate` and `in_progress` are not told apart | RED |
| M10–M12 | expired principal / authority denial not recorded; `POLICY_EVALUATED` appended after an authority denial | RED |
| M13–M16 | `result`, `would_have`, `execution`; `blocked_reason` keeps the last reason | RED |
| M17–M19 | banner absent; banner on stdout; `verify` exits 0 | RED |
| M20 | `--since` accepts a naive timestamp | **first GREEN** — nothing in the refused list parsed as a naive ISO datetime; now RED |
| M21 | `--since` exclusive at the boundary | RED |
| M22 | enforce mode prints a breakdown it cannot substantiate | RED |
| M23 | the gateway keeps enforcing its pre-check in observe mode | RED |
| M24–M25 | the authority loader ignores a nested `mode:` in the section / in a grant | RED |

## Spec ambiguity resolved

`# SPEC:` §6.3 lists `unknown_action` and `no_matching_rule` among `blocked_reason`'s values and stops there, but a policy also denies by a `rule[N]` and by a bare `decision`. Taken uniformly: **a denial's `blocked_reason` is its `decision_reason`.** That is what makes §6.3's two named values right, and inventing a `policy_denied` bucket for the other two would leave `ctrlrun stats` unable to say which rule an operator should look at. Comment in `control.py`.

## Breaking, for readers

`ReceiptResult` gains `observed`. `Receipt.from_dict` parses `result` into a closed `StrEnum`, so a ≤ 0.2 process running `ctrlrun receipts` against a store an 0.3 observe-mode process wrote raises. **Upgrade every reader before switching any writer to `mode: observe`.** An enforce-mode 0.3 writer emits no `observed` receipt and is safe to mix. Recorded in the changelog.

## Verification

`ruff format --check`, `ruff check`, `mypy --strict src/` clean. 1699 tests pass (85 new). `ctrlrun demo` runs in 0.09s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)