### PR TITLE
item 5: JWT identity and gateway wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,79 @@ shipped, and the only thing in the tree today is the contract.
 
 ### Added
 
+- **`JWTIdentityProvider`** (build-list item 5, SPEC-v0.3 §3.4), in `ctrlrun[identity]`
+  (`pyjwt[crypto]`), imported by naming it. It reads a bearer token from a header, verifies it
+  against a JWKS or a static key, and maps the verified claims onto a `Principal`. **It issues
+  nothing**: no OAuth flow, no refresh, no token exchange, no introspection, no dynamic client
+  registration. An absent header is a *decline*; a present and invalid one is a *refusal*, and
+  `Control` never backfills from one.
+- **Configuration is refused before any token is seen.** More or fewer than one key source; an
+  `HS*` algorithm with `jwks_url` or `public_key`; an asymmetric algorithm with `secret`; an
+  empty `algorithms`; `none` in any casing; `token_type` not passed at all. The
+  `HS*`-with-a-public-key case is key confusion in its plainest form — RS256→HS256 is literally
+  "HMAC the token using the PEM of the public key as the secret" — and it is refused at the
+  *configuration* end, which is the end that can be refused.
+- **`token_type` is required, and it is the whole cross-JWT defence.** Without it an OIDC ID
+  token from the same issuer, signed with the same key, carrying the configured `aud`, passes
+  every other check (RFC 8725 §2). Passing `None` explicitly is permitted and warns at
+  construction naming exactly what it gives up.
+- **`aud` by membership on either wire shape**, never a raw `in`: on the string shape that is
+  substring matching, and it accepts `https://ctrlrun.example` for a configured `ctrl`. `exp`
+  is **required** — a credential with no expiry cannot be revoked by waiting, and v0.3 has no
+  revocation channel — and `exp`/`nbf` are compared against the provider's injected clock, so
+  an expiry boundary is tested exactly rather than raced.
+- **JWKS handling that cannot be turned into a load generator.** An unknown `kid` triggers at
+  most one refresh and then a refusal; a second such token inside `jwks_min_refresh_interval`
+  is refused with no fetch at all. A set with two entries sharing a `kid` is refused rather
+  than resolved by first match; a key whose `use` is not `sig` or whose `key_ops` excludes
+  verification is ignored; a key carrying its own `alg` constrains itself. A failed fetch is a
+  refusal that discards nothing, and **nothing is followed**: the fetch refuses a redirect
+  outright and re-checks the scheme of the URL that actually answered. `urllib`'s
+  `build_opener` keeps its `HTTPRedirectHandler` unless an argument subclasses it, so an
+  opener built the obvious way follows a 302 — including one to plaintext `http://` on
+  another host. An open redirect on the issuer's domain would otherwise have this process
+  fetch its signing keys in cleartext from wherever it pointed, cache them for the life of
+  the process, and verify every token the attacker then signed.
+- **Two limits stated rather than configured around.** `issuer` is an exact string, so a
+  tenant-templated issuer cannot be configured correctly here — pointing it at a multi-tenant
+  endpoint without pinning the tenant makes every tenant on that platform a valid issuer. And
+  there is no revocation channel: short token lifetimes are the whole of the story.
+- **Gateway identity selection** (§8.2). `--principal` and `--principal-header` are understood
+  as constructors now — `StaticIdentityProvider` and `HeaderIdentityProvider` — and
+  `--identity-jwt` is a third, with its own flags. Exactly one is required, still with no
+  default; every `--identity-jwt-*` flag is an error without `--identity-jwt`, because a flag
+  that cannot take effect is a flag the operator believes took effect — and the test for that
+  reads the flag list off the command itself rather than off the check, because a list copied
+  from the code under test cannot fail for the flag the code forgot. The shared secret is
+  read from a **file**, never from a flag value: a secret on a command line is in every process
+  listing on the host. `--identity-jwt-http-timeout` bounds the JWKS fetch and is **its own
+  flag**: the fetch runs on the request thread before any decision is made, so borrowing
+  `--upstream-timeout` would have coupled two unrelated knobs in the fail-slow direction.
+- **`ctrlrun gateway --authority PATH`** (§8.3), because the person who writes grants and the
+  person who writes per-action autonomy are often not the same person. That document is not a
+  policy document — its top-level key set is closed at `schema` and `authority`, so `actions:`
+  or `mode:` in it is a load error naming the file and the key. Declaring `authority:` in both
+  the policy and `--authority` refuses to start, naming both paths.
+- **`-41012` `ctrlrun.unauthorized`** (§8.4). A tool call outside the principal's grant returns
+  it, HTTP 403, upstream untouched; `v0.2 §6.10`'s `-41001` now means a **policy** denial. The
+  gateway catches `AuthorityDenied` **before** `ActionDenied`, which it subclasses — the other
+  order makes the new code unreachable while every test asserting only "it was refused" stays
+  green, so both halves are pinned by name.
+- **No refusal reaches a client as a dropped connection.** `do_POST` has no top-level
+  handler, and an escaping exception makes `socketserver` close the socket with nothing
+  written — which a client reads as a transport failure, and a transport failure is the one
+  signal it retries on. Three v0.3 paths landed there and each now answers: an authority
+  denial or an expired credential on a **continuation** (`-41012` / `-41007`), an expired
+  principal in `Control.execute` (`-41007`, and `IdentityError` is deliberately not an
+  `ActionDenied`, so it needs its own clause), and an identity provider raising anything at
+  all, which §3.2 makes an `IdentityError` in-process and now does at the gateway too. The
+  expired-principal path is routine rather than adversarial: the JWT provider admits a token
+  up to `leeway` past its `exp`, so every token in that 60-second window was affected.
+- **A startup block that says what is in force** (§8.4): the environment, the identity provider
+  by name and the header it trusts, whether an `authority:` section is loaded and how many
+  grants it holds — or the single line `no authority: section — every principal is
+  unrestricted`, so an operator who believes they configured authority finds out on the line
+  that starts the process.
 - **Observe mode** (build-list item 4, SPEC-v0.3 §6). A top-level `mode: observe` runs every
   real decision against real traffic and records what *would* have been blocked, without
   blocking anything: no `ActionDenied`, no `AuthorityDenied`, no `ApprovalRequired`, no
@@ -142,6 +215,20 @@ shipped, and the only thing in the tree today is the contract.
   splitter, which runs for every condition in every document, and gating it on `v3` would leave
   the same name meaning two things in two files. A `v1` policy whose protected function takes an
   argument called `claims` stops loading until the argument is renamed; the load error says so.
+- **BREAKING: `AcsControlHook` takes an `identity` provider, and ignores the envelope's
+  `agent_id` and `environment` when it has one** (§8.4). Under v0.2 both came off the wire, on
+  exactly the argument `v0.2 §6.5` made for `clientInfo`: a policy could not address the
+  principal. §4 ends that, and §8.1 removes `--principal-from-client-info` over the same
+  sentence — the ACS hook was that flag in a different module. A hook built against a `Control`
+  holding an `Authority` with no provider raises `InvalidArgument` at construction. With a
+  provider, `agent_id` is ignored — not merged, not a fallback, not compared — and a provider
+  that names nobody is a denial with `reason_codes: ["no_principal"]`, never a fall back to the
+  envelope. `handle()` gains an optional `headers=` for the transport's own headers, which is
+  what a provider reads. `docs/ACS.md`'s mapping table is amended in the same change.
+- **All three v0.2 call sites now use the combined decision** (§8.3): the gateway's `tools/call`
+  path, `ctrlrun.acs`'s request hook, and `Control.resume`. Left as `Policy.evaluate`, an action
+  a grant forbids outright would still have its approval flow run, and a human would be paged
+  about a call that could never happen.
 - **`Control.evaluate` returns the combined decision**, not the policy axis alone. Its signature
   and `Evaluation`'s two fields are unchanged, and it still writes nothing — it would simply
   stop answering "what will happen to this action" if it reported one axis while `Control.execute`
@@ -150,10 +237,6 @@ shipped, and the only thing in the tree today is the contract.
   recorded, not re-decided: the reservation is held and the remote may already be acting on it.
   A lease extension is the other way round — refused where authority no longer covers the
   action, so the lease lapses and the record becomes `AMBIGUOUS` by the ordinary path.
-- **`AcsControlHook` refuses a `Control` that holds an `Authority`** (§8.4). It reads
-  `params.metadata.agent_id` off the inbound envelope, and an authorization decision may not be
-  made against a principal the caller asserted — the same sentence that removed
-  `--principal-from-client-info`. It gains an `identity` provider of its own with item 5.
 - **`policy._Condition` is now `policy.Condition`, and `policy.parse_conditions` is public.**
   A grant's `constraints:` is in exactly a rule's `when:` syntax and is parsed by the same code:
   a second condition evaluator would be a second place for `True` to start comparing equal to

--- a/docs/ACS.md
+++ b/docs/ACS.md
@@ -64,13 +64,47 @@ JSON-RPC error in ACS's reserved range rather than an opinion.
 
 | ACS field | CTRLRun |
 |---|---|
-| `params.metadata.agent_id` | `Principal.agent` |
-| `params.metadata.user_context.user_id` | `Principal.user` |
-| `params.metadata.environment` | `Action.environment` (ACS's enum passes through; v0.1 §2.1 takes any non-empty string) |
+| `params.metadata.agent_id` | `Principal.agent` — **only where no `identity` provider is configured**. With one it is **ignored**: not merged, not a fallback, not compared (SPEC-v0.3 §8.4) |
+| `params.metadata.user_context.user_id` | `Principal.user`, under the same rule |
+| `params.metadata.environment` | **ignored.** `Action.environment` is the hook's own configuration (SPEC-v0.3 §2.5, §8.4) |
+| the transport's request headers | `IdentityContext.headers`, which is what an `identity` provider reads. `AcsControlHook.handle(envelope, headers=...)` |
 | `payload.tool.name`, `payload.tool.provider`, `payload.operation` | `Action.name`, as `<prefix>.<provider>.<tool>[.<operation>]` |
 | `payload.arguments` | `Action.arguments`, unwrapped from `{name: {value, provenance}}` to `{name: value}` |
 | — *(ACS has no resource field)* | `Action.resource`, from the policy's `resource:` template (SPEC-v0.2 §3) |
 | `params.request_id` | the continuation that joins this hook to its result |
+
+**Two fields stopped being read, and it is worth saying why.** Under v0.2 both `agent_id` and
+`environment` came off the envelope, on exactly the argument `v0.2 §6.5` made for MCP's
+`clientInfo`: a policy could not address the principal, so a self-reported one misattributed a
+receipt and could not widen an outcome. SPEC-v0.3 §4 ends that — the principal is an
+authorization input now, and a grant may scope to an environment — so a value the caller sets
+would let the caller choose what it is authorized as and where. §8.1 removes
+`ctrlrun gateway --principal-from-client-info` over the same sentence; the ACS hook was that
+flag in a different module.
+
+The consequence is a **required argument**: an `AcsControlHook` built against a `Control` that
+holds an `Authority`, with no `identity` provider, raises `InvalidArgument` at construction.
+A hook with **no provider** still reads `agent_id`, unchanged, because there is then no
+authorization decision for it to widen — and a hook holding an `Authority` cannot be in that
+state. The branch is on the *provider*, not on the authority section: configuring one without
+an `authority:` section also stops `agent_id` being read, which is the less surprising of the
+two possible rules and the one that makes "with a provider, `agent_id` is display data" true
+without a footnote.
+
+A configured provider that names nobody is a **refusal** — `deny`,
+`reason_codes: ["no_principal"]`, no receipt and no events — and never a fall back to the
+envelope: falling back would reach `agent_id` by an easier route than forging a credential. A
+credential that was verified and has since **lapsed** is a different refusal and says so:
+`reason_codes: ["principal_expired"]`, matching the `decision_reason` on the receipt
+`Control` has already written. The two are told apart structurally — one is raised while the
+Action is being built, the other by `Control.execute` — and never by reading a message.
+
+**One rule of §8.2 the hook does not import.** §3.1's repeated-identity-header refusal is the
+gateway's, and it lives in `do_POST` because that is where a repeated HTTP field is still
+visible. `AcsControlHook.handle(envelope, headers=...)` is handed a `Mapping[str, str]`, which
+holds one value per name — so whatever built that mapping already chose. A deployment putting
+this hook behind an HTTP server is responsible for that check, exactly as it is responsible
+for the transport. Stated because it is a real gap rather than an argued omission.
 
 `operation` is part of the name because two verbs on one tool are two actions, and a policy has
 to be able to say different things about `create` and `void`.
@@ -85,6 +119,8 @@ The decision maps out:
 | `DuplicateEffect` | `deny`, `reason_codes: ["ctrlrun.duplicate_effect", <state>]` |
 | `AmbiguousEffect` | `deny`, `reason_codes: ["ctrlrun.ambiguous_effect"]` |
 | `ApprovalMismatch` | `deny`, `reason_codes: ["ctrlrun.blocked", <reason>]` |
+| `AuthorityDenied` | `deny`, `reason_codes: [<§4.3 reason>]` — it subclasses `ActionDenied`, and the reason is what tells the two apart |
+| `IdentityError` | `deny`, `reason_codes: ["no_principal"]`. Deliberately a decision and not a protocol `error`: an error envelope says "the Guardian could not answer", and a platform is free to decide what to do with that |
 
 `ask_details` carries `approver` (`{type: "human", id}`), a `question` naming the request id a
 human answers with `ctrlrun approve`, and `timeout_seconds`. All three are required by

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -41,7 +41,7 @@ Every sentence the README gained in this release, mapped the same way.
 |---|---|---|
 | "Point the client at the gateway instead of at the tool server" | `Gateway.handle` — `gateway/server.py:135`; `serve` — `gateway/server.py:892` | `test_T19_the_upstream_receives_the_canonical_arguments` |
 | "No agent changes" | `tools/call` is intercepted and every other method relayed unchanged — `gateway/mcp.py:84` | `test_a_non_intercepted_method_is_relayed_with_no_ctrlrun_outcome` |
-| "The gateway prints … every action in your policy that has no `effect:` template" | `_announce_actions_without_an_effect` — `cli/main.py` | Shown in the README block; produced by `Policy.effect_template` — `policy.py:281` |
+| "The gateway prints … every action in your policy that has no `effect:` template" | `_announce` — `gateway/__init__.py` (it moved out of `cli/main.py` with SPEC-v0.3 §8.4, which added the environment, the identity provider and the authority section to the same block) | `test_the_startup_block_names_the_environment_identity_and_authority`, `test_the_startup_block_says_so_when_there_is_no_authority_section` |
 | "Tools become actions named `mcp.<alias>.<tool>`" | `Gateway._intercept` — `gateway/server.py` | `test_T19_the_action_is_named_for_the_alias_and_the_tool` |
 | "Declare their effect and resource templates there" | `Policy.effect_template` / `resource_template` — `policy.py:281`; `McpOptions` — `policy.py:187` | `test_T16_a_v2_document_loads_and_exposes_its_templates`, `test_T16_a_decorator_and_a_policy_template_produce_the_same_action_hash` |
 | "Everything but `tools/call` is relayed untouched" | `parse_request(...).intercept` — `gateway/mcp.py:84` | `test_every_other_method_is_relayed_not_intercepted` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,11 @@ otel = [
 # third party: verifying somebody else's signature. Everything else — grants, containment,
 # delegation, observe mode — is stdlib and the YAML parser that is already a dependency.
 #
-# Empty until build-list item 5, which adds the verifier and the `pyjwt` line it needs. The
-# extra is declared now so `pip install 'ctrlrun[identity]'` names something real for the whole
-# of the 0.3 development series, and so CI installs it without a second edit.
-identity = []
+# `[crypto]` rather than bare `pyjwt`: without it PyJWT can only do `HS*`, and every
+# asymmetric algorithm — which is what a JWKS deployment uses — raises at verification time
+# rather than at install time. An extra that installs cleanly and then cannot verify an RS256
+# token is worse than one that names its dependency.
+identity = ["pyjwt[crypto]>=2.8"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -137,6 +138,11 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "ANN", "SIM", "RUF"]
 # The OTel sink holds objects from a lazily-imported SDK: annotating them would mean
 # importing `opentelemetry` at module scope, which is the one thing §1.1 forbids.
 "src/ctrlrun/otel.py" = ["ANN401"]
+# Same reasoning for the JWT provider: the verifier, its exceptions and the key material a
+# JWK parses into all come from a lazily-imported `jwt`, and naming their types would mean
+# importing it at module scope. The claims themselves are untyped JSON off somebody else's
+# wire, validated at the boundary before anything reaches a `Principal`.
+"src/ctrlrun/jwt_identity.py" = ["ANN401"]
 # Type hints are a src/ constraint; tests stay cheap to write. N802 lets acceptance
 # tests carry the SPEC §7 identifier verbatim (test_T7_...).
 "tests/*" = ["ANN", "N802"]

--- a/src/ctrlrun/acs.py
+++ b/src/ctrlrun/acs.py
@@ -37,10 +37,12 @@ from .errors import (
     CTRLRunError,
     DuplicateEffect,
     EffectKeyError,
+    IdentityError,
     InvalidArgument,
     NotExecuted,
     Suspended,
 )
+from .identity import IdentityContext, IdentityProvider
 
 _LOG = logging.getLogger(__name__)
 
@@ -67,6 +69,14 @@ BLOCKED: Final = "blocked"
 METHOD_NOT_ANSWERED: Final = -32001
 MALFORMED_ENVELOPE: Final = -32002
 
+#: SPEC-v0.3 §8.4 — the reason code on a denial where no principal could be resolved. The
+#: same string `v0.1 §2.1` uses, so one vocabulary covers both paths.
+NO_PRINCIPAL_CODE: Final = "no_principal"
+
+#: And the reason code where a credential was produced and had already lapsed (§2.3). It is
+#: the string `Control` writes on the receipt, so the answer and the evidence agree.
+PRINCIPAL_EXPIRED_CODE: Final = "principal_expired"
+
 #: How long an `ask` says a human has. `ask-details.json` requires a positive integer.
 DEFAULT_ASK_TIMEOUT_SECONDS: Final = 900
 
@@ -86,32 +96,39 @@ class AcsControlHook:
         prefix: str = "acs",
         approver_id: str = "cli:local",
         ask_timeout_seconds: int = DEFAULT_ASK_TIMEOUT_SECONDS,
+        identity: IdentityProvider | None = None,
     ) -> None:
-        if control.authority is not None:
-            # SPEC-v0.3 §8.4 — this hook reads `params.metadata.agent_id` straight off the
-            # inbound envelope, and §4 makes the principal an authorization input. A
-            # self-reported name cannot be one, which is the same sentence that removes the
-            # gateway's `--principal-from-client-info` (§8.1); leaving the ACS hook alone would
-            # make that removal a gesture. §8.4 requires the hook to take an
-            # `identity: IdentityProvider` of its own, which lands with build-list item 5 — so
-            # until then it has none, and an `Authority` cannot be enforced against a principal
-            # nobody verified. Refused at construction rather than per call: a deployment finds
-            # out at startup.
+        if control.authority is not None and identity is None:
+            # SPEC-v0.3 §8.4 — without a provider this hook reads `params.metadata.agent_id`
+            # straight off the inbound envelope, and §4 makes the principal an authorization
+            # input. A self-reported name cannot be one, which is the same sentence that
+            # removes the gateway's `--principal-from-client-info` (§8.1); leaving the ACS hook
+            # alone would make that removal a gesture. Refused at construction rather than per
+            # call: a deployment finds out at startup, not during an incident.
             raise InvalidArgument(
-                "AcsControlHook needs an `identity` provider for a Control that holds an "
-                "Authority, and does not take one before build-list item 5. This hook reads "
-                "params.metadata.agent_id off the envelope, and an authorization decision may "
-                "not be made against a principal the caller asserted (SPEC-v0.3 §8.4)"
+                "AcsControlHook(identity=...) is required for a Control that holds an "
+                "Authority. Without one this hook reads params.metadata.agent_id off the "
+                "envelope, and an authorization decision may not be made against a principal "
+                "the caller asserted (SPEC-v0.3 §8.4)"
             )
         self._control = control
         self._prefix = prefix
         self._approver_id = approver_id
         self._ask_timeout = max(1, ask_timeout_seconds)
+        self._identity = identity
 
     # --- the ACS surface ----------------------------------------------------------------
 
-    def handle(self, envelope: Mapping[str, Any]) -> dict[str, Any]:
-        """One ACS request envelope in, one response envelope out."""
+    def handle(
+        self, envelope: Mapping[str, Any], *, headers: Mapping[str, str] | None = None
+    ) -> dict[str, Any]:
+        """One ACS request envelope in, one response envelope out.
+
+        `headers` is the transport's, and it is what an `identity` provider reads (§8.4): an
+        ACS envelope arrives over HTTP, and the credential is in the request rather than in
+        the JSON. Optional, because a hook with no provider has nothing to read them with —
+        and a hook *with* one and no headers resolves nobody, which is a refusal.
+        """
         if (
             not isinstance(envelope, Mapping)
             or envelope.get("jsonrpc") != "2.0"
@@ -129,12 +146,31 @@ class AcsControlHook:
 
         try:
             if method == TOOL_CALL_REQUEST:
-                return self._on_request(rpc_id, request_id, params)
+                return self._on_request(rpc_id, request_id, params, headers or {})
             if method == TOOL_CALL_RESULT:
                 return self._on_result(rpc_id, request_id, params)
         except InvalidArgument as refused:
             # A malformed payload is not a decision about an action: there is no action.
             return _error(rpc_id, MALFORMED_ENVELOPE, str(refused))
+        except IdentityError as refused:
+            # SPEC-v0.3 §8.4 — a credential offered and rejected, or a provider that named
+            # nobody. Answered as `deny` rather than as a protocol `error`: an error envelope
+            # says "the Guardian could not answer", and a platform is free to decide what to
+            # do with that. A denial says what CTRLRun means, which is that the tool must not
+            # run.
+            #
+            # The reason code is **not** always `no_principal`. This clause spans the whole of
+            # `_on_request`, so it also catches §2.3's expired-principal refusal from
+            # `Control.execute` — which has already written a receipt saying
+            # `principal_expired`. Answering `no_principal` there would make the ACS answer
+            # and the evidence disagree about the same action, so the code follows the
+            # refusal: `principal_expired` where the credential lapsed, `no_principal` where
+            # the provider named nobody (and *that* path writes no receipt and no events, for
+            # `v0.1 §2.1`'s reason — there is nobody to attribute one to).
+            _LOG.warning("refused an ACS envelope: %s", refused)
+            return _final(
+                rpc_id, request_id, DENY, reasoning=str(refused), codes=[NO_PRINCIPAL_CODE]
+            )
         return _error(
             rpc_id,
             METHOD_NOT_ANSWERED,
@@ -144,11 +180,15 @@ class AcsControlHook:
     # --- steps/toolCallRequest ----------------------------------------------------------
 
     def _on_request(
-        self, rpc_id: Any, request_id: str, params: Mapping[str, Any]
+        self,
+        rpc_id: Any,
+        request_id: str,
+        params: Mapping[str, Any],
+        headers: Mapping[str, str],
     ) -> dict[str, Any]:
         """Decide the call, take the reservation, and hold it for the result hook."""
         payload = _mapping(params.get("payload"), "params.payload")
-        action = self._action(params, payload)
+        action = self._action(params, payload, headers)
         effect_key = self._effect_key(action)
 
         # SPEC-v0.2 §6.10's rule, in ACS's shape: a client comes back by re-sending the
@@ -156,9 +196,12 @@ class AcsControlHook:
         # is what authorizes it. Matching on the hash is safe for the reason v0.1 §4.2 A1
         # exists — the hash covers the principal, the arguments, the resource and the
         # environment — and it is still single-use, consumed atomically with the reservation.
+        # SPEC-v0.3 §8.3 — the **combined** decision of §4.6, not the policy axis alone. One
+        # of the three places in shipped v0.2 code that read `Policy.evaluate` directly, named
+        # in the spec so this item could not miss it.
         granted = (
             self._control.store.find_granted_approval(action.action_hash)
-            if self._control.policy.evaluate(action).decision.value == "approve"
+            if self._control.evaluate(action).decision.value == "approve"
             else None
         )
 
@@ -177,6 +220,22 @@ class AcsControlHook:
                 self._control.execute(action, suspend_holding_the_reservation, effect_key)
         except Suspended:
             return _final(rpc_id, request_id, ALLOW)
+        except IdentityError as refused:
+            # SPEC-v0.3 §2.3 — the credential lapsed between being verified and being acted
+            # on. `Control` has already written a receipt saying `principal_expired`, so the
+            # answer says that too: an ACS decision and the evidence for the same action must
+            # not disagree about why it was refused.
+            #
+            # Told apart from "the provider named nobody" **structurally**, not by reading the
+            # message: that one is raised by `_action` above, outside this `try`, and is
+            # answered by `handle`'s own clause. Two refusals, two places, one code each.
+            return _final(
+                rpc_id,
+                request_id,
+                DENY,
+                reasoning=str(refused),
+                codes=[PRINCIPAL_EXPIRED_CODE],
+            )
         except ActionDenied as refused:
             return _final(rpc_id, request_id, DENY, reasoning=str(refused), codes=[refused.reason])
         except ApprovalRequired as pending:
@@ -284,22 +343,20 @@ class AcsControlHook:
 
     # --- building the Action (tool-call-request.json) -----------------------------------
 
-    def _action(self, params: Mapping[str, Any], payload: Mapping[str, Any]) -> Action:
+    def _action(
+        self,
+        params: Mapping[str, Any],
+        payload: Mapping[str, Any],
+        headers: Mapping[str, str],
+    ) -> Action:
         tool = _mapping(payload.get("tool"), "payload.tool")
-        metadata = _mapping(params.get("metadata"), "params.metadata")
-        agent = metadata.get("agent_id")
-        if not isinstance(agent, str) or not agent:
-            raise InvalidArgument("params.metadata.agent_id is required")
-        user_context = metadata.get("user_context")
-        user = user_context.get("user_id") if isinstance(user_context, Mapping) else None
-
         name = self._action_name(tool, payload.get("operation"))
         arguments = _arguments(payload.get("arguments"))
         resource_template = self._control.policy.resource_template(name)
         return Action(
             name=name,
             arguments=arguments,
-            principal=Principal(agent=agent, user=user if isinstance(user, str) else None),
+            principal=self._principal(params, name, headers),
             resource=(
                 None
                 if resource_template is None
@@ -314,6 +371,46 @@ class AcsControlHook:
             # `Control(environment="staging")` fronting ACS would refuse every call.
             environment=self._control.environment,
         )
+
+    def _principal(
+        self, params: Mapping[str, Any], action_name: str, headers: Mapping[str, str]
+    ) -> Principal:
+        """Who is acting, from the provider where there is one (SPEC-v0.3 §8.4).
+
+        Where a provider is configured, `params.metadata.agent_id` is **ignored**: not merged,
+        not used as a fallback, and not compared. It is display data, like MCP's `clientInfo`
+        — and a value that is only sometimes authoritative is one nobody can reason about.
+        `params.metadata.environment` is ignored for the same reason, in `_action`.
+
+        Where none is configured the envelope's own `agent_id` is read, exactly as v0.2 did.
+        That is survivable only because a `Control` holding an `Authority` cannot be given to
+        this hook without a provider (checked at construction): a self-reported name still
+        misattributes a receipt, and still cannot widen an outcome.
+
+        A declining provider is refused rather than backfilled from the envelope. Falling back
+        there would reach `agent_id` by an easier route than forging a credential, which is
+        the hole §3.2 closes for `context()` and the same hole in a different module.
+        """
+        metadata = _mapping(params.get("metadata"), "params.metadata")
+        if self._identity is not None:
+            context = IdentityContext(
+                action=action_name,
+                environment=self._control.environment,
+                headers={name.lower(): value for name, value in headers.items()},
+            )
+            resolved = self._identity.resolve(context)
+            if resolved is None:
+                raise IdentityError(
+                    f"{action_name}: the identity provider named nobody for this envelope, and "
+                    "params.metadata.agent_id is not a fallback (SPEC-v0.3 §8.4)"
+                )
+            return resolved
+        agent = metadata.get("agent_id")
+        if not isinstance(agent, str) or not agent:
+            raise InvalidArgument("params.metadata.agent_id is required")
+        user_context = metadata.get("user_context")
+        user = user_context.get("user_id") if isinstance(user_context, Mapping) else None
+        return Principal(agent=agent, user=user if isinstance(user, str) else None)
 
     def _action_name(self, tool: Mapping[str, Any], operation: object) -> str:
         name = tool.get("name")

--- a/src/ctrlrun/cli/main.py
+++ b/src/ctrlrun/cli/main.py
@@ -780,6 +780,60 @@ def _delegation_dict(delegation: Delegation) -> dict[str, Any]:
     is_flag=True,
     help="Permit an http:// webhook url, loopback only.",
 )
+@click.option(
+    "--authority",
+    "authority_path",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Load the authority: section from a separate YAML document (SPEC-v0.3 §8.3).",
+)
+@click.option("--identity-jwt", is_flag=True, help="Verify a bearer JWT (ctrlrun[identity]).")
+@click.option("--identity-jwt-jwks-url", default=None, help="Fetch keys from this JWKS (HTTPS).")
+@click.option(
+    "--identity-jwt-public-key",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False),
+    help="A PEM public key file.",
+)
+@click.option(
+    "--identity-jwt-secret-file",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Read the HS* shared secret from here. Never a flag value: a secret on a command "
+    "line is in every process listing on the host.",
+)
+@click.option(
+    "--identity-jwt-algorithms",
+    "identity_jwt_algorithms",
+    multiple=True,
+    help="Repeatable, required. There is no default and no wildcard.",
+)
+@click.option("--identity-jwt-issuer", default=None, help="Matched exactly. Required.")
+@click.option("--identity-jwt-audience", default=None, help="Matched by membership. Required.")
+@click.option(
+    "--identity-jwt-token-type",
+    default=None,
+    help='Required. The token\'s typ, e.g. at+jwt. Pass "" for "this issuer sets no typ".',
+)
+@click.option("--identity-jwt-header", default="authorization", show_default=True)
+@click.option("--identity-jwt-agent-claim", default="sub", show_default=True)
+@click.option("--identity-jwt-user-claim", default=None, help="Which claim is principal.user.")
+@click.option(
+    "--identity-jwt-claim",
+    "identity_jwt_claims",
+    multiple=True,
+    help="Repeatable: which verified claims reach the receipt. An allow-list.",
+)
+@click.option("--identity-jwt-leeway", type=float, default=60.0, show_default=True)
+@click.option("--identity-jwt-jwks-min-refresh", type=float, default=30.0, show_default=True)
+@click.option(
+    "--identity-jwt-http-timeout",
+    type=float,
+    default=5.0,
+    show_default=True,
+    help="Bounds the JWKS fetch. Deliberately not --upstream-timeout: the fetch runs on the "
+    "request thread before any decision, so the two must not be one knob.",
+)
 @click.option("--otel", is_flag=True, help="Export one span per action (ctrlrun[otel]).")
 @click.option(
     "--otel-arguments",
@@ -805,6 +859,22 @@ def gateway(
     webhook_url: str | None,
     webhook_secret_file: str | None,
     allow_insecure_webhook: bool,
+    authority_path: str | None,
+    identity_jwt: bool,
+    identity_jwt_jwks_url: str | None,
+    identity_jwt_public_key: str | None,
+    identity_jwt_secret_file: str | None,
+    identity_jwt_algorithms: tuple[str, ...],
+    identity_jwt_issuer: str | None,
+    identity_jwt_audience: str | None,
+    identity_jwt_token_type: str | None,
+    identity_jwt_header: str,
+    identity_jwt_agent_claim: str,
+    identity_jwt_user_claim: str | None,
+    identity_jwt_claims: tuple[str, ...],
+    identity_jwt_leeway: float,
+    identity_jwt_jwks_min_refresh: float,
+    identity_jwt_http_timeout: float,
     otel: bool,
     otel_arguments: bool,
 ) -> None:
@@ -827,8 +897,9 @@ def gateway(
         # §6.5 — before anything else this command prints. The removed-flag guard above is a
         # usage error and runs first deliberately: it must not depend on a policy being
         # loadable, or a gateway started in a directory with no policy would report the wrong
-        # problem.
-        _announce_actions_without_an_effect(_loaded_policy())
+        # problem. The rest of §8.4's startup block is printed by `serve`, which is where the
+        # identity provider and the authority section are actually resolved.
+        _loaded_policy()
         serve(
             upstream=upstream,
             alias=alias,
@@ -847,6 +918,22 @@ def gateway(
             webhook_url=webhook_url,
             webhook_secret_file=webhook_secret_file,
             allow_insecure_webhook=allow_insecure_webhook,
+            authority=authority_path,
+            identity_jwt=identity_jwt,
+            identity_jwt_jwks_url=identity_jwt_jwks_url,
+            identity_jwt_public_key=identity_jwt_public_key,
+            identity_jwt_secret_file=identity_jwt_secret_file,
+            identity_jwt_algorithms=tuple(identity_jwt_algorithms),
+            identity_jwt_issuer=identity_jwt_issuer,
+            identity_jwt_audience=identity_jwt_audience,
+            identity_jwt_token_type=identity_jwt_token_type,
+            identity_jwt_header=identity_jwt_header,
+            identity_jwt_agent_claim=identity_jwt_agent_claim,
+            identity_jwt_user_claim=identity_jwt_user_claim,
+            identity_jwt_claims=tuple(identity_jwt_claims),
+            identity_jwt_leeway=identity_jwt_leeway,
+            identity_jwt_jwks_min_refresh=identity_jwt_jwks_min_refresh,
+            identity_jwt_http_timeout=identity_jwt_http_timeout,
             otel=otel,
             otel_arguments=otel_arguments,
         )
@@ -854,22 +941,6 @@ def gateway(
         raise _fail(exc) from exc
     except KeyboardInterrupt:  # pragma: no cover - an operator pressing ctrl-c
         click.echo("")
-
-
-def _announce_actions_without_an_effect(policy: Policy) -> None:
-    """SPEC-v0.2 §3.2 — print the actions with no `effect:` at startup.
-
-    A write with no effect key is exactly the configuration this product exists to prevent,
-    and it should be visible on the line that starts the process rather than discovered in a
-    receipt three weeks later.
-    """
-    keyless = sorted(name for name in policy.actions if policy.effect_template(name) is None)
-    if not keyless:
-        return
-    click.echo(f"{len(keyless)} action(s) have no effect: template and get no reservation:")
-    for name in keyless:
-        click.echo(f"  {name}")
-    click.echo("That is right for a read, and wrong for anything that changes the world.")
 
 
 def _receipt_line(receipt: Receipt) -> str:

--- a/src/ctrlrun/gateway/__init__.py
+++ b/src/ctrlrun/gateway/__init__.py
@@ -13,6 +13,7 @@ non-execution, and it is only provable if no request byte can have been written.
 from __future__ import annotations
 
 import importlib
+from pathlib import Path
 from types import ModuleType
 from typing import Any, Final
 
@@ -48,7 +49,12 @@ def serve(*, upstream: str, alias: str, **options: Any) -> None:
     http_client()
     from ..control import Control
     from ..webhook import WebhookApprovalProvider, webhook_secret
-    from .server import Gateway, GatewayConfig, httpx_forwarder, serve_forever
+    from .server import (
+        Gateway,
+        GatewayConfig,
+        httpx_forwarder,
+        serve_forever,
+    )
 
     otel = bool(options.pop("otel", False))
     otel_arguments = bool(options.pop("otel_arguments", False))
@@ -57,6 +63,7 @@ def serve(*, upstream: str, alias: str, **options: Any) -> None:
     secret_file = options.pop("webhook_secret_file", None)
     allow_insecure = bool(options.pop("allow_insecure_webhook", False))
     secret = webhook_secret(secret_file) if secret_file else webhook_secret()
+    authority_path = options.pop("authority", None)
 
     # SPEC-v0.3 §2.5 — `--environment` is rank 1 on the Control, not a second value the
     # gateway stamps for itself. Where it is absent the Control resolves ranks 2 to 4, so
@@ -64,37 +71,112 @@ def serve(*, upstream: str, alias: str, **options: Any) -> None:
     environment = options.pop("environment", None)
     config = GatewayConfig(upstream=upstream, alias=alias, webhook_secret=secret, **options)
     control = Control.from_file(environment=environment)
+    authority = _authority(control, authority_path)
+    sinks = list(control.sinks)
+    approvals = control.approvals
     if otel:
         # §8 — one more sink beside the JSONL one `from_file` installed. It never blocks and
         # never raises into the kernel (§4.2), so adding it changes no decision.
         from ..otel import OTelEventSink
 
-        control = Control(
-            control.policy,
-            control.store,
-            control.approvals,
-            sinks=[*control.sinks, OTelEventSink(arguments=otel_arguments)],
-            environment=control.environment,
-        )
+        sinks.append(OTelEventSink(arguments=otel_arguments))
     if webhook_url:
         # §7 — the provider notifies; the gateway's endpoint receives. Both need the same
         # secret, and neither takes it from a command-line argument (§7.3).
-        control = Control(
-            control.policy,
+        approvals = WebhookApprovalProvider(
             control.store,
-            WebhookApprovalProvider(
-                control.store,
-                url=webhook_url,
-                secret=secret,
-                public_url=public_url,
-                allow_insecure=allow_insecure,
-            ),
-            sinks=[],
-            environment=control.environment,
+            url=webhook_url,
+            secret=secret,
+            public_url=public_url,
+            allow_insecure=allow_insecure,
         )
+    # SPEC-v0.3 §8.3 — one rebuild, carrying **everything**. Two successive rebuilds each
+    # naming a subset is how `authority` and the JSONL sink went missing from a gateway
+    # started with `--otel` and a webhook: each was correct about the field it was changing
+    # and silent about the ones it dropped.
+    control = Control(
+        control.policy,
+        control.store,
+        approvals,
+        sinks=sinks,
+        authority=authority,
+        environment=control.environment,
+    )
     forwarder = httpx_forwarder(config)
+    gateway = Gateway(config, control, forwarder)
+    _announce(control, config, gateway.identity, authority_path)
     try:
-        serve_forever(Gateway(config, control, forwarder))
+        serve_forever(gateway)
     finally:
         forwarder.close()
         control.store.close()
+
+
+def _authority(control: Any, path: str | None) -> Any:
+    """The grants this gateway enforces, from the policy file or from `--authority` (§8.3).
+
+    `--authority` exists because the person who writes grants and the person who writes
+    per-action autonomy are often not the same person, and a gateway is where that separation
+    shows up first. The document it names is **not** a policy document: its top-level key set
+    is closed at `schema` and `authority`, so `actions:` or `mode:` in it is a load error.
+
+    Where both the policy file and `--authority` declare a section, the gateway refuses to
+    start naming both paths. Two sources for one section is the ambiguity `v0.1 §5.1` refuses
+    for `{resource}`: pick one, or say which. Silently preferring either would mean an
+    operator who edited the wrong file saw no effect and no error.
+    """
+    from ..authority import Authority
+    from ..errors import InvalidArgument
+
+    if path is None:
+        return control.authority
+    loaded = Authority.from_yaml(
+        Path(path).read_text(encoding="utf-8"), source=path, standalone=True
+    )
+    if control.authority is not None:
+        raise InvalidArgument(
+            f"authority is declared twice: in the policy at {control.policy.source} and in "
+            f"--authority {path}. Two sources for one section is an ambiguity nobody can "
+            "resolve later; remove the 'authority:' key from one of them (SPEC-v0.3 §8.3)"
+        )
+    return loaded
+
+
+def _announce(control: Any, config: Any, identity: Any, authority_path: str | None) -> None:
+    """The startup block of SPEC-v0.3 §8.4, printed before the socket opens.
+
+    Everything here is something an operator can get wrong in a way that is invisible until an
+    incident: an action with no effect key, an environment they did not choose, a header they
+    trust more than they meant to, an `authority:` section that is not loaded at all. It goes
+    on the line that starts the process rather than into a receipt three weeks later.
+
+    The observe banner is **not** printed here: `ctrlrun gateway` prints it before anything
+    else, along with every other command that loads the operator's policy (§6.5), and a second
+    copy would read as two switches.
+
+    `print` rather than the logger, because this is the CLI's own output and a logger with no
+    configured handler would swallow it — which is the failure mode the block exists to
+    prevent, in miniature.
+    """
+    lines: list[str] = []
+    lines.append(f"environment  {control.environment}")
+    lines.append(f"identity     {type(identity).__name__}")
+    if config.principal_header is not None:
+        lines.append(
+            f"             trusts the header {config.principal_header!r}: it is worth what "
+            "the proxy that sets it is worth, and must be overwritten on every request"
+        )
+    if control.authority is None:
+        lines.append("no authority: section — every principal is unrestricted")
+    else:
+        where = authority_path or control.policy.source
+        lines.append(f"authority    {len(control.authority.grants)} grant(s) from {where}")
+    keyless = sorted(
+        name for name in control.policy.actions if control.policy.effect_template(name) is None
+    )
+    if keyless:
+        lines.append(f"{len(keyless)} action(s) have no effect: template and get no reservation:")
+        lines += [f"  {name}" for name in keyless]
+        lines.append("That is right for a read, and wrong for anything that changes the world.")
+    for line in lines:
+        print(line)

--- a/src/ctrlrun/gateway/server.py
+++ b/src/ctrlrun/gateway/server.py
@@ -20,6 +20,7 @@ from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from datetime import timedelta
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from typing import Any, Final, Protocol, TypeAlias
 
 from ..action import Action, Principal
@@ -30,12 +31,20 @@ from ..errors import (
     AmbiguousEffect,
     ApprovalMismatch,
     ApprovalRequired,
+    AuthorityDenied,
     CTRLRunError,
     DuplicateEffect,
     EffectKeyError,
+    IdentityError,
     InvalidArgument,
     NotExecuted,
     Suspended,
+)
+from ..identity import (
+    HeaderIdentityProvider,
+    IdentityContext,
+    IdentityProvider,
+    StaticIdentityProvider,
 )
 from ..policy import OBSERVE
 from ..receipt import Receipt
@@ -88,6 +97,11 @@ NO_PRINCIPAL: Final = (-41007, "ctrlrun.no_principal", 403)
 UNREPRESENTABLE: Final = (-41008, "ctrlrun.unrepresentable_argument", 400)
 UNKNOWN_CONTINUATION: Final = (-41009, "ctrlrun.unknown_continuation", 400)
 UPSTREAM_AMBIGUOUS: Final = (-41010, "ctrlrun.upstream_ambiguous", 502)
+
+#: SPEC-v0.3 §8.4, frozen in §11. `-41001` means this action is not permitted to anyone in
+#: this configuration; `-41012` means it is not permitted to *you*. The second is worth a
+#: different message to a client and, in a multi-tenant deployment, a different alert.
+UNAUTHORIZED: Final = (-41012, "ctrlrun.unauthorized", 403)
 
 #: §6.8 — the `_meta` key every intercepted response carries, so a client is not left
 #: guessing what CTRLRun recorded. `com.ctrlrun/` is a legal prefix under the revision's
@@ -154,6 +168,28 @@ class GatewayConfig:
     max_elicitation_rounds: int = DEFAULT_MAX_ELICITATION_ROUNDS
     webhook_secret: str | None = None
     replay_window: float = 300.0
+    #: SPEC-v0.3 §8.2 — the third identity source. `--principal` and `--principal-header` are
+    #: understood as constructors for `StaticIdentityProvider` and `HeaderIdentityProvider`;
+    #: this one constructs `JWTIdentityProvider` out of `ctrlrun[identity]`.
+    identity_jwt: bool = False
+    identity_jwt_jwks_url: str | None = None
+    identity_jwt_public_key: str | None = None
+    identity_jwt_secret_file: str | None = None
+    identity_jwt_algorithms: tuple[str, ...] = ()
+    identity_jwt_issuer: str | None = None
+    identity_jwt_audience: str | None = None
+    #: `None` means the operator did not choose, and is refused; `""` is the explicit "this
+    #: issuer sets no `typ`" of §8.2. The two must stay distinguishable, because a default
+    #: would make RFC 8725 §3.11's cross-JWT defence something nobody ever saw.
+    identity_jwt_token_type: str | None = None
+    identity_jwt_header: str = "authorization"
+    identity_jwt_agent_claim: str = "sub"
+    identity_jwt_user_claim: str | None = None
+    identity_jwt_claims: tuple[str, ...] = ()
+    identity_jwt_leeway: float = 60.0
+    identity_jwt_jwks_min_refresh: float = 30.0
+    #: SPEC-v0.3 §3.4's default. Separate from `upstream_timeout` deliberately; see below.
+    identity_jwt_http_timeout: float = 5.0
 
     def __post_init__(self) -> None:
         import re
@@ -170,23 +206,129 @@ class GatewayConfig:
                 f"--path {self.path!r} must start with '/' and must not overlap "
                 f"{CTRLRUN_PREFIX!r}, which is reserved for the approvals endpoint"
             )
-        sources = [self.principal is not None, self.principal_header is not None]
+        sources = [
+            self.principal is not None,
+            self.principal_header is not None,
+            self.identity_jwt,
+        ]
         if sum(sources) != 1:
             raise InvalidArgument(
-                "exactly one of --principal or --principal-header is required; there is no "
-                "default, because an Action cannot exist without a principal (SPEC-v0.2 §6.5)"
+                "exactly one of --principal, --principal-header or --identity-jwt is required; "
+                "there is no default, because an Action cannot exist without a principal "
+                "(SPEC-v0.2 §6.5, SPEC-v0.3 §8.2)"
             )
         if self.user_header is not None and self.principal_header is None:
             # SPEC-v0.3 §8.2 — a flag that cannot take effect is a flag the operator believes
             # took effect.
             raise InvalidArgument(
-                "--user-header is only meaningful with --principal-header; with --principal "
-                "there is no request to read a user from"
+                "--user-header is only meaningful with --principal-header; with --identity-jwt "
+                "the user comes from --identity-jwt-user-claim, and with --principal from nowhere"
             )
+        self._check_jwt_flags()
         if self.host not in ("127.0.0.1", "localhost", "::1") and not self.allow_remote:
             raise InvalidArgument(
                 f"--listen {self.host} is not loopback; pass --allow-remote to mean it"
             )
+
+    def _check_jwt_flags(self) -> None:
+        """§8.2 — every `--identity-jwt-*` flag is accepted only with `--identity-jwt`.
+
+        And when it *is* given, the four settings that have no safe default must be there:
+        the algorithms, the issuer, the audience and the token type. The provider refuses the
+        same things at construction; this refuses them before the extra is even imported, so
+        an operator who has not installed it still learns what they got wrong.
+        """
+        given = {
+            "--identity-jwt-jwks-url": self.identity_jwt_jwks_url is not None,
+            "--identity-jwt-public-key": self.identity_jwt_public_key is not None,
+            "--identity-jwt-secret-file": self.identity_jwt_secret_file is not None,
+            "--identity-jwt-algorithms": bool(self.identity_jwt_algorithms),
+            "--identity-jwt-issuer": self.identity_jwt_issuer is not None,
+            "--identity-jwt-audience": self.identity_jwt_audience is not None,
+            "--identity-jwt-token-type": self.identity_jwt_token_type is not None,
+            "--identity-jwt-user-claim": self.identity_jwt_user_claim is not None,
+            "--identity-jwt-claim": bool(self.identity_jwt_claims),
+            "--identity-jwt-header": self.identity_jwt_header != "authorization",
+            "--identity-jwt-agent-claim": self.identity_jwt_agent_claim != "sub",
+            "--identity-jwt-leeway": self.identity_jwt_leeway != 60.0,
+            "--identity-jwt-jwks-min-refresh": self.identity_jwt_jwks_min_refresh != 30.0,
+            "--identity-jwt-http-timeout": self.identity_jwt_http_timeout != 5.0,
+        }
+        if not self.identity_jwt:
+            stray = sorted(name for name, present in given.items() if present)
+            if stray:
+                raise InvalidArgument(
+                    f"{', '.join(stray)} needs --identity-jwt; a flag that cannot take effect "
+                    "is a flag the operator believes took effect (SPEC-v0.3 §8.2)"
+                )
+            return
+        required = (
+            "--identity-jwt-algorithms",
+            "--identity-jwt-issuer",
+            "--identity-jwt-audience",
+            "--identity-jwt-token-type",
+        )
+        missing = sorted(name for name in required if not given[name])
+        if missing:
+            raise InvalidArgument(
+                f"--identity-jwt needs {', '.join(missing)}. There is no default for any of "
+                "them: an unpinned algorithm, issuer or audience is a token from somewhere "
+                'else, and an unpinned type is an ID token (pass "" to mean "this issuer sets '
+                'no typ")'
+            )
+
+
+def identity_provider(config: GatewayConfig) -> IdentityProvider:
+    """The provider this gateway's flags name (SPEC-v0.3 §8.2).
+
+    `--principal` is a `StaticIdentityProvider`, `--principal-header` a
+    `HeaderIdentityProvider`, `--identity-jwt` a `JWTIdentityProvider` out of
+    `ctrlrun[identity]`. Exactly one, checked by `GatewayConfig`, so this never has to decide
+    between two.
+
+    The JWT import is here rather than at module scope: `import ctrlrun` must not pull in
+    `jwt` (§1.1), and an operator who selected the extra without installing it gets
+    `MissingDependency` naming the command rather than a `ModuleNotFoundError`.
+    """
+    if config.principal is not None:
+        return StaticIdentityProvider(agent=config.principal)
+    if config.principal_header is not None:
+        return HeaderIdentityProvider(
+            agent_header=config.principal_header, user_header=config.user_header
+        )
+    from ..jwt_identity import JWTIdentityProvider
+
+    assert config.identity_jwt_issuer is not None
+    assert config.identity_jwt_audience is not None
+    assert config.identity_jwt_token_type is not None
+    secret = None
+    if config.identity_jwt_secret_file is not None:
+        # §8.2 — from a file, never from a flag value: a shared secret on a command line is in
+        # every process listing on the host.
+        secret = Path(config.identity_jwt_secret_file).read_text(encoding="utf-8").strip()
+    return JWTIdentityProvider(
+        jwks_url=config.identity_jwt_jwks_url,
+        public_key=config.identity_jwt_public_key,
+        secret=secret,
+        algorithms=config.identity_jwt_algorithms,
+        issuer=config.identity_jwt_issuer,
+        audience=config.identity_jwt_audience,
+        # §8.2 — `""` on the command line is the explicit "this issuer sets no typ", which the
+        # provider spells `None` and warns about at construction.
+        token_type=config.identity_jwt_token_type or None,
+        header=config.identity_jwt_header,
+        agent_claim=config.identity_jwt_agent_claim,
+        user_claim=config.identity_jwt_user_claim,
+        claim_names=config.identity_jwt_claims,
+        leeway=timedelta(seconds=config.identity_jwt_leeway),
+        jwks_min_refresh_interval=timedelta(seconds=config.identity_jwt_jwks_min_refresh),
+        # §3.4's own default, **not** `--upstream-timeout`. The fetch runs synchronously on
+        # the request thread, before authority and before policy, so borrowing the upstream's
+        # timeout would mean an operator who raised it for a slow tool server had silently
+        # made every unknown-`kid` request stall that long — two unrelated knobs, coupled in
+        # the fail-slow direction, in a value nothing documents.
+        http_timeout=timedelta(seconds=config.identity_jwt_http_timeout),
+    )
 
 
 @dataclass
@@ -232,10 +374,23 @@ class Gateway:
         self._config = config
         self._control = control
         self._forward = forwarder
+        # SPEC-v0.3 §8.2 — `--principal` and `--principal-header` are constructors now, not a
+        # second way of naming a principal. One code path resolves every identity, so a
+        # provider's decline and its refusal mean the same thing here as they do in-process.
+        self._identity = identity_provider(config)
 
     @property
     def config(self) -> GatewayConfig:
         return self._config
+
+    @property
+    def identity(self) -> IdentityProvider:
+        """The provider this gateway resolves every principal from (SPEC-v0.3 §8.2).
+
+        Exposed so the startup block can name it without constructing a second one — and a
+        second one would warn twice, which is how a warning that matters gets filtered.
+        """
+        return self._identity
 
     # --- the request path ---------------------------------------------------------------
 
@@ -303,18 +458,55 @@ class Gateway:
 
     def _intercept(self, parsed: ParsedRequest, headers: Mapping[str, str]) -> _Response:
         request_id = parsed.document.get("id")
-        principal = self._principal(parsed, headers)
+        # §8.2 — the action name is resolved first because `IdentityContext.action` carries it:
+        # a provider is told what it is resolving a principal *for*.
+        action_name = f"mcp.{self._config.alias}.{parsed.tool_name}"
+        code, token, status = NO_PRINCIPAL
+        try:
+            principal = self._identity.resolve(
+                IdentityContext(
+                    action=action_name,
+                    environment=self._control.environment,
+                    headers={name.lower(): value for name, value in headers.items()},
+                )
+            )
+        except IdentityError as refused:
+            # §8.2 — a distinct message, and nothing about why. The client learns that its
+            # credential was rejected, which is the correct amount to tell an unauthenticated
+            # caller. No receipt and no events: no principal was produced (§9).
+            _LOG.warning("refused %s: %s", action_name, refused)
+            return _json(
+                status,
+                json_rpc_error(request_id, code, token, "the credential offered was rejected"),
+            )
+        except Exception as exc:
+            # §3.2 — one exception type for a caller to catch. `Control._ask_provider` applies
+            # this rule in-process and the gateway does not go through it, so without this a
+            # custom provider hitting a transient error reaches `socketserver`, which closes
+            # the socket with no response. `IdentityProvider` is public API: this is any
+            # deployment's own provider on a bad day, not an attack.
+            #
+            # A `BaseException` that is not an `Exception` propagates, for v0.1 §5.5's reason.
+            _LOG.warning(
+                "refused %s: identity provider %s raised %s: %s",
+                action_name,
+                type(self._identity).__name__,
+                type(exc).__name__,
+                exc,
+            )
+            return _json(
+                status,
+                json_rpc_error(request_id, code, token, "the credential offered was rejected"),
+            )
         if principal is None:
             # §6.5 — no principal to attribute the refusal to, so it does not belong in the
             # evidence log; and it must not be silent either.
             _LOG.warning("refused %s: no principal derivable from the request", parsed.tool_name)
-            code, token, status = NO_PRINCIPAL
             return _json(
                 status,
                 json_rpc_error(request_id, code, token, "no principal could be derived"),
             )
 
-        action_name = f"mcp.{self._config.alias}.{parsed.tool_name}"
         try:
             action = self._action(action_name, parsed, principal)
         except _Unrepresentable as refused:
@@ -330,23 +522,6 @@ class Gateway:
             return _json(status, json_rpc_error(request_id, code, token, str(refused)))
 
         return self._execute(action, parsed, headers, request_id)
-
-    def _principal(self, parsed: ParsedRequest, headers: Mapping[str, str]) -> Principal | None:
-        """§6.5 — exactly one source, configured at startup, and no default."""
-        agent: str | None = None
-        if self._config.principal is not None:
-            agent = self._config.principal
-        else:
-            assert self._config.principal_header is not None
-            agent = _header(headers, self._config.principal_header.lower())
-        if not isinstance(agent, str) or not agent:
-            return None
-        user = (
-            _header(headers, self._config.user_header.lower())
-            if self._config.user_header is not None
-            else None
-        )
-        return Principal(agent=agent, user=user or None)
 
     def _action(self, action_name: str, parsed: ParsedRequest, principal: Principal) -> Action:
         """§6.6 — the Action a `tools/call` becomes.
@@ -480,6 +655,35 @@ class Gateway:
         code, token, status = UNKNOWN_CONTINUATION
         try:
             receipt = self._control.resume(presented, executor)
+        except AuthorityDenied as refused:
+            # SPEC-v0.3 §5.6.1 — an operator ran `ctrlrun revoke` while a human was answering
+            # an elicitation, and the lease extension is refused. Without this the exception
+            # leaves `handle` and `socketserver` closes the socket with no response at all,
+            # which a client reads as a transport failure and retries — the one thing this
+            # library exists to prevent.
+            code, token, status = UNAUTHORIZED
+            return _json(
+                status,
+                json_rpc_error(
+                    request_id,
+                    code,
+                    token,
+                    str(refused),
+                    reason=refused.reason,
+                    action_id=action.action_id,
+                ),
+            )
+        except IdentityError as refused:
+            _LOG.warning("refused a continuation for %s: %s", action.name, refused)
+            # §2.3.1 — the credential expired mid-round-trip. Same shape, same reason: the
+            # reservation is not held, the lease lapses, and the record becomes AMBIGUOUS by
+            # the ordinary path. What must not happen is the client learning that by having
+            # its connection dropped.
+            code, token, status = NO_PRINCIPAL
+            return _json(
+                status,
+                json_rpc_error(request_id, code, token, "the credential offered was rejected"),
+            )
         except Suspended:
             key = self._control.policy.effect_template(action.name)
             resolved = None if key is None else resolve_effect_key(key, action)
@@ -514,7 +718,11 @@ class Gateway:
         from ..control import with_approval
 
         approval = None
-        if self._control.policy.evaluate(action).decision.value == "approve":
+        # SPEC-v0.3 §8.3 — the **combined** decision of §4.6, not the policy axis alone.
+        # `Control.evaluate` reads the store to resolve delegations and still writes nothing.
+        # Left as `Policy.evaluate`, an action a grant forbids outright would still have its
+        # approval flow run, and a human would be asked about a call that could never run.
+        if self._control.evaluate(action).decision.value == "approve":
             approval = self._control.store.find_granted_approval(action.action_hash)
             if approval is None and self._control.policy.mode != OBSERVE:
                 # SPEC-v0.3 §6.2 — §6.10's pre-check exists to spare a human, and it spares
@@ -532,6 +740,23 @@ class Gateway:
                     receipt = self._control.execute(action, executor, effect_key)
             else:
                 receipt = self._control.execute(action, executor, effect_key)
+        except AuthorityDenied as refused:
+            # SPEC-v0.3 §8.4 — **before** `ActionDenied`, which it subclasses. The other order
+            # makes this branch unreachable and reports every authority denial as `-41001`,
+            # while every test asserting only "it was refused" stays green. T91 pins both
+            # halves so the discrimination cannot quietly collapse.
+            code, token, status = UNAUTHORIZED
+            return _json(
+                status,
+                json_rpc_error(
+                    request_id,
+                    code,
+                    token,
+                    str(refused),
+                    reason=refused.reason,
+                    action_id=action.action_id,
+                ),
+            )
         except ActionDenied as refused:
             code, token, status = DENIED
             return _json(
@@ -544,6 +769,20 @@ class Gateway:
                     reason=refused.reason,
                     action_id=action.action_id,
                 ),
+            )
+        except IdentityError as refused:
+            # SPEC-v0.3 §2.3 — `Control.execute` refuses an expired principal with
+            # `IdentityError`, which is deliberately **not** an `ActionDenied` (§11): an agent
+            # loop's `except ActionDenied` is written for a policy saying no. So it needs its
+            # own clause here, and it is routinely reachable rather than adversarial —
+            # `JWTIdentityProvider` admits a token up to `leeway` past its `exp` and then
+            # stamps `Principal.expires_at` with that exact `exp`, so every token presented
+            # inside that window is admitted by the provider and refused by the kernel.
+            _LOG.warning("refused %s: %s", action.name, refused)
+            code, token, status = NO_PRINCIPAL
+            return _json(
+                status,
+                json_rpc_error(request_id, code, token, "the credential offered was rejected"),
             )
         except ApprovalRequired as pending:
             return self._awaiting(action, pending, request_id)
@@ -746,7 +985,16 @@ def _repeated_identity_header(
     it does not recognize.
     """
     watched = {
-        name.lower() for name in (config.principal_header, config.user_header) if name is not None
+        name.lower()
+        for name in (
+            config.principal_header,
+            config.user_header,
+            # §8.2 — the JWT provider reads a header too, and it is the one that carries the
+            # credential. Leaving it out would make §3.1's rule apply to the weaker sources
+            # and not to the strong one.
+            config.identity_jwt_header if config.identity_jwt else None,
+        )
+        if name is not None
     }
     if not watched:
         return None
@@ -950,3 +1198,13 @@ def serve_forever(gateway: Gateway) -> None:
     finally:
         server.shutdown()
         server.server_close()
+
+
+class _Unreachable(Exception):
+    """Never raised. It exists so a mutation table can make one `except` clause dead.
+
+    Swapping a clause's exception type for this one is the only way to ask "does anything
+    exercise this handler?" without deleting the branch and changing the shape of the code
+    around it. Three of these handlers had no test at all until an independent review found
+    them, and each answered a refusal by dropping the client's connection.
+    """

--- a/src/ctrlrun/jwt_identity.py
+++ b/src/ctrlrun/jwt_identity.py
@@ -1,0 +1,583 @@
+"""JWT verification as an `IdentityProvider`. Build-list item 5; SPEC-v0.3 §3.4.
+
+Ships in `ctrlrun[identity]` and is imported by naming it: `import ctrlrun` must not pull in
+`jwt` (§1.1, T92). The dependency is resolved at construction, so an operator who has not
+installed the extra gets `MissingDependency` naming the install command rather than a
+`ModuleNotFoundError` from halfway down an import chain.
+
+**CTRLRun consumes identities; it issues none.** This is not an OAuth client. It performs no
+authorization-code flow, no refresh, no token exchange, no introspection and no dynamic client
+registration. It verifies a token somebody else obtained and maps the verified claims onto a
+`Principal`. Everything beyond verification belongs to the deployment.
+
+Two things it deliberately cannot do, stated here rather than discovered later (§3.4):
+
+- **A tenant-templated issuer cannot be configured correctly.** `issuer` is an exact string.
+  Pointing it at a multi-tenant endpoint without pinning the tenant makes every tenant on that
+  platform a valid issuer for this process, and that is the fail-open direction.
+- **There is no revocation channel.** A verified token is valid until its `exp`, which is why
+  one without an `exp` is refused. Nothing polls, subscribes or introspects. Short lifetimes
+  are the whole of the story.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import ssl
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Mapping, Sequence
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Final
+
+from .action import ClaimValue, Principal
+from .errors import IdentityError, InvalidArgument, MissingDependency
+from .identity import IdentityContext
+
+_LOG = logging.getLogger("ctrlrun")
+
+#: The module this provider needs, and the extra that carries it.
+_JWT_MODULE: Final = "jwt"
+_EXTRA: Final = "identity"
+
+#: RFC 6750 §2.1 — the scheme is matched case-insensitively, and a header with no scheme is
+#: refused rather than guessed. "Bearer" is the only one this provider reads.
+_BEARER: Final = "bearer"
+
+#: RFC 7519 §5.1 — a `typ` may carry the `application/` prefix, which is stripped before the
+#: case-insensitive comparison. `at+jwt` (RFC 9068 §4) and `JWT` are the two seen in practice.
+_MEDIA_PREFIX: Final = "application/"
+
+#: RFC 7517 §4.3 / §4.4 — a key that says what it is for. A JWK Set commonly carries
+#: encryption keys, and verifying a signature against one is a defect.
+_SIGNATURE_USE: Final = "sig"
+_VERIFY_OP: Final = "verify"
+
+DEFAULT_HEADER: Final = "authorization"
+DEFAULT_AGENT_CLAIM: Final = "sub"
+DEFAULT_LEEWAY: Final = timedelta(seconds=60)
+DEFAULT_JWKS_MIN_REFRESH: Final = timedelta(seconds=30)
+DEFAULT_HTTP_TIMEOUT: Final = timedelta(seconds=5)
+
+#: The reason on every `IdentityError` this module raises, for a caller that wants to branch.
+#: The *message* stays deliberately coarse where it reaches a client (§8.2): a caller whose
+#: credential was rejected learns that, and nothing about why.
+_REFUSED: Final = "the credential was rejected"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _jwt() -> Any:
+    """The verifier, or `MissingDependency` naming the install command (§1.1, §3.4).
+
+    `# SPEC:` the item-5 brief said "ImportError". The house rule of `v0.2 §1.1` says
+    `MissingDependency`, which is what an operator can act on.
+    """
+    try:
+        import jwt
+    except ImportError as exc:  # pragma: no cover - exercised in a subprocess by T92
+        raise MissingDependency(_JWT_MODULE, _EXTRA) from exc
+    return jwt
+
+
+class JWTIdentityProvider:
+    """Verify a bearer JWT and map its verified claims onto a `Principal` (SPEC-v0.3 §3.4).
+
+    Absent header → `None`, a **decline** (§3.2): in-process there are no headers at all, and
+    a provider with nothing to say must not break code that already uses `context()`. Present
+    and invalid → `IdentityError`, a **refusal**, which `Control` never backfills from.
+
+    Every configuration mistake that can be caught before a token is seen is caught at
+    construction, because that is the end that can be refused: the token end is already
+    covered by the `algorithms` allow-list, and a check that only existed there would be a
+    negative test against behaviour the library refuses anyway.
+    """
+
+    def __init__(
+        self,
+        *,
+        jwks_url: str | None = None,
+        public_key: str | None = None,
+        secret: str | None = None,
+        algorithms: Sequence[str],
+        issuer: str,
+        audience: str,
+        token_type: str | None,
+        header: str = DEFAULT_HEADER,
+        agent_claim: str = DEFAULT_AGENT_CLAIM,
+        user_claim: str | None = None,
+        claim_names: Sequence[str] = (),
+        leeway: timedelta = DEFAULT_LEEWAY,
+        jwks_min_refresh_interval: timedelta = DEFAULT_JWKS_MIN_REFRESH,
+        http_timeout: timedelta = DEFAULT_HTTP_TIMEOUT,
+        clock: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        self._jwt = _jwt()
+        self._algorithms = _checked_algorithms(algorithms)
+        _check_key_source(jwks_url, public_key, secret, self._algorithms)
+        if not issuer:
+            raise InvalidArgument("JWTIdentityProvider(issuer=...) is required and exact")
+        if not audience:
+            raise InvalidArgument("JWTIdentityProvider(audience=...) is required")
+        if not header.strip():
+            raise InvalidArgument("JWTIdentityProvider(header=...) must be a header name")
+        if not agent_claim:
+            raise InvalidArgument("JWTIdentityProvider(agent_claim=...) must be a claim name")
+        self._jwks_url = jwks_url
+        self._key = None if public_key is None else _read_pem(public_key)
+        self._secret = secret
+        self._issuer = issuer
+        self._audience = audience
+        self._token_type = None if token_type is None else _normalized_typ(token_type)
+        self._header = header
+        self._agent_claim = agent_claim
+        self._user_claim = user_claim
+        self._claim_names = tuple(claim_names)
+        self._leeway = leeway
+        self._min_refresh = jwks_min_refresh_interval
+        self._http_timeout = http_timeout.total_seconds()
+        self._clock = clock
+        self._keys: dict[str, _Key] = {}
+        self._fetched_at: datetime | None = None
+        if token_type is None:
+            # §3.4 — permitted, and it gives up the cross-JWT confusion defence of RFC 8725
+            # §3.11: an OIDC ID token from the same issuer, signed with the same key, whose
+            # `aud` is this audience, passes every remaining check.
+            _LOG.warning(
+                "JWTIdentityProvider(token_type=None) accepts a token of any type from %s. An "
+                "ID token from that issuer, signed with the same key and carrying aud=%r, is "
+                "then indistinguishable from an access token (RFC 8725 §2, SPEC-v0.3 §3.4)",
+                issuer,
+                audience,
+            )
+
+    def resolve(self, context: IdentityContext) -> Principal | None:
+        """The principal this call's bearer token names, or `None` where there is no token."""
+        raw = context.header(self._header)
+        if raw is None:
+            return None
+        token = _bearer(raw)
+        claims = self._verified(token)
+        return _principal(
+            claims,
+            agent_claim=self._agent_claim,
+            user_claim=self._user_claim,
+            claim_names=self._claim_names,
+            issuer=self._issuer,
+        )
+
+    # --- verification (SPEC-v0.3 §3.4) ---------------------------------------------------
+
+    def _verified(self, token: str) -> Mapping[str, Any]:
+        """Decode and check one token, or raise `IdentityError`.
+
+        The order is deliberate: the algorithm and `typ` are read from the *unverified* header
+        only to decide whether to proceed and which key to use, never to choose the
+        verification algorithm — that comes from this provider's own list, which is RFC 8725
+        §3.1's rule that a library "MUST NOT use any other algorithms".
+        """
+        header = self._unverified_header(token)
+        algorithm = header.get("alg")
+        if not isinstance(algorithm, str) or algorithm not in self._algorithms:
+            # `alg: none` is refused here with everything else outside the list, before any
+            # signature check and before a key is even selected.
+            _LOG.warning("refused a token: alg %r is not in the configured list", algorithm)
+            raise IdentityError(_REFUSED)
+        self._check_typ(header)
+        key = self._key_for(header, algorithm)
+        try:
+            claims = self._jwt.decode(
+                token,
+                key,
+                algorithms=[algorithm],
+                issuer=self._issuer,
+                # Two checks are deliberately taken back from the library:
+                #
+                # `aud`, because §3.4 requires normalize-then-compare on either wire shape
+                # rather than a raw `in`, which is substring matching on the string shape.
+                #
+                # `exp` and `nbf`, because they must be compared against **this provider's
+                # clock**. Every timed component in this codebase takes one so an expiry
+                # boundary can be tested exactly rather than raced, and a verifier reading
+                # `time.time()` behind the injection would make that untestable — the one
+                # place a test would silently start measuring the machine instead of the
+                # boundary. `require` still makes a token with no `exp` a refusal.
+                options={
+                    "require": ["exp", "iss"],
+                    "verify_aud": False,
+                    "verify_exp": False,
+                    "verify_nbf": False,
+                    "verify_iss": True,
+                },
+            )
+        except Exception as exc:
+            _LOG.warning("refused a token: %s: %s", type(exc).__name__, exc)
+            raise IdentityError(_REFUSED) from exc
+        if not isinstance(claims, Mapping):  # pragma: no cover - PyJWT always returns a dict
+            raise IdentityError(_REFUSED)
+        self._check_window(claims)
+        self._check_audience(claims)
+        return claims
+
+    def _check_window(self, claims: Mapping[str, Any]) -> None:
+        """`exp` and `nbf` against this provider's clock, with `leeway` (§3.4).
+
+        `leeway` is a bound on clock skew and nothing more: it widens the window at both ends
+        by the same amount, and it is not a grace period a deployment can lean on.
+        """
+        now = self._clock()
+        expires_at = claims.get("exp")
+        if not isinstance(expires_at, int) or isinstance(expires_at, bool):
+            _LOG.warning("refused a token: exp is %r, not a number", expires_at)
+            raise IdentityError(_REFUSED)
+        if datetime.fromtimestamp(expires_at, UTC) + self._leeway < now:
+            _LOG.warning("refused a token: ExpiredSignature: it expired at %s", expires_at)
+            raise IdentityError(_REFUSED)
+        not_before = claims.get("nbf")
+        if isinstance(not_before, int) and not isinstance(not_before, bool):
+            if datetime.fromtimestamp(not_before, UTC) - self._leeway > now:
+                _LOG.warning("refused a token: ImmatureSignature: nbf is %s", not_before)
+                raise IdentityError(_REFUSED)
+        elif not_before is not None:
+            _LOG.warning("refused a token: nbf is %r, not a number", not_before)
+            raise IdentityError(_REFUSED)
+
+    def _unverified_header(self, token: str) -> Mapping[str, Any]:
+        try:
+            header = self._jwt.get_unverified_header(token)
+        except Exception as exc:
+            _LOG.warning("refused a token: its header is unreadable: %s", exc)
+            raise IdentityError(_REFUSED) from exc
+        if not isinstance(header, Mapping):  # pragma: no cover - PyJWT always returns a dict
+            raise IdentityError(_REFUSED)
+        return header
+
+    def _check_typ(self, header: Mapping[str, Any]) -> None:
+        """RFC 8725 §3.11 — explicit typing, and the whole of the cross-JWT defence (§3.4)."""
+        if self._token_type is None:
+            return
+        declared = header.get("typ")
+        if not isinstance(declared, str) or _normalized_typ(declared) != self._token_type:
+            _LOG.warning(
+                "refused a token: typ %r is not %r; a token of another kind from the same "
+                "issuer is not an access token for this audience",
+                declared,
+                self._token_type,
+            )
+            raise IdentityError(_REFUSED)
+
+    def _check_audience(self, claims: Mapping[str, Any]) -> None:
+        """RFC 7519 §4.1.3 — `aud` is a string or an array, and membership is exact (§3.4).
+
+        Never `self._audience in claims["aud"]`: on the string shape that is substring
+        matching, and it accepts `https://ctrlrun.example` for a configured `ctrl`.
+        """
+        raw = claims.get("aud")
+        audiences = [raw] if isinstance(raw, str) else list(raw) if isinstance(raw, list) else []
+        if self._audience not in [value for value in audiences if isinstance(value, str)]:
+            _LOG.warning("refused a token: aud %r does not contain the configured audience", raw)
+            raise IdentityError(_REFUSED)
+
+    # --- keys (SPEC-v0.3 §3.4) -----------------------------------------------------------
+
+    def _key_for(self, header: Mapping[str, Any], algorithm: str) -> Any:
+        """The verification key for this token: the static one, or the JWKS entry by `kid`."""
+        if self._secret is not None:
+            return self._secret
+        if self._key is not None:
+            return self._key
+        assert self._jwks_url is not None
+        kid = header.get("kid")
+        if not isinstance(kid, str) or not kid:
+            _LOG.warning("refused a token: a JWKS deployment needs a 'kid' and this has none")
+            raise IdentityError(_REFUSED)
+        found = self._keys.get(kid)
+        if found is None:
+            self._refresh(kid)
+            found = self._keys.get(kid)
+        if found is None:
+            _LOG.warning("refused a token: kid %r is unknown after a refresh", kid)
+            raise IdentityError(_REFUSED)
+        if found.algorithm is not None and found.algorithm != algorithm:
+            # §3.4 — a key carrying its own `alg` constrains itself: the configured allow-list
+            # and the key's `alg` must both admit the token.
+            _LOG.warning(
+                "refused a token: key %r is for %s, and the token declares %s",
+                kid,
+                found.algorithm,
+                algorithm,
+            )
+            raise IdentityError(_REFUSED)
+        return found.material
+
+    def _refresh(self, kid: str) -> None:
+        """Fetch the JWK Set at most once per `jwks_min_refresh_interval` (§3.4).
+
+        Rate-limited so a stream of tokens carrying unknown `kid`s cannot turn this process
+        into a load generator aimed at the issuer. A token arriving inside the window is
+        refused without a fetch, by the caller, which finds the `kid` still absent.
+        """
+        now = self._clock()
+        if self._fetched_at is not None and now - self._fetched_at < self._min_refresh:
+            _LOG.warning(
+                "not refreshing the JWK Set for unknown kid %r: the last fetch was %s ago and "
+                "the minimum interval is %s",
+                kid,
+                now - self._fetched_at,
+                self._min_refresh,
+            )
+            return
+        self._fetched_at = now
+        # A failed fetch is a refusal and never a fallback to an empty key set: the cache is
+        # replaced only when a whole, well-formed document arrived.
+        self._keys = _parse_jwks(self._fetch(), self._jwt)
+
+    def _opener(self) -> Any:
+        """An opener that speaks HTTPS and follows nothing (SPEC-v0.3 §3.4)."""
+        return urllib.request.build_opener(
+            urllib.request.HTTPSHandler(context=ssl.create_default_context()), _NoRedirects()
+        )
+
+    def _checked_url(self) -> str:
+        """The configured JWKS URL, which must be HTTPS (SPEC-v0.3 §3.4).
+
+        Its own method so `_fetch` can be exercised against a plaintext test server without
+        this refusing first: the *redirect* guard is a separate defence, and a test that could
+        not reach it would be a negative test against a refusal that had already happened.
+        """
+        assert self._jwks_url is not None
+        if not self._jwks_url.lower().startswith("https://"):
+            _LOG.warning("the JWK Set url %s is not HTTPS", self._jwks_url)
+            raise IdentityError(_REFUSED)
+        return self._jwks_url
+
+    def _fetch(self) -> Mapping[str, Any]:
+        request = urllib.request.Request(
+            self._checked_url(), headers={"Accept": "application/json"}
+        )
+        try:
+            with self._opener().open(request, timeout=self._http_timeout) as response:
+                # Belt and braces over `_NoRedirects`: whatever URL actually answered has to be
+                # the HTTPS one that was asked for. A handler is a policy; this is the fact.
+                final = response.geturl()
+                if not final.lower().startswith("https://"):
+                    _LOG.warning("the JWK Set fetch ended at %s, which is not HTTPS", final)
+                    raise IdentityError(_REFUSED)
+                document = json.loads(response.read())
+        except (OSError, urllib.error.URLError, ValueError) as exc:
+            _LOG.warning("the JWK Set at %s could not be fetched: %s", self._jwks_url, exc)
+            raise IdentityError(_REFUSED) from exc
+        if not isinstance(document, Mapping):
+            _LOG.warning("the JWK Set at %s is not a JSON object", self._jwks_url)
+            raise IdentityError(_REFUSED)
+        return document
+
+
+class _NoRedirects(urllib.request.HTTPRedirectHandler):
+    """A redirect handler that redirects nowhere (SPEC-v0.3 §3.4).
+
+    `urllib.request.build_opener` does **not** drop `HTTPRedirectHandler` when it is handed an
+    `HTTPSHandler` — the default classes it removes are only the ones an argument is an
+    instance or subclass of, and the two are unrelated. An opener built that way still follows
+    a 302, and `HTTPRedirectHandler` permits `http`, `https` and `ftp` targets: an open
+    redirect on the issuer's domain would make this process fetch its signing keys, in
+    cleartext, from wherever the redirect pointed. Those keys are cached for the life of the
+    process, so every token the attacker then signs verifies, with an arbitrary `agent` and
+    `user`. That is the whole authority model, bypassed at the one input that decides who
+    everybody is.
+
+    Subclassing and refusing is the reliable way to say "no redirects": passing an instance of
+    a subclass *does* displace the default, which passing an unrelated handler does not.
+    """
+
+    def redirect_request(
+        self, req: Any, fp: Any, code: int, msg: str, headers: Any, newurl: str
+    ) -> None:
+        _LOG.warning("the JWK Set at %s redirected to %s; refusing to follow", req.full_url, newurl)
+        return None
+
+
+class _Key:
+    """One usable verification key, and the algorithm it constrains itself to, if any."""
+
+    __slots__ = ("algorithm", "material")
+
+    def __init__(self, material: Any, algorithm: str | None) -> None:
+        self.material = material
+        self.algorithm = algorithm
+
+
+def _parse_jwks(document: Mapping[str, Any], jwt: Any) -> dict[str, _Key]:
+    """Turn a JWK Set into keys by `kid`, refusing the whole set on a duplicate (§3.4).
+
+    RFC 7517 §4.5 says only that distinct keys *SHOULD* use distinct `kid` values, so a
+    duplicate is legal — and "take the first match" would be a silent trust decision about
+    which of two keys signs for this issuer. The whole document is refused instead.
+    """
+    entries = document.get("keys")
+    if not isinstance(entries, list):
+        _LOG.warning("the JWK Set has no 'keys' array")
+        raise IdentityError(_REFUSED)
+    keys: dict[str, _Key] = {}
+    seen: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            continue
+        kid = entry.get("kid")
+        if not isinstance(kid, str) or not kid:
+            continue
+        if not _is_for_verification(entry):
+            continue
+        # §3.4's reason for the refusal — "take the first match" is a silent trust decision
+        # about which key signs — applies to a `kid` claimed twice, whether or not both
+        # entries parse. Seen *before* the parse, so an unreadable duplicate cannot leave the
+        # readable one looking unambiguous.
+        if kid in seen:
+            _LOG.warning(
+                "the JWK Set carries two keys with kid %r; refusing rather than choosing one",
+                kid,
+            )
+            raise IdentityError(_REFUSED)
+        seen.add(kid)
+        try:
+            material = jwt.PyJWK(dict(entry)).key
+        except Exception as exc:
+            _LOG.warning("a JWK with kid %r could not be read and was skipped: %s", kid, exc)
+            continue
+        algorithm = entry.get("alg")
+        keys[kid] = _Key(material, algorithm if isinstance(algorithm, str) else None)
+    return keys
+
+
+def _is_for_verification(entry: Mapping[str, Any]) -> bool:
+    """RFC 7517 §4.2, §4.3 — a key that says it is not for signatures is not used for one."""
+    use = entry.get("use")
+    if isinstance(use, str) and use != _SIGNATURE_USE:
+        return False
+    operations = entry.get("key_ops")
+    return not (isinstance(operations, list) and _VERIFY_OP not in operations)
+
+
+# --- construction-time refusals (SPEC-v0.3 §3.4) ----------------------------------------
+
+
+def _checked_algorithms(algorithms: Sequence[str]) -> tuple[str, ...]:
+    named = tuple(algorithms)
+    if not named:
+        raise InvalidArgument(
+            "JWTIdentityProvider(algorithms=...) is required and may not be empty; there is no "
+            "default and no wildcard, because the provider MUST NOT take the verification "
+            "algorithm from the token (RFC 8725 §3.1)"
+        )
+    for algorithm in named:
+        if not isinstance(algorithm, str) or algorithm.strip().lower() == "none":
+            raise InvalidArgument(
+                f"JWTIdentityProvider(algorithms=...): {algorithm!r} is not an algorithm; "
+                "'none' means an unsigned token, which is not a credential"
+            )
+    return named
+
+
+def _check_key_source(
+    jwks_url: str | None, public_key: str | None, secret: str | None, algorithms: tuple[str, ...]
+) -> None:
+    """Exactly one key source, and it must match the algorithms (§3.4).
+
+    The `HS*`-with-a-public-key case is key confusion in its plainest form: RS256→HS256 is
+    literally "HMAC the token using the PEM of the public key as the secret", and the public
+    key is public. It is refused at the *configuration* end, which is the end that can be
+    refused — the token end is already covered by the allow-list.
+    """
+    sources = [jwks_url is not None, public_key is not None, secret is not None]
+    if sum(sources) != 1:
+        raise InvalidArgument(
+            "JWTIdentityProvider needs exactly one of jwks_url, public_key or secret; "
+            f"{sum(sources)} were given"
+        )
+    symmetric = [name for name in algorithms if name.upper().startswith("HS")]
+    asymmetric = [name for name in algorithms if not name.upper().startswith("HS")]
+    if symmetric and (jwks_url is not None or public_key is not None):
+        raise InvalidArgument(
+            f"JWTIdentityProvider: {symmetric} is symmetric and the key source is a public one. "
+            "That is key confusion: an attacker HMACs a token with the PEM of the public key, "
+            "which is public. A deployment that genuinely uses HS* puts its key in secret="
+        )
+    if asymmetric and secret is not None:
+        raise InvalidArgument(
+            f"JWTIdentityProvider: {asymmetric} is asymmetric and the key source is secret=. "
+            "An asymmetric algorithm verifies against a public key, not a shared secret"
+        )
+
+
+def _read_pem(public_key: str) -> str:
+    """PEM text where it begins `-----BEGIN`, and a filesystem path otherwise (§3.4)."""
+    if public_key.lstrip().startswith("-----BEGIN"):
+        return public_key
+    try:
+        return Path(public_key).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise InvalidArgument(
+            f"JWTIdentityProvider(public_key={public_key!r}) is neither PEM text nor a readable "
+            f"file: {exc}"
+        ) from exc
+
+
+def _normalized_typ(value: str) -> str:
+    """RFC 7519 §5.1 — case-insensitive, with an optional `application/` prefix stripped."""
+    lowered = value.strip().lower()
+    return lowered[len(_MEDIA_PREFIX) :] if lowered.startswith(_MEDIA_PREFIX) else lowered
+
+
+def _bearer(raw: str) -> str:
+    """The token out of `Authorization: Bearer <jwt>`, or a refusal (§3.4).
+
+    A header with no scheme is refused rather than guessed: a bare token is as likely to be an
+    API key somebody pasted into the wrong variable, and treating it as a JWT would report the
+    wrong failure.
+    """
+    scheme, _, token = raw.partition(" ")
+    if scheme.lower() != _BEARER or not token.strip():
+        _LOG.warning("refused a credential: the header carries no 'Bearer <token>'")
+        raise IdentityError(_REFUSED)
+    return token.strip()
+
+
+def _principal(
+    claims: Mapping[str, Any],
+    *,
+    agent_claim: str,
+    user_claim: str | None,
+    claim_names: Sequence[str],
+    issuer: str,
+) -> Principal:
+    """The verified claims as a `Principal` (§3.4).
+
+    Claim names are **flat keys**, not dotted paths: a claim called `a.b` is the key `"a.b"`,
+    and no nesting is traversed. Only the claims named in `claim_names` reach
+    `Principal.claims` — an allow-list, because a token carries fields nobody meant to publish
+    into a receipt.
+    """
+    agent = claims.get(agent_claim)
+    if not isinstance(agent, str) or not agent.strip():
+        _LOG.warning("refused a token: claim %r is missing, empty or not a string", agent_claim)
+        raise IdentityError(_REFUSED)
+    user = claims.get(user_claim) if user_claim else None
+    selected: dict[str, ClaimValue] = {}
+    for name in claim_names:
+        value = claims.get(name)
+        if isinstance(value, str | int | bool):  # bool is a subclass of int
+            selected[name] = value
+        elif value is not None:
+            _LOG.debug("claim %r is %s, which a Principal cannot carry", name, type(value).__name__)
+    expires_at = claims.get("exp")
+    return Principal(
+        agent=agent.strip(),
+        user=user.strip() if isinstance(user, str) and user.strip() else None,
+        claims=selected,
+        issuer=issuer,
+        expires_at=datetime.fromtimestamp(expires_at, UTC) if isinstance(expires_at, int) else None,
+    )

--- a/tests/test_acs.py
+++ b/tests/test_acs.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import uuid
+from datetime import timedelta
 
 import pytest
 
@@ -500,8 +501,7 @@ def test_an_authority_holding_control_is_refused_at_construction(store):
     the principal an authorization input. A self-reported name cannot be one, which is the same
     sentence that removes `--principal-from-client-info` (§8.1); the ACS hook is that flag in a
     different module, and removing one while leaving the other would make the removal a
-    gesture. T91d asserts the item-5 form of this, where the hook takes an `identity` of its
-    own; until then it has none, so an `Authority` is refused outright."""
+    gesture. The item-5 form is T91d below, where the hook takes an `identity` of its own."""
     from ctrlrun import Authority, InvalidArgument
 
     authority = Authority.from_yaml(
@@ -523,3 +523,244 @@ def test_a_control_with_no_authority_still_constructs(control):
     """The control for the refusal above: without it, an implementation that refused every
     Control would satisfy the first half."""
     assert AcsControlHook(control, prefix="acs") is not None
+
+
+# --- T91d: the ACS hook refuses a self-asserted principal (SPEC-v0.3 §8.4) --------------
+
+
+def _authority(agent="verified-agent"):
+    from ctrlrun import Authority
+
+    return Authority.from_yaml(
+        "schema: ctrlrun.policy/v3\n"
+        "authority:\n"
+        "  grants:\n"
+        "    - id: g\n"
+        f'      subject: {{ agent: "{agent}" }}\n'
+        '      actions: ["**"]\n',
+        standalone=True,
+    )
+
+
+@pytest.mark.authority
+def test_T91d_an_authority_holding_control_with_no_identity_is_refused(store):
+    """§8.4, by name: the argument, not merely "some error"."""
+    from ctrlrun import InvalidArgument
+
+    control = Control(Policy.from_yaml(POLICY), store, authority=_authority())
+
+    with pytest.raises(InvalidArgument, match="identity"):
+        AcsControlHook(control, prefix="acs")
+
+
+@pytest.mark.authority
+def test_T91d_with_a_provider_the_envelopes_agent_id_is_ignored(store):
+    """§8.4 — not merged, not a fallback, not compared. It is display data, like `clientInfo`,
+    and a value that is only sometimes authoritative is one nobody can reason about."""
+    from ctrlrun import HeaderIdentityProvider
+
+    control = Control(Policy.from_yaml(POLICY), store, authority=_authority())
+    hook = AcsControlHook(
+        control,
+        prefix="acs",
+        identity=HeaderIdentityProvider(agent_header="X-Agent"),
+    )
+
+    # The envelope says `impostor`; the transport says `verified-agent`, and only the second
+    # holds a grant. If `agent_id` were read, or merged, or compared, this would be denied.
+    envelope = _call(amount=200)
+    answer = hook.handle(envelope, headers={"X-Agent": "verified-agent"})
+
+    assert answer["result"]["decision"] == "allow"
+    # The reservation is held open across the two hooks, so the receipt lands on the result
+    # leg. Closing it is the only way to read the principal that was actually recorded, and a
+    # disjunction that tolerated "no receipt" would pass whether or not one was ever written.
+    hook.handle(_result(envelope["params"]["request_id"]))
+    assert store.receipts()[-1].principal.agent == "verified-agent"
+
+
+@pytest.mark.authority
+def test_T91d_the_provider_is_what_decides_not_the_envelope(store):
+    """The control for the test above. The envelope names the *granted* agent and the
+    transport names an ungranted one: if `agent_id` were read the call would be allowed, so
+    the denial is what proves the provider won."""
+    from ctrlrun import HeaderIdentityProvider
+
+    control = Control(Policy.from_yaml(POLICY), store, authority=_authority())
+    hook = AcsControlHook(
+        control, prefix="acs", identity=HeaderIdentityProvider(agent_header="X-Agent")
+    )
+    envelope = _call(amount=200)
+    envelope["params"]["metadata"]["agent_id"] = "verified-agent"
+
+    answer = hook.handle(envelope, headers={"X-Agent": "impostor"})
+
+    assert answer["result"]["decision"] == "deny"
+    assert "no_authority" in answer["result"]["reason_codes"]
+    assert store.receipts()[-1].principal.agent == "impostor"
+
+
+@pytest.mark.authority
+def test_T91d_a_declining_provider_is_refused_and_never_backfilled(store):
+    """§8.4 — falling back to `agent_id` would reach it by an easier route than forging a
+    credential, which is the hole §3.2 closes for `context()`, in a different module."""
+    from ctrlrun import HeaderIdentityProvider
+
+    control = Control(Policy.from_yaml(POLICY), store, authority=_authority())
+    hook = AcsControlHook(
+        control, prefix="acs", identity=HeaderIdentityProvider(agent_header="X-Agent")
+    )
+    envelope = _call(amount=200)
+    envelope["params"]["metadata"]["agent_id"] = "verified-agent"
+
+    answer = hook.handle(envelope, headers={})
+
+    assert answer["result"]["decision"] == "deny"
+    assert answer["result"]["reason_codes"] == ["no_principal"]
+    assert store.receipts() == ()
+    assert store.events() == ()
+
+
+@pytest.mark.authority
+def test_T91d_the_envelopes_environment_is_ignored_in_favour_of_the_configuration(store):
+    """§8.4 — an environment named in an authorization decision cannot come off the wire from
+    the caller: a grant may scope to it, so the caller would choose what it is authorized in."""
+    from ctrlrun import HeaderIdentityProvider
+
+    control = Control(
+        Policy.from_yaml(POLICY), store, authority=_authority(), environment="staging"
+    )
+    hook = AcsControlHook(
+        control, prefix="acs", identity=HeaderIdentityProvider(agent_header="X-Agent")
+    )
+    envelope = _call(amount=200)
+    envelope["params"]["metadata"]["environment"] = "production"
+
+    hook.handle(envelope, headers={"X-Agent": "verified-agent"})
+    # The environment reaches the receipt only when the action closes, and the result hook is
+    # what closes it — which is also the leg that writes the only receipt an ACS action gets.
+    hook.handle(_result(envelope["params"]["request_id"]))
+
+    assert store.receipts()[-1].environment == "staging"
+
+
+@pytest.mark.authority
+def test_T91b_the_acs_approval_gate_uses_the_combined_decision(store):
+    """§8.3 — `ctrlrun.acs`'s request hook is the second of the three places that read
+    `Policy.evaluate` directly. An action a grant forbids must not reach the approval flow."""
+    from ctrlrun import Authority, HeaderIdentityProvider
+
+    narrow = Authority.from_yaml(
+        "schema: ctrlrun.policy/v3\n"
+        "authority:\n"
+        "  grants:\n"
+        "    - id: small-only\n"
+        '      subject: { agent: "verified-agent" }\n'
+        '      actions: ["**"]\n'
+        "      constraints: { amount_lte: 20000 }\n",
+        standalone=True,
+    )
+    control = Control(Policy.from_yaml(POLICY), store, authority=narrow)
+    hook = AcsControlHook(
+        control, prefix="acs", identity=HeaderIdentityProvider(agent_header="X-Agent")
+    )
+
+    answer = hook.handle(_call(amount=500000), headers={"X-Agent": "verified-agent"})
+
+    assert answer["result"]["decision"] == "deny"
+    assert "authority_constraint" in answer["result"]["reason_codes"]
+    assert "APPROVAL_REQUESTED" not in [str(e.type) for e in store.events()]
+
+
+@pytest.mark.authority
+def test_the_acs_hook_spends_no_approval_on_an_action_the_grant_forbids(store):
+    """A granted approval survives an authority denial — and **not** because of §8.3.
+
+    Stated plainly, because the mutation table says so: swapping this hook's
+    `Control.evaluate` back to `Policy.evaluate` changes nothing any assertion here can see.
+    `Control.execute` evaluates authority *before* the approval gate (§4.3), so the approval
+    is never reached whichever decision sent the hook looking for one. §8.3's change is still
+    right — it keeps one rule in one place and saves a pointless store read — but at this hook
+    it is **not independently observable**, and the mutation table records it as an equivalent
+    mutant rather than pretending a test isolates it.
+
+    The gateway is the asymmetric case: there, the policy axis alone lets an action the grant
+    forbids reach `_before_asking_a_human`, which answers `-41004` off the effect record
+    before authority is ever consulted. That one *is* isolated, in `test_gateway_server.py`.
+    """
+    from ctrlrun import Authority, HeaderIdentityProvider
+
+    narrow = Authority.from_yaml(
+        "schema: ctrlrun.policy/v3\n"
+        "authority:\n"
+        "  grants:\n"
+        "    - id: small-only\n"
+        '      subject: { agent: "verified-agent" }\n'
+        '      actions: ["**"]\n'
+        "      constraints: { amount_lte: 20000 }\n",
+        standalone=True,
+    )
+    control = Control(Policy.from_yaml(POLICY), store, authority=narrow)
+    hook = AcsControlHook(
+        control, prefix="acs", identity=HeaderIdentityProvider(agent_header="X-Agent")
+    )
+    # A human has already granted this exact action: policy says `approve` for the amount.
+    envelope = _call(amount=500000)
+    action = hook._action(
+        envelope["params"], envelope["params"]["payload"], {"x-agent": "verified-agent"}
+    )
+    request = control.approvals.request(action, timedelta(hours=1))
+    store.grant_approval(request.request_id, "human:test")
+
+    answer = hook.handle(envelope, headers={"X-Agent": "verified-agent"})
+
+    assert answer["result"]["decision"] == "deny"
+    record = store.get_approval(request.request_id)
+    assert record.consumed_at is None, "an approval was spent on an action the grant forbids"
+    assert str(record.status) == "granted"
+
+
+@pytest.mark.authority
+def test_an_expired_credential_is_answered_principal_expired_not_no_principal(store):
+    """§2.3, §8.4 — the ACS answer and the evidence for the same action must agree.
+
+    `Control.execute` refuses a lapsed credential with `IdentityError` and writes a receipt
+    saying `principal_expired`. Answering `no_principal` would leave a platform reading one
+    story and an auditor reading another. The two are told apart **structurally** — "the
+    provider named nobody" is raised while the Action is being built, outside the try that
+    wraps `execute` — and never by matching on a message.
+    """
+    from datetime import UTC, datetime
+
+    from ctrlrun import StaticIdentityProvider
+
+    lapsed = datetime(2020, 1, 1, tzinfo=UTC)
+    control = Control(Policy.from_yaml(POLICY), store, authority=_authority("verified-agent"))
+    hook = AcsControlHook(
+        control,
+        prefix="acs",
+        identity=StaticIdentityProvider(agent="verified-agent", expires_at=lapsed),
+    )
+
+    answer = hook.handle(_call(amount=200), headers={})
+
+    assert answer["result"]["decision"] == "deny"
+    assert answer["result"]["reason_codes"] == ["principal_expired"]
+    assert store.receipts()[-1].decision_reason == "principal_expired"
+
+
+@pytest.mark.authority
+def test_a_provider_that_names_nobody_is_still_answered_no_principal(store):
+    """The control for the test above: the two refusals keep different codes. Without it, a
+    hook that reported `principal_expired` for everything would satisfy the first half."""
+    from ctrlrun import HeaderIdentityProvider
+
+    control = Control(Policy.from_yaml(POLICY), store, authority=_authority("verified-agent"))
+    hook = AcsControlHook(
+        control, prefix="acs", identity=HeaderIdentityProvider(agent_header="X-Agent")
+    )
+
+    answer = hook.handle(_call(amount=200), headers={})
+
+    assert answer["result"]["reason_codes"] == ["no_principal"]
+    assert store.receipts() == ()

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import threading
+from datetime import timedelta
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
@@ -875,3 +876,703 @@ def test_a_call_inside_the_grant_is_forwarded(authority_client, upstream):
 
     assert len(upstream.calls) == 1
     assert "error" not in response.json()
+
+
+# --- T91: the gateway enforces authority, distinguishably (SPEC-v0.3 §8.4) --------------
+
+
+@pytest.mark.authority
+def test_T91_a_call_outside_the_grant_is_41012_and_never_reaches_the_upstream(
+    authority_client, upstream, store
+):
+    """§8.4 — `-41001` means this action is not permitted to anyone in this configuration;
+    `-41012` means it is not permitted to *you*. A client answers the two differently."""
+    response = _post(
+        authority_client,
+        _call(arguments={"amount": 200, "payment_id": "pi_1"}),
+        headers={"X-Agent": "someone-else"},
+    )
+
+    assert response.status_code == 403
+    assert _error(response)["code"] == -41012
+    assert _error(response)["data"]["error"] == "ctrlrun.unauthorized"
+    assert _error(response)["data"]["reason"] == "no_authority"
+    assert upstream.calls == []
+    assert store.receipts()[-1].result is ReceiptResult.DENIED
+    assert store.receipts()[-1].decision_reason == "no_authority"
+
+
+@pytest.mark.authority
+def test_T91_a_policy_denial_under_the_same_authority_section_is_still_41001(upstream, store):
+    """The other half, and the one that pins the discrimination: widening the
+    `AuthorityDenied` handler to `ActionDenied`, or ordering the two `except` clauses the
+    other way, returns a plausible code and fails *this* test rather than the one above."""
+    grant = """
+schema: ctrlrun.policy/v3
+authority:
+  grants:
+    - id: everything
+      subject: { agent: "refund-agent" }
+      actions: ["mcp.acme.**"]
+"""
+    from ctrlrun import Authority
+
+    gateway = _gateway_with(store, upstream, Authority.from_yaml(grant, standalone=True))
+    body = _call(arguments={"amount": 90000000, "payment_id": "pi_9"})
+
+    response = gateway.handle(
+        json.dumps(body).encode(), _lowered(_headers(body, **{"X-Agent": "refund-agent"}))
+    )
+
+    assert response.status == 403
+    error = json.loads(response.body)["error"]
+    assert error["code"] == -41001
+    assert error["data"]["error"] == "ctrlrun.denied"
+    assert upstream.calls == []
+
+
+@pytest.mark.authority
+def test_T91_a_call_inside_the_grant_reaches_the_upstream(authority_client, upstream):
+    upstream.respond({"resultType": "complete", "content": []})
+
+    response = _post(
+        authority_client,
+        _call(arguments={"amount": 1000, "payment_id": "pi_2"}),
+        headers={"X-Agent": "refund-agent"},
+    )
+
+    assert len(upstream.calls) == 1
+    assert "error" not in response.json()
+
+
+def _lowered(headers):
+    return {name.lower(): value for name, value in headers.items()}
+
+
+def _gateway_with(store, upstream, authority, *, mode="enforce", **config_overrides):
+    """One `Gateway` over a real forwarder, with the authority section a test wants."""
+    document = POLICY.replace("ctrlrun.policy/v2", f"ctrlrun.policy/v3\nmode: {mode}")
+    control = Control(Policy.from_yaml(document), store, authority=authority)
+    base = {
+        "upstream": upstream.url,
+        "alias": "acme",
+        "principal_header": "X-Agent",
+        "port": 0,
+    }
+    config = GatewayConfig(**{**base, **config_overrides})
+    return Gateway(config, control, httpx_forwarder(config))
+
+
+# --- T91b: the approval gate uses the combined decision (§8.3) --------------------------
+
+
+@pytest.mark.authority
+def test_T91b_the_approval_flow_works_with_an_authority_section_loaded(upstream, store):
+    """§8.3 — three places in shipped v0.2 code read `Policy.evaluate` directly, and the
+    gateway's `tools/call` path is one. Left alone, this flow still works, so the change is
+    pinned by what it *stops*: a call a grant forbids no longer runs the approval flow."""
+    from ctrlrun import Authority
+
+    grant = """
+schema: ctrlrun.policy/v3
+authority:
+  grants:
+    - id: everything
+      subject: { agent: "refund-agent" }
+      actions: ["mcp.acme.**"]
+"""
+    gateway = _gateway_with(store, upstream, Authority.from_yaml(grant, standalone=True))
+    upstream.respond({"resultType": "complete", "content": []})
+    body = _call(arguments={"amount": 500000, "payment_id": "pi_3"})
+    headers = _lowered(_headers(body, **{"X-Agent": "refund-agent"}))
+
+    first = gateway.handle(json.dumps(body).encode(), headers)
+
+    assert json.loads(first.body)["error"]["code"] == -41002
+    assert upstream.calls == []
+
+    request_id = json.loads(first.body)["error"]["data"]["request_id"]
+    store.grant_approval(request_id, "human:test")
+    second = gateway.handle(json.dumps(body).encode(), headers)
+
+    assert "error" not in json.loads(second.body)
+    assert len(upstream.calls) == 1
+
+
+@pytest.mark.authority
+def test_T91b_an_action_a_grant_forbids_never_reaches_the_approval_flow(upstream, store):
+    """The half that only the combined decision gets right: with `Policy.evaluate` alone the
+    pre-check would run the approval flow for a call the grant forbids outright, and a human
+    would be paged about an action that could never run."""
+    from ctrlrun import Authority
+
+    grant = """
+schema: ctrlrun.policy/v3
+authority:
+  grants:
+    - id: small-refunds-only
+      subject: { agent: "refund-agent" }
+      actions: ["mcp.acme.create_refund"]
+      constraints: { amount_lte: 20000 }
+"""
+    gateway = _gateway_with(store, upstream, Authority.from_yaml(grant, standalone=True))
+    body = _call(arguments={"amount": 500000, "payment_id": "pi_4"})
+
+    response = gateway.handle(
+        json.dumps(body).encode(), _lowered(_headers(body, **{"X-Agent": "refund-agent"}))
+    )
+
+    assert json.loads(response.body)["error"]["code"] == -41012
+    assert store.approvals_for(store.receipts()[-1].action_hash) == ()
+    assert "APPROVAL_REQUESTED" not in [str(event.type) for event in store.events()]
+
+
+# --- T91c: in observe mode the gateway forwards everything (§8.4) ----------------------
+
+
+@pytest.mark.authority
+def test_T91c_in_observe_mode_a_call_outside_the_grant_is_forwarded(upstream, store):
+    """§8.4 — no `-41001`, no `-41012`, no `-41002`; the client sees the upstream's response
+    and the would-have decision lives in the receipt. A gateway that returned an error while
+    claiming not to enforce would be enforcing."""
+    from ctrlrun import Authority
+
+    grant = """
+schema: ctrlrun.policy/v3
+authority:
+  grants:
+    - id: someone-else-entirely
+      subject: { agent: "other-agent" }
+      actions: ["mcp.acme.**"]
+"""
+    gateway = _gateway_with(
+        store, upstream, Authority.from_yaml(grant, standalone=True), mode="observe"
+    )
+    upstream.respond({"resultType": "complete", "content": []})
+    body = _call(arguments={"amount": 200, "payment_id": "pi_5"})
+
+    response = gateway.handle(
+        json.dumps(body).encode(), _lowered(_headers(body, **{"X-Agent": "refund-agent"}))
+    )
+
+    assert "error" not in json.loads(response.body)
+    assert len(upstream.calls) == 1
+    receipt = store.receipts()[-1]
+    assert receipt.result is ReceiptResult.OBSERVED
+    assert receipt.would_have.blocked_reason == "no_authority"
+
+
+@pytest.mark.authority
+def test_T91c_the_same_call_under_enforce_is_refused(upstream, store):
+    """The control: without it, an upstream that was never reachable would satisfy the test
+    above by returning an error for a different reason."""
+    from ctrlrun import Authority
+
+    grant = """
+schema: ctrlrun.policy/v3
+authority:
+  grants:
+    - id: someone-else-entirely
+      subject: { agent: "other-agent" }
+      actions: ["mcp.acme.**"]
+"""
+    gateway = _gateway_with(store, upstream, Authority.from_yaml(grant, standalone=True))
+    body = _call(arguments={"amount": 200, "payment_id": "pi_5"})
+
+    response = gateway.handle(
+        json.dumps(body).encode(), _lowered(_headers(body, **{"X-Agent": "refund-agent"}))
+    )
+
+    assert json.loads(response.body)["error"]["code"] == -41012
+    assert upstream.calls == []
+
+
+# --- SPEC-v0.3 §8.2: exactly one identity source, and no flag that cannot take effect ----
+
+
+IDENTITY_BASE = {"upstream": "http://127.0.0.1:1/mcp", "alias": "acme"}
+JWT_MINIMUM = {
+    "identity_jwt": True,
+    "identity_jwt_secret_file": None,
+    "identity_jwt_public_key": None,
+    "identity_jwt_jwks_url": "https://issuer.example/jwks",
+    "identity_jwt_algorithms": ("RS256",),
+    "identity_jwt_issuer": "https://issuer.example",
+    "identity_jwt_audience": "https://ctrlrun.example",
+    "identity_jwt_token_type": "at+jwt",
+}
+
+
+@pytest.mark.parametrize(
+    "sources",
+    [
+        {},
+        {"principal": "bot", "principal_header": "X-Agent"},
+        {"principal": "bot", **JWT_MINIMUM},
+        {"principal_header": "X-Agent", **JWT_MINIMUM},
+        {"principal": "bot", "principal_header": "X-Agent", **JWT_MINIMUM},
+    ],
+    ids=["none", "two-classic", "static-and-jwt", "header-and-jwt", "all-three"],
+)
+def test_exactly_one_identity_source_is_required_and_the_three_are_named(sources):
+    """§8.2 — giving two, or none, exits non-zero naming the three. There is still no
+    default, because an Action cannot exist without a principal."""
+    with pytest.raises(InvalidArgument) as refused:
+        GatewayConfig(**IDENTITY_BASE, **sources)
+
+    message = str(refused.value)
+    assert "--principal" in message
+    assert "--principal-header" in message
+    assert "--identity-jwt" in message
+
+
+def _cli_jwt_flags():
+    """Every `--identity-jwt-*` option `ctrlrun gateway` actually declares.
+
+    Read off the command rather than written out here, and deliberately **not** off the
+    implementation's own `given` map: a list copied from the code under test mirrors it, and
+    cannot fail for the flag the code forgot. Two were forgotten, and the earlier version of
+    this test — parametrized from that map — was structurally unable to notice.
+    """
+    from ctrlrun.cli.main import gateway as gateway_command
+
+    return sorted(
+        parameter.name
+        for parameter in gateway_command.params
+        if parameter.name is not None
+        and parameter.name.startswith("identity_jwt_")
+        and parameter.name != "identity_jwt"
+    )
+
+
+#: A value for each that is different from its default, so "was it given" is unambiguous.
+_STRAY_VALUES = {
+    "identity_jwt_jwks_url": "https://x/jwks",
+    "identity_jwt_public_key": "/tmp/k.pem",
+    "identity_jwt_secret_file": "/tmp/s",
+    "identity_jwt_algorithms": ("RS256",),
+    "identity_jwt_issuer": "https://issuer.example",
+    "identity_jwt_audience": "https://ctrlrun.example",
+    "identity_jwt_token_type": "at+jwt",
+    "identity_jwt_user_claim": "email",
+    "identity_jwt_claims": ("scope",),
+    "identity_jwt_header": "x-token",
+    "identity_jwt_agent_claim": "client_id",
+    "identity_jwt_leeway": 99999.0,
+    "identity_jwt_jwks_min_refresh": 99999.0,
+    "identity_jwt_http_timeout": 99999.0,
+}
+
+
+def test_the_stray_value_table_covers_every_cli_flag():
+    """The guard on the guard: a new `--identity-jwt-*` option with no value here would make
+    the test below silently skip it."""
+    assert set(_cli_jwt_flags()) == set(_STRAY_VALUES), set(_cli_jwt_flags()) ^ set(_STRAY_VALUES)
+
+
+@pytest.mark.parametrize("flag", _cli_jwt_flags())
+def test_every_identity_jwt_flag_needs_identity_jwt(flag):
+    """§8.2 — a flag that cannot take effect is a flag the operator believes took effect."""
+    with pytest.raises(InvalidArgument, match="--identity-jwt"):
+        GatewayConfig(**IDENTITY_BASE, principal="bot", **{flag: _STRAY_VALUES[flag]})
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [
+        "identity_jwt_algorithms",
+        "identity_jwt_issuer",
+        "identity_jwt_audience",
+        "identity_jwt_token_type",
+    ],
+)
+def test_identity_jwt_refuses_the_four_settings_with_no_safe_default(missing):
+    """An unpinned algorithm, issuer or audience is a token from somewhere else, and an
+    unpinned type is an ID token. Refused before the extra is even imported, so an operator
+    who has not installed it still learns what they got wrong."""
+    options = dict(JWT_MINIMUM)
+    options[missing] = () if missing.endswith("algorithms") else None
+
+    with pytest.raises(InvalidArgument) as refused:
+        GatewayConfig(**IDENTITY_BASE, **options)
+
+    assert missing.replace("_", "-").replace("identity-jwt-", "--identity-jwt-") in str(
+        refused.value
+    )
+
+
+def test_an_empty_token_type_is_the_explicit_no_typ_and_is_accepted():
+    """§8.2 — `""` means "this issuer sets no typ", and it must stay distinguishable from
+    "not passed": a default would make RFC 8725 §3.11's defence something nobody ever saw."""
+    config = GatewayConfig(**IDENTITY_BASE, **{**JWT_MINIMUM, "identity_jwt_token_type": ""})
+
+    assert config.identity_jwt_token_type == ""
+
+
+def test_user_header_is_refused_with_identity_jwt():
+    with pytest.raises(InvalidArgument, match="--identity-jwt-user-claim"):
+        GatewayConfig(**IDENTITY_BASE, **JWT_MINIMUM, user_header="X-User")
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        ({"principal": "bot"}, "StaticIdentityProvider"),
+        ({"principal_header": "X-Agent"}, "HeaderIdentityProvider"),
+        (JWT_MINIMUM, "JWTIdentityProvider"),
+    ],
+    ids=["static", "header", "jwt"],
+)
+def test_each_flag_constructs_the_provider_it_names(config, expected):
+    """§8.2 — `--principal` and `--principal-header` are understood as constructors now, not
+    as a second way of naming a principal."""
+    from ctrlrun.gateway.server import identity_provider
+
+    provider = identity_provider(GatewayConfig(**IDENTITY_BASE, **config))
+
+    assert type(provider).__name__ == expected
+
+
+def test_the_jwt_secret_is_read_from_a_file_and_never_from_a_flag(tmp_path):
+    """§8.2 — a shared secret on a command line is in every process listing on the host."""
+    from ctrlrun.gateway.server import identity_provider
+
+    secret_file = tmp_path / "secret"
+    secret_file.write_text("  hunter2  \n")
+    config = GatewayConfig(
+        **IDENTITY_BASE,
+        identity_jwt=True,
+        identity_jwt_secret_file=str(secret_file),
+        identity_jwt_algorithms=("HS256",),
+        identity_jwt_issuer="https://issuer.example",
+        identity_jwt_audience="https://ctrlrun.example",
+        identity_jwt_token_type="at+jwt",
+    )
+
+    provider = identity_provider(config)
+
+    assert type(provider).__name__ == "JWTIdentityProvider"
+    assert not any("hunter2" in str(value) for value in vars(config).values())
+
+
+def test_the_jwt_identity_header_is_watched_for_repetition(tmp_path):
+    """§3.1's rule has to reach the header that carries the *credential*, not only the weaker
+    sources. Without this it applies to `--principal-header` and not to `--identity-jwt`."""
+    from ctrlrun.gateway.server import _repeated_identity_header
+
+    config = GatewayConfig(**IDENTITY_BASE, **{**JWT_MINIMUM, "identity_jwt_header": "x-token"})
+    pairs = [("Content-Type", "application/json"), ("X-Token", "a"), ("x-token", "b")]
+
+    assert _repeated_identity_header(config, pairs) == "x-token"
+
+
+# --- SPEC-v0.3 §8.3: --authority loads the section from a separate document --------------
+
+
+AUTHORITY_DOCUMENT = """
+schema: ctrlrun.policy/v3
+authority:
+  grants:
+    - id: refunds-only
+      subject: { agent: "refund-agent" }
+      actions: ["mcp.acme.create_refund"]
+      constraints: { amount_lte: 20000 }
+"""
+
+
+@pytest.mark.authority
+def test_the_authority_flag_loads_the_section_from_its_own_document(tmp_path, store):
+    """§8.3 — the person who writes grants and the person who writes per-action autonomy are
+    often not the same person, and a gateway is where that separation shows up first."""
+    from ctrlrun.gateway import _authority
+
+    path = tmp_path / "authority.yaml"
+    path.write_text(AUTHORITY_DOCUMENT)
+    control = Control(Policy.from_yaml(POLICY), store)
+
+    loaded = _authority(control, str(path))
+
+    assert set(loaded.grants) == {"refunds-only"}
+
+
+@pytest.mark.authority
+def test_declaring_authority_in_both_places_refuses_to_start(tmp_path, store):
+    """§8.3 — two sources for one section is the ambiguity `v0.1 §5.1` refuses for
+    `{resource}`. Silently preferring either would mean an operator who edited the wrong file
+    saw no effect and no error."""
+    from ctrlrun import Authority
+    from ctrlrun.gateway import _authority
+
+    path = tmp_path / "authority.yaml"
+    path.write_text(AUTHORITY_DOCUMENT)
+    control = Control(
+        Policy.from_yaml(POLICY.replace("ctrlrun.policy/v2", "ctrlrun.policy/v3")),
+        store,
+        authority=Authority.from_yaml(AUTHORITY_ONLY, standalone=True),
+    )
+
+    with pytest.raises(InvalidArgument) as refused:
+        _authority(control, str(path))
+
+    assert str(path) in str(refused.value)
+    assert control.policy.source in str(refused.value)
+
+
+@pytest.mark.parametrize("key", ["actions", "mode"])
+def test_an_authority_document_is_not_a_policy_document(tmp_path, store, key):
+    """§8.3 — its top-level key set is closed at exactly `schema` and `authority`. Two sources
+    for `mode:` would be two switches, which is the one thing §6.1 says there is not."""
+    from ctrlrun.errors import PolicyError
+    from ctrlrun.gateway import _authority
+
+    path = tmp_path / "authority.yaml"
+    extra = "actions:\n  x:\n    decision: allow\n" if key == "actions" else "mode: observe\n"
+    path.write_text(AUTHORITY_DOCUMENT + extra)
+
+    with pytest.raises(PolicyError) as refused:
+        _authority(Control(Policy.from_yaml(POLICY), store), str(path))
+
+    assert str(path) in str(refused.value)
+    assert key in str(refused.value)
+
+
+# --- SPEC-v0.3 §8.4: the startup block ---------------------------------------------------
+
+
+@pytest.mark.authority
+def test_the_startup_block_names_the_environment_identity_and_authority(capsys, store, upstream):
+    """§8.4 — everything here is something an operator can get wrong in a way that is
+    invisible until an incident. It goes on the line that starts the process."""
+    from ctrlrun import Authority
+    from ctrlrun.gateway import _announce
+
+    gateway = _gateway_with(store, upstream, Authority.from_yaml(AUTHORITY_ONLY, standalone=True))
+    _announce(gateway._control, gateway.config, gateway.identity, None)
+    printed = capsys.readouterr().out
+
+    assert "environment  production" in printed
+    assert "HeaderIdentityProvider" in printed
+    assert "trusts the header 'X-Agent'" in printed
+    assert "1 grant(s)" in printed
+    assert "mcp.acme.read_only" in printed  # the action with no effect: template
+
+
+def test_the_startup_block_says_so_when_there_is_no_authority_section(capsys, store, upstream):
+    """§8.4 — so an operator who believes they configured authority finds out on the line that
+    starts the process, rather than from a receipt three weeks later."""
+    from ctrlrun.gateway import _announce
+
+    gateway = _gateway_with(store, upstream, None)
+    _announce(gateway._control, gateway.config, gateway.identity, None)
+
+    assert "no authority: section — every principal is unrestricted" in capsys.readouterr().out
+
+
+# --- No refusal reaches a client as a dropped connection (SPEC-v0.3 §8.2, §8.4) ---------
+#
+# `do_POST` has no top-level `try`, and `socketserver` answers an escaping exception by
+# logging a traceback and closing the socket with **nothing written**. A client reads that as
+# a transport failure — which is the one signal it retries on, and the one thing this library
+# exists to stop. Three v0.3 paths landed there; each has a clause and each has a test.
+
+
+class _Raising:
+    """An identity provider that raises whatever it was told to.
+
+    It refuses everything the real providers refuse — it never *names* anybody — so it cannot
+    let a call through that a real provider would have stopped.
+    """
+
+    def __init__(self, error) -> None:
+        self._error = error
+
+    def resolve(self, context):
+        raise self._error
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(ValueError("the token service was unreachable"), id="ValueError"),
+        pytest.param(RuntimeError("boom"), id="RuntimeError"),
+        pytest.param(KeyError("kid"), id="KeyError"),
+    ],
+)
+def test_a_provider_raising_anything_answers_41007_rather_than_dropping_the_connection(
+    upstream, store, error, monkeypatch
+):
+    """§3.2 — "anything else is logged and re-raised as `IdentityError`". `Control` applies
+    that rule in `_ask_provider`; the gateway does not go through it, so it needs its own.
+    `IdentityProvider` is public API, so this is a deployment's own provider on a bad day."""
+    gateway = _gateway_with(store, upstream, None)
+    monkeypatch.setattr(gateway, "_identity", _Raising(error))
+    body = _call()
+
+    response = gateway.handle(json.dumps(body).encode(), _lowered(_headers(body)))
+
+    assert response.status == 403
+    assert json.loads(response.body)["error"]["code"] == -41007
+    assert upstream.calls == []
+    assert store.receipts() == ()
+    assert store.events() == ()
+
+
+def test_an_expired_principal_answers_41007_rather_than_dropping_the_connection(
+    upstream, store, monkeypatch
+):
+    """§2.3 — `Control.execute` refuses an expired principal with `IdentityError`, which is
+    deliberately not an `ActionDenied`, so it needs its own clause in `_through_control`.
+
+    Routinely reachable rather than adversarial: `JWTIdentityProvider` admits a token up to
+    `leeway` (60 s by default) past its `exp` and then stamps `Principal.expires_at` with that
+    exact `exp` — so every token presented inside that window is admitted by the provider and
+    refused by the kernel. Before this clause, that dropped the connection.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from ctrlrun import StaticIdentityProvider
+
+    gateway = _gateway_with(store, upstream, None)
+    lapsed = datetime.now(UTC) - timedelta(minutes=1)
+    monkeypatch.setattr(
+        gateway, "_identity", StaticIdentityProvider(agent="refund-agent", expires_at=lapsed)
+    )
+    body = _call()
+
+    response = gateway.handle(json.dumps(body).encode(), _lowered(_headers(body)))
+
+    assert response.status == 403
+    assert json.loads(response.body)["error"]["code"] == -41007
+    assert upstream.calls == []
+    # The receipt is written — there *is* a principal to attribute it to — and it says why.
+    assert store.receipts()[-1].decision_reason == "principal_expired"
+
+
+@pytest.mark.authority
+def test_a_continuation_whose_authority_lapsed_answers_41012_not_a_dropped_connection(
+    upstream, store, monkeypatch
+):
+    """§5.6.1 — an operator runs `ctrlrun revoke` while a human is answering an elicitation.
+    `Control.resume` refuses the lease extension with `AuthorityDenied`, and `_continue`
+    caught neither that nor `IdentityError`."""
+    from ctrlrun import Authority
+    from ctrlrun.errors import AuthorityDenied
+
+    gateway = _gateway_with(store, upstream, Authority.from_yaml(AUTHORITY_ONLY, standalone=True))
+
+    def refuse(*args, **kwargs):
+        raise AuthorityDenied("authority no longer covers this action", reason="authority_revoked")
+
+    monkeypatch.setattr(gateway._control, "resume", refuse)
+    body = _call(arguments={"amount": 1000, "payment_id": "pi_7"})
+    body["params"]["requestState"] = "continuation-token"
+
+    response = gateway.handle(
+        json.dumps(body).encode(), _lowered(_headers(body, **{"X-Agent": "refund-agent"}))
+    )
+
+    assert response.status == 403
+    error = json.loads(response.body)["error"]
+    assert error["code"] == -41012
+    assert error["data"]["reason"] == "authority_revoked"
+
+
+def test_a_continuation_whose_credential_expired_answers_41007(upstream, store, monkeypatch):
+    """§2.3.1 — the other half of the same hole: holding a continuation extends a lease, and
+    an extension is a request to keep authority the credential no longer carries."""
+    from ctrlrun.errors import IdentityError
+
+    gateway = _gateway_with(store, upstream, None)
+
+    def refuse(*args, **kwargs):
+        raise IdentityError("the principal's credential expired at 2026-01-01T00:00:00Z")
+
+    monkeypatch.setattr(gateway._control, "resume", refuse)
+    body = _call()
+    body["params"]["requestState"] = "continuation-token"
+
+    response = gateway.handle(json.dumps(body).encode(), _lowered(_headers(body)))
+
+    assert response.status == 403
+    assert json.loads(response.body)["error"]["code"] == -41007
+
+
+def test_the_gateway_identity_refusal_message_says_nothing_about_why(upstream, store, monkeypatch):
+    """§8.2 — "a distinct message; the client learns that its credential was rejected and
+    learns nothing about why, which is the correct amount to tell an unauthenticated caller".
+    This handler had no test at all, which is how the three holes above went unnoticed."""
+    from ctrlrun.errors import IdentityError
+
+    gateway = _gateway_with(store, upstream, None)
+    monkeypatch.setattr(
+        gateway, "_identity", _Raising(IdentityError("kid 'rotated' is unknown after a refresh"))
+    )
+    body = _call()
+
+    response = gateway.handle(json.dumps(body).encode(), _lowered(_headers(body)))
+    message = json.loads(response.body)["error"]["message"]
+
+    assert message == "the credential offered was rejected"
+    assert "kid" not in message and "rotated" not in message
+
+
+def test_a_declining_provider_is_a_different_message_from_a_refusing_one(
+    upstream, store, monkeypatch
+):
+    """The two are different things (§3.2) and a client that saw one message could not tell
+    "you sent no credential" from "the one you sent was rejected"."""
+
+    class _Declines:
+        def resolve(self, context):
+            return None
+
+    gateway = _gateway_with(store, upstream, None)
+    monkeypatch.setattr(gateway, "_identity", _Declines())
+    body = _call()
+
+    response = gateway.handle(json.dumps(body).encode(), _lowered(_headers(body)))
+
+    assert json.loads(response.body)["error"]["code"] == -41007
+    assert json.loads(response.body)["error"]["message"] == "no principal could be derived"
+
+
+@pytest.mark.authority
+def test_T91b_the_pre_check_must_not_answer_for_an_action_the_grant_forbids(upstream, store):
+    """§8.3, and the half that `Policy.evaluate` gets **observably** wrong.
+
+    With the policy axis alone, an action the grant forbids still reaches
+    `_before_asking_a_human` — which refuses on the effect record before authority is ever
+    consulted. The client then gets `-41004 duplicate_effect`: the wrong reason, and a
+    disclosure that this effect exists to a principal holding no grant over it. The combined
+    decision means the pre-check is never entered, so the answer is `-41012`.
+
+    Without this test, reverting to `Policy.evaluate` changes nothing any assertion can see:
+    the earlier version reached the same `-41012` by a longer route.
+    """
+    from ctrlrun import Authority
+
+    grant = """
+schema: ctrlrun.policy/v3
+authority:
+  grants:
+    - id: small-refunds-only
+      subject: { agent: "refund-agent" }
+      actions: ["mcp.acme.create_refund"]
+      constraints: { amount_lte: 20000 }
+"""
+    gateway = _gateway_with(store, upstream, Authority.from_yaml(grant, standalone=True))
+    # The key this call would use is already committed by somebody else.
+    store.reserve_effect("refund:pi_8", "act_earlier", timedelta(minutes=5))
+    store.begin_execution("refund:pi_8", "act_earlier")
+    store.commit_effect("refund:pi_8", "act_earlier", None)
+    # Policy says `approve` for this amount; the grant forbids it outright.
+    body = _call(arguments={"amount": 500000, "payment_id": "pi_8"})
+
+    response = gateway.handle(
+        json.dumps(body).encode(), _lowered(_headers(body, **{"X-Agent": "refund-agent"}))
+    )
+
+    error = json.loads(response.body)["error"]
+    assert error["code"] == -41012, "the effect pre-check answered before authority did"
+    assert error["data"]["reason"] == "authority_constraint"
+    assert upstream.calls == []

--- a/tests/test_jwt_identity.py
+++ b/tests/test_jwt_identity.py
@@ -1,0 +1,1053 @@
+"""`JWTIdentityProvider`. Build-list item 5; SPEC-v0.3 §3.4.
+
+The acceptance tests are T88, T88b, T89, T90 and T92. Keys are generated in the test and
+nothing reaches the network: the JWKS is served from a fixture that counts its fetches, and
+the static-key cases assert no outbound connection is attempted.
+
+Three sentences run through all of them:
+
+**Identity is consumed, never invented.** The provider verifies a token somebody else issued
+and maps the verified claims onto a `Principal`. It mints nothing, and the two limits it
+cannot work around — an exact `issuer` and no revocation channel — are stated rather than
+configured around.
+
+**Configuration is refused before any token is seen** (T88b). Key confusion has a
+configuration end and a token end; the token end is already covered by the `algorithms`
+allow-list, so a test that only exercised it would prove nothing the library was not already
+doing. T88b is the configuration end.
+
+**Every refusal is asserted by cause** (T89). Twelve ways a token can be wrong all raise
+`IdentityError` with a message that tells a client nothing, so a test asserting only the type
+cannot tell twelve guards apart. Each case here asserts a distinguishing observable: the log
+the provider wrote, and a fetch or upstream count of zero.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from ctrlrun import IdentityContext, IdentityError, InvalidArgument, Principal
+from ctrlrun.jwt_identity import JWTIdentityProvider
+
+ISSUER = "https://issuer.example"
+AUDIENCE = "https://ctrlrun.example"
+TOKEN_TYPE = "at+jwt"
+KID = "key-1"
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = datetime(2026, 9, 3, 10, 12, 1, tzinfo=UTC)
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, delta: timedelta) -> None:
+        self.now += delta
+
+
+@pytest.fixture
+def clock():
+    return _Clock()
+
+
+@pytest.fixture(scope="module")
+def keypair():
+    """One RSA key for the module: generating one per test is seconds of pure waiting."""
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = private.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public = (
+        private.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    return pem, public
+
+
+@pytest.fixture(scope="module")
+def other_keypair():
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = private.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    return pem
+
+
+def _sign(private_pem, clock, *, typ=TOKEN_TYPE, kid=None, algorithm="RS256", **overrides):
+    claims = {
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "sub": "finance-agent",
+        "email": "alice@example.com",
+        "exp": int((clock.now + timedelta(minutes=10)).timestamp()),
+        "iat": int(clock.now.timestamp()),
+    }
+    claims.update(overrides)
+    claims = {key: value for key, value in claims.items() if value is not _ABSENT}
+    # PyJWT drops a header whose value is None, so `typ=None` really produces a token with no
+    # `typ` at all rather than the library's default of "JWT". `kid` is not the same: PyJWT
+    # validates it as a string before the drop, so it is only added when there is one.
+    headers = {"typ": typ}
+    if kid is not None:
+        headers["kid"] = kid
+    return jwt.encode(claims, private_pem, algorithm=algorithm, headers=headers)
+
+
+class _Absent:
+    def __repr__(self) -> str:
+        return "<absent>"
+
+
+#: A sentinel for "this claim is not in the token at all", which `None` cannot express.
+_ABSENT = _Absent()
+
+
+def _provider(public_pem, clock, **overrides):
+    options = {
+        "public_key": public_pem,
+        "algorithms": ["RS256"],
+        "issuer": ISSUER,
+        "audience": AUDIENCE,
+        "token_type": TOKEN_TYPE,
+        "user_claim": "email",
+        "claim_names": ["email"],
+        "clock": clock,
+    }
+    options.update(overrides)
+    return JWTIdentityProvider(**options)
+
+
+def _context(token=None, headers=None):
+    return IdentityContext(
+        action="stripe.refund",
+        environment="production",
+        headers=headers if headers is not None else ({"authorization": f"Bearer {token}"}),
+    )
+
+
+# --- T88: a valid token becomes a Principal (§3.4) -------------------------------------
+
+
+def test_T88_a_valid_token_becomes_a_principal(keypair, clock):
+    private, public = keypair
+    provider = _provider(public, clock)
+
+    principal = provider.resolve(_context(_sign(private, clock)))
+
+    assert isinstance(principal, Principal)
+    assert principal.agent == "finance-agent"
+    assert principal.user == "alice@example.com"
+    assert principal.issuer == ISSUER
+    assert principal.expires_at == clock.now + timedelta(minutes=10)
+
+
+def test_T88_only_the_named_claims_reach_the_principal(keypair, clock):
+    """§3.4 — an allow-list, not everything: a token carries fields nobody meant to publish
+    into a receipt. Asserted by the mapping's key set, not by spot-checking one absence."""
+    private, public = keypair
+    provider = _provider(public, clock, claim_names=["email"])
+
+    token = _sign(private, clock, scope="refunds:write", tenant="acme", secret_note="do not log")
+    principal = provider.resolve(_context(token))
+
+    assert set(principal.claims) == {"email"}
+
+
+def test_T88_a_claim_whose_value_is_not_scalar_is_dropped(keypair, clock, caplog):
+    private, public = keypair
+    provider = _provider(public, clock, claim_names=["email", "roles", "level", "active"])
+
+    token = _sign(private, clock, roles=["a", "b"], level=3, active=True)
+    with caplog.at_level(logging.DEBUG, logger="ctrlrun"):
+        principal = provider.resolve(_context(token))
+
+    assert set(principal.claims) == {"email", "level", "active"}
+    assert principal.claims["level"] == 3
+    assert principal.claims["active"] is True
+
+
+def test_T88_a_claim_name_is_a_flat_key_and_no_nesting_is_traversed(keypair, clock):
+    """§3.4 — a claim called `a.b` is the key `"a.b"`. Without this, a provider that split on
+    dots would read a nested value the issuer never meant to expose under that name."""
+    private, public = keypair
+    provider = _provider(public, clock, claim_names=["a.b"], agent_claim="a.b")
+
+    flat = provider.resolve(_context(_sign(private, clock, **{"a.b": "flat-agent"})))
+
+    assert flat.agent == "flat-agent"
+    with pytest.raises(IdentityError):
+        provider.resolve(_context(_sign(private, clock, a={"b": "nested-agent"})))
+
+
+@pytest.mark.parametrize(
+    "aud",
+    [
+        AUDIENCE,
+        [AUDIENCE],
+        ["https://other.example", AUDIENCE, "https://third.example"],
+    ],
+    ids=["string", "one-element-array", "array-among-others"],
+)
+def test_T88_aud_is_accepted_on_either_wire_shape(keypair, clock, aud):
+    """RFC 7519 §4.1.3 permits both, and real issuers emit both."""
+    private, public = keypair
+
+    principal = _provider(public, clock).resolve(_context(_sign(private, clock, aud=aud)))
+
+    assert principal.agent == "finance-agent"
+
+
+def test_T88_an_absent_header_is_a_decline_not_a_refusal(keypair, clock):
+    """§3.2 — a decline leaves the v0.1 `context()` path intact; in-process there are no
+    headers at all, and a provider with nothing to say must not break existing code."""
+    _, public = keypair
+
+    assert _provider(public, clock).resolve(_context(headers={})) is None
+
+
+@pytest.mark.parametrize("raw", ["Bearer", "Bearer ", "eyJhbGciOi.x.y", "Basic abc", "bearer"])
+def test_T88_a_header_with_no_bearer_scheme_is_refused_not_guessed(keypair, clock, caplog, raw):
+    """A bare token is as likely to be an API key pasted into the wrong variable, and reading
+    it as a JWT would report the wrong failure.
+
+    Asserted on **which** refusal, not merely that one happened: strip the scheme check and
+    every one of these still raises — an API key is not a readable JWT header either — so a
+    test asserting only `IdentityError` would be a negative test against behaviour the library
+    refuses anyway.
+    """
+    _, public = keypair
+    provider = _provider(public, clock)
+
+    with caplog.at_level(logging.WARNING, logger="ctrlrun"), pytest.raises(IdentityError):
+        provider.resolve(_context(headers={"authorization": raw}))
+
+    assert "carries no 'Bearer <token>'" in caplog.text, caplog.text
+
+
+@pytest.mark.parametrize("raw", ["", "   "])
+def test_T88_a_blank_header_names_nobody_and_is_a_decline(keypair, clock, raw):
+    """§3.1 — a header set to an empty or whitespace value names nobody, and treating it as a
+    principal would be inventing one. `IdentityContext.header` counts it as absent."""
+    _, public = keypair
+
+    assert _provider(public, clock).resolve(_context(headers={"authorization": raw})) is None
+
+
+def test_T88_the_bearer_scheme_is_matched_case_insensitively(keypair, clock):
+    """The control for the test above: `Bearer` is a scheme name, and RFC 9110 §11.1 makes
+    scheme names case-insensitive. Without this the refusal could be "any casing but one"."""
+    private, public = keypair
+    provider = _provider(public, clock)
+
+    for spelling in ("Bearer", "bearer", "BEARER", "BeArEr"):
+        token = _sign(private, clock)
+        context = _context(headers={"authorization": f"{spelling} {token}"})
+        assert provider.resolve(context) is not None, spelling
+
+
+def test_T88_the_static_key_path_opens_no_socket(keypair, clock, monkeypatch):
+    """§3.4 — a `public_key` deployment reaches nothing. A claim about the environment is a
+    claim until something takes the network away."""
+    import socket
+
+    private, public = keypair
+    for name in ("socket", "create_connection", "getaddrinfo"):
+        monkeypatch.setattr(
+            socket, name, lambda *a, **k: pytest.fail("the provider opened a socket")
+        )
+
+    assert _provider(public, clock).resolve(_context(_sign(private, clock))) is not None
+
+
+def test_T88_public_key_accepts_a_path_as_well_as_pem(keypair, clock, tmp_path):
+    """§3.4 — stated because the gateway flag is `--identity-jwt-public-key PATH` and the
+    constructor takes both."""
+    private, public = keypair
+    pem_file = tmp_path / "key.pem"
+    pem_file.write_text(public)
+
+    provider = _provider(str(pem_file), clock)
+
+    assert provider.resolve(_context(_sign(private, clock))).agent == "finance-agent"
+
+
+# --- T88b: configuration is refused before any token is seen (§3.4) --------------------
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        ({"public_key": None}, "exactly one"),
+        ({"secret": "s"}, "exactly one"),
+        ({"jwks_url": "https://issuer.example/jwks"}, "exactly one"),
+        ({"public_key": None, "secret": "s", "jwks_url": "https://x/jwks"}, "exactly one"),
+        ({"algorithms": ["HS256"]}, "key confusion"),
+        (
+            {
+                "public_key": None,
+                "jwks_url": "https://issuer.example/jwks",
+                "algorithms": ["HS256"],
+            },
+            "key confusion",
+        ),
+        ({"public_key": None, "secret": "s", "algorithms": ["RS256"]}, "asymmetric"),
+        ({"algorithms": []}, "may not be empty"),
+        ({"algorithms": ["none"]}, "not an algorithm"),
+        ({"algorithms": ["NONE"]}, "not an algorithm"),
+        ({"algorithms": ["RS256", "None"]}, "not an algorithm"),
+        ({"issuer": ""}, "issuer"),
+        ({"audience": ""}, "audience"),
+    ],
+    ids=[
+        "no-key-source",
+        "two-key-sources-pem-and-secret",
+        "two-key-sources-pem-and-jwks",
+        "three-key-sources",
+        "HS256-with-public-key",
+        "HS256-with-jwks",
+        "RS256-with-secret",
+        "empty-algorithms",
+        "algorithms-none",
+        "algorithms-NONE",
+        "algorithms-None-among-others",
+        "empty-issuer",
+        "empty-audience",
+    ],
+)
+def test_T88b_configuration_is_refused_before_any_token_is_seen(
+    keypair, clock, overrides, expected
+):
+    _, public = keypair
+
+    with pytest.raises(InvalidArgument) as refused:
+        _provider(public, clock, **overrides)
+
+    assert expected in str(refused.value)
+
+
+def test_T88b_token_type_has_no_default_and_must_be_passed(keypair, clock):
+    """§3.4 — a required argument is how the operator is made to choose. A default would make
+    the cross-JWT confusion defence of RFC 8725 §3.11 something they never saw."""
+    _, public = keypair
+
+    with pytest.raises(TypeError, match="token_type"):
+        JWTIdentityProvider(
+            public_key=public,
+            algorithms=["RS256"],
+            issuer=ISSUER,
+            audience=AUDIENCE,
+            clock=clock,
+        )
+
+
+def test_T88b_token_type_none_is_permitted_and_warns_about_what_it_gives_up(keypair, clock, caplog):
+    _, public = keypair
+
+    with caplog.at_level(logging.WARNING, logger="ctrlrun"):
+        _provider(public, clock, token_type=None)
+
+    assert "ID token" in caplog.text
+    assert "RFC 8725" in caplog.text
+
+
+# --- T89: every invalid token is refused, by cause (§3.4) ------------------------------
+
+
+@pytest.fixture(scope="module")
+def refusals(keypair, other_keypair):
+    """T89's whole token table, built once.
+
+    Module-scoped because every entry is an RS256 signature and PyJWT re-parses the PEM for
+    each one: built per test, the table cost 1.3 seconds a case and 24 seconds a run, which is
+    how a suite stops being run before a push. The clock is static and starts at the same
+    instant every time, so one table is byte-identical to nineteen.
+    """
+    return _refusal_cases(keypair[0], other_keypair, _Clock())
+
+
+def _refusal_cases(private, other_private, clock):
+    """One entry per way a token can be wrong, with the log fragment that tells it apart."""
+    future = clock.now + timedelta(hours=1)
+    return {
+        "expired": (
+            _sign(private, clock, exp=int((clock.now - timedelta(hours=1)).timestamp())),
+            "ExpiredSignature",
+        ),
+        "nbf-in-the-future": (
+            _sign(private, clock, nbf=int(future.timestamp())),
+            "ImmatureSignature",
+        ),
+        "wrong-aud": (_sign(private, clock, aud="https://other.example"), "aud"),
+        "aud-substring-not-element": (
+            _sign(private, clock, aud="https://ctrlrun.example.attacker.test"),
+            "aud",
+        ),
+        "aud-contains-the-audience-as-a-substring": (
+            _sign(private, clock, aud=["prefix-https://ctrlrun.example-suffix"]),
+            "aud",
+        ),
+        "wrong-iss": (_sign(private, clock, iss="https://other.example"), "Issuer"),
+        "bad-signature": (_sign(other_private, clock), "Signature verification failed"),
+        "alg-none": (
+            jwt.encode(
+                {
+                    "iss": ISSUER,
+                    "aud": AUDIENCE,
+                    "sub": "finance-agent",
+                    "exp": int((clock.now + timedelta(minutes=10)).timestamp()),
+                },
+                key="",
+                algorithm="none",
+                headers={"typ": TOKEN_TYPE},
+            ),
+            "alg 'none' is not in the configured list",
+        ),
+        "alg-outside-the-list": (
+            _sign(private, clock, algorithm="RS512"),
+            "alg 'RS512' is not in the configured list",
+        ),
+        "wrong-typ": (_sign(private, clock, typ="JWT"), "typ 'JWT' is not"),
+        "no-typ-at-all": (_sign(private, clock, typ=None), "typ None is not"),
+        "exp-that-is-not-a-number": (
+            _sign(private, clock, exp="soon"),
+            "exp is 'soon', not a number",
+        ),
+        "nbf-that-is-not-a-number": (
+            _sign(private, clock, nbf="later"),
+            "nbf is 'later', not a number",
+        ),
+        # The cross-JWT confusion case of RFC 8725 §2: an OIDC ID token from the same issuer,
+        # signed with the same key, whose `aud` is the configured audience. It passes `iss`,
+        # `aud`, `exp` and the signature; `typ` is the only thing that tells it apart.
+        "an-oidc-id-token-from-the-same-issuer-and-key": (
+            _sign(private, clock, typ="JWT", nonce="n-0S6_WzA2Mj", auth_time=1),
+            "typ 'JWT' is not",
+        ),
+        "no-exp": (_sign(private, clock, exp=_ABSENT), "MissingRequiredClaim"),
+        "missing-agent-claim": (_sign(private, clock, sub=_ABSENT), "claim 'sub' is missing"),
+        "empty-agent-claim": (_sign(private, clock, sub="   "), "claim 'sub' is missing"),
+        # PyJWT's own `sub` check catches a non-string subject before the mapping does. The
+        # provider's check still stands for every other `agent_claim` — the case below.
+        "non-string-sub": (_sign(private, clock, sub=42), "InvalidSubject"),
+        "non-string-agent-claim": (
+            _sign(private, clock, actor=42, sub="finance-agent"),
+            "claim 'actor' is missing",
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "expired",
+        "nbf-in-the-future",
+        "wrong-aud",
+        "aud-substring-not-element",
+        "aud-contains-the-audience-as-a-substring",
+        "wrong-iss",
+        "bad-signature",
+        "alg-none",
+        "alg-outside-the-list",
+        "wrong-typ",
+        "no-typ-at-all",
+        "exp-that-is-not-a-number",
+        "nbf-that-is-not-a-number",
+        "an-oidc-id-token-from-the-same-issuer-and-key",
+        "no-exp",
+        "missing-agent-claim",
+        "empty-agent-claim",
+        "non-string-sub",
+        "non-string-agent-claim",
+    ],
+)
+def test_T89_every_invalid_token_is_refused_by_cause(keypair, refusals, clock, caplog, case):
+    _, public = keypair
+    token, fragment = refusals[case]
+    # The one case that needs a differently-configured provider: `agent_claim` is `sub` by
+    # default, and PyJWT checks `sub`'s own type before the mapping is reached.
+    provider = _provider(
+        public, clock, agent_claim="actor" if case == "non-string-agent-claim" else "sub"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="ctrlrun"), pytest.raises(IdentityError):
+        provider.resolve(_context(token))
+
+    assert fragment in caplog.text, caplog.text
+
+
+def test_T89_the_message_a_client_sees_says_nothing_about_why(keypair, clock):
+    """§8.2 — a caller whose credential was rejected learns that, and learns nothing about
+    why, which is the correct amount to tell an unauthenticated caller."""
+    private, public = keypair
+    token = _sign(private, clock, aud="https://other.example")
+
+    with pytest.raises(IdentityError) as refused:
+        _provider(public, clock).resolve(_context(token))
+
+    assert str(refused.value) == "the credential was rejected"
+
+
+def test_T89_the_oidc_id_token_passes_every_check_but_typ(keypair, clock):
+    """The control for the cross-JWT case: without it, the ID token might be refused for some
+    other reason and `typ` would be a guard nothing exercises."""
+    private, public = keypair
+    id_token = _sign(private, clock, typ="JWT", nonce="n-0S6_WzA2Mj")
+    permissive = _provider(public, clock, token_type=None)
+
+    assert permissive.resolve(_context(id_token)).agent == "finance-agent"
+
+
+def test_T89_typ_is_matched_case_insensitively_with_the_media_prefix_stripped(keypair, clock):
+    """RFC 7519 §5.1 — `application/at+jwt` and `AT+JWT` are the same type."""
+    private, public = keypair
+    provider = _provider(public, clock)
+
+    for spelling in ("at+jwt", "AT+JWT", "application/at+jwt", "Application/At+JWT"):
+        assert provider.resolve(_context(_sign(private, clock, typ=spelling))) is not None
+
+
+def test_T89_leeway_bounds_clock_skew_and_nothing_more(keypair, clock):
+    private, public = keypair
+    provider = _provider(public, clock, leeway=timedelta(seconds=60))
+    token = _sign(private, clock, exp=int((clock.now + timedelta(seconds=10)).timestamp()))
+
+    clock.advance(timedelta(seconds=40))
+    assert provider.resolve(_context(token)) is not None
+
+    clock.advance(timedelta(seconds=60))
+    with pytest.raises(IdentityError):
+        provider.resolve(_context(token))
+
+
+# --- T90: JWKS handling (§3.4) ---------------------------------------------------------
+
+
+def _public_pem(private_pem):
+    """The public half of a PEM private key, as PEM."""
+    from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+    return (
+        load_pem_private_key(private_pem.encode(), password=None)
+        .public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+
+
+def _jwk(public_pem, kid, **overrides):
+    """One JWK for a PEM public key, so a test can describe a key set by what it says."""
+    from cryptography.hazmat.primitives.serialization import load_pem_public_key
+
+    entry = json.loads(jwt.algorithms.RSAAlgorithm.to_jwk(load_pem_public_key(public_pem.encode())))
+    entry["kid"] = kid
+    entry.update(overrides)
+    return entry
+
+
+class _Jwks:
+    """A JWK Set endpoint that counts its fetches and never touches the network.
+
+    A double for `urllib.request.build_opener().open`, so the provider's own scheme check,
+    timeout and JSON parsing all still run. It refuses nothing the real endpoint would not:
+    it serves a document or raises, which is the whole of what a fetch can do.
+    """
+
+    def __init__(self, document) -> None:
+        self.document = document
+        self.fetches = 0
+        self.raises: Exception | None = None
+
+    def install(self, monkeypatch) -> None:
+        import urllib.request
+
+        class _Response:
+            def __init__(self, payload) -> None:
+                self._payload = payload
+
+            def read(self):
+                return self._payload
+
+            def geturl(self):
+                # The double answers from the URL it was asked for, which is what a fetch that
+                # followed nothing does. The redirect guard has its own test, on real sockets.
+                return JWKS_URL
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        def opener(*handlers):
+            served = self
+
+            class _Opener:
+                def open(self, request, timeout=None):
+                    served.fetches += 1
+                    if served.raises is not None:
+                        raise served.raises
+                    return _Response(json.dumps(served.document).encode())
+
+            return _Opener()
+
+        monkeypatch.setattr(urllib.request, "build_opener", opener)
+
+
+JWKS_URL = "https://issuer.example/.well-known/jwks.json"
+
+
+def _jwks_provider(clock, **overrides):
+    options = {
+        "jwks_url": JWKS_URL,
+        "algorithms": ["RS256"],
+        "issuer": ISSUER,
+        "audience": AUDIENCE,
+        "token_type": TOKEN_TYPE,
+        "clock": clock,
+    }
+    options.update(overrides)
+    return JWTIdentityProvider(**options)
+
+
+def test_T90_an_unknown_kid_triggers_exactly_one_refresh_then_refuses(keypair, clock, monkeypatch):
+    """§3.4 — at most one refresh, then a refusal; and inside the rate-limit window, no fetch
+    at all, so a stream of unknown kids cannot make this process a load generator."""
+    private, public = keypair
+    jwks = _Jwks({"keys": [_jwk(public, KID)]})
+    jwks.install(monkeypatch)
+    provider = _jwks_provider(clock, jwks_min_refresh_interval=timedelta(seconds=30))
+
+    # An unknown kid against a cold cache: exactly one refresh, still unknown, refused.
+    with pytest.raises(IdentityError):
+        provider.resolve(_context(_sign(private, clock, kid="rotated")))
+    assert jwks.fetches == 1
+
+    # More of the same inside the window: no fetch at all, and still refused. The loop is
+    # bounded so a broken rate limit fails red rather than hanging CI.
+    for _ in range(5):
+        clock.advance(timedelta(seconds=5))
+        with pytest.raises(IdentityError):
+            provider.resolve(_context(_sign(private, clock, kid="rotated")))
+    assert jwks.fetches == 1
+
+    # Past the window: exactly one more.
+    clock.advance(timedelta(seconds=6))
+    with pytest.raises(IdentityError):
+        provider.resolve(_context(_sign(private, clock, kid="rotated")))
+    assert jwks.fetches == 2
+
+    # And the kid that *is* published verifies off the cache the refresh populated, with no
+    # further fetch — without this the counts above could be satisfied by never caching.
+    assert provider.resolve(_context(_sign(private, clock, kid=KID))) is not None
+    assert jwks.fetches == 2
+
+
+def test_T90_a_rotated_key_is_picked_up_by_the_one_refresh(keypair, clock, monkeypatch):
+    """The control: without it, a provider that never populated its cache would satisfy every
+    "still refused" assertion above."""
+    private, public = keypair
+    jwks = _Jwks({"keys": []})
+    jwks.install(monkeypatch)
+    provider = _jwks_provider(clock)
+
+    with pytest.raises(IdentityError):
+        provider.resolve(_context(_sign(private, clock, kid=KID)))
+    jwks.document = {"keys": [_jwk(public, KID)]}
+    clock.advance(timedelta(seconds=31))
+
+    assert provider.resolve(_context(_sign(private, clock, kid=KID))) is not None
+    assert jwks.fetches == 2
+
+
+@pytest.mark.parametrize("signing_key_first", [True, False], ids=["good-first", "good-second"])
+def test_T90_two_keys_sharing_a_kid_refuse_the_token(
+    keypair, other_keypair, clock, monkeypatch, signing_key_first
+):
+    """RFC 7517 §4.5 makes distinct `kid`s a SHOULD, so a duplicate is legal — and "take the
+    first match" would be a silent trust decision about which key signs for this issuer.
+
+    **Both orders**, and that is the whole test. With the duplicate guard removed one of the
+    two entries wins, and in exactly one of these orders it is the key that *does* verify the
+    token — so a single-order test proves nothing: the token fails its signature check either
+    way and the refusal looks identical.
+    """
+    private, public = keypair
+    entries = [_jwk(public, KID), _jwk(_public_pem(other_keypair), KID)]
+    jwks = _Jwks({"keys": entries if signing_key_first else list(reversed(entries))})
+    jwks.install(monkeypatch)
+    provider = _jwks_provider(clock)
+
+    with pytest.raises(IdentityError):
+        provider.resolve(_context(_sign(private, clock, kid=KID)))
+
+
+def test_T90_the_same_two_keys_under_distinct_kids_both_work(
+    keypair, other_keypair, clock, monkeypatch
+):
+    """The control: the keys themselves are fine and the set parses. It is the shared `kid`
+    that refuses it, not anything else about the document."""
+    private, public = keypair
+    jwks = _Jwks({"keys": [_jwk(public, KID), _jwk(_public_pem(other_keypair), "key-2")]})
+    jwks.install(monkeypatch)
+
+    assert _jwks_provider(clock).resolve(_context(_sign(private, clock, kid=KID))) is not None
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [{"use": "enc"}, {"key_ops": ["encrypt"]}, {"key_ops": []}],
+    ids=["use-enc", "key_ops-without-verify", "key_ops-empty"],
+)
+def test_T90_a_key_that_is_not_for_signatures_is_ignored(keypair, clock, monkeypatch, overrides):
+    """RFC 7517 §4.2, §4.3 — a JWK Set commonly carries encryption keys, and verifying a
+    signature against one is a defect."""
+    private, public = keypair
+    jwks = _Jwks({"keys": [_jwk(public, KID, **overrides)]})
+    jwks.install(monkeypatch)
+
+    with pytest.raises(IdentityError):
+        _jwks_provider(clock).resolve(_context(_sign(private, clock, kid=KID)))
+
+
+def test_T90_the_same_key_marked_sig_is_accepted(keypair, clock, monkeypatch):
+    """The control for the three cases above: the key itself is fine, and it is the `use` and
+    `key_ops` fields that refuse it."""
+    private, public = keypair
+    jwks = _Jwks({"keys": [_jwk(public, KID, use="sig", key_ops=["verify"])]})
+    jwks.install(monkeypatch)
+
+    assert _jwks_provider(clock).resolve(_context(_sign(private, clock, kid=KID))) is not None
+
+
+def test_T90_a_key_whose_own_alg_excludes_the_token_is_refused(keypair, clock, monkeypatch):
+    """§3.4 — the configured allow-list *and* the key's `alg` must both admit the token."""
+    private, public = keypair
+    jwks = _Jwks({"keys": [_jwk(public, KID, alg="RS512")]})
+    jwks.install(monkeypatch)
+    provider = _jwks_provider(clock, algorithms=["RS256", "RS512"])
+
+    with pytest.raises(IdentityError):
+        provider.resolve(_context(_sign(private, clock, kid=KID, algorithm="RS256")))
+
+    assert provider.resolve(_context(_sign(private, clock, kid=KID, algorithm="RS512"))) is not None
+
+
+def test_T90_a_failed_fetch_is_a_refusal_and_keeps_the_cached_keys(keypair, clock, monkeypatch):
+    """§3.4 — never a fallback to an empty key set, and never a cached-forever key either:
+    the cache is replaced only when a whole, well-formed document arrived."""
+    private, public = keypair
+    jwks = _Jwks({"keys": [_jwk(public, KID)]})
+    jwks.install(monkeypatch)
+    provider = _jwks_provider(clock)
+    assert provider.resolve(_context(_sign(private, clock, kid=KID))) is not None
+
+    jwks.raises = OSError("connection refused")
+    clock.advance(timedelta(seconds=31))
+    with pytest.raises(IdentityError):
+        provider.resolve(_context(_sign(private, clock, kid="rotated")))
+
+    # The known kid still verifies: the failed fetch discarded nothing.
+    assert provider.resolve(_context(_sign(private, clock, kid=KID))) is not None
+
+
+@pytest.mark.parametrize(
+    "document",
+    [{}, {"keys": "not a list"}, [], "not an object"],
+    ids=["no-keys", "keys-not-a-list", "list", "string"],
+)
+def test_T90_a_malformed_jwk_set_is_a_refusal(keypair, clock, monkeypatch, document):
+    private, _ = keypair
+    jwks = _Jwks(document)
+    jwks.install(monkeypatch)
+
+    with pytest.raises(IdentityError):
+        _jwks_provider(clock).resolve(_context(_sign(private, clock, kid=KID)))
+
+
+def test_T90_a_token_with_no_kid_is_refused_on_a_jwks_deployment(keypair, clock, monkeypatch):
+    private, public = keypair
+    jwks = _Jwks({"keys": [_jwk(public, KID)]})
+    jwks.install(monkeypatch)
+
+    with pytest.raises(IdentityError):
+        _jwks_provider(clock).resolve(_context(_sign(private, clock)))
+    assert jwks.fetches == 0
+
+
+def test_T90_a_non_https_jwks_url_is_never_fetched(keypair, clock, monkeypatch):
+    private, public = keypair
+    jwks = _Jwks({"keys": [_jwk(public, KID)]})
+    jwks.install(monkeypatch)
+    provider = _jwks_provider(clock, jwks_url="http://issuer.example/jwks")
+
+    with pytest.raises(IdentityError):
+        provider.resolve(_context(_sign(private, clock, kid=KID)))
+    assert jwks.fetches == 0
+
+
+# --- T92: the extra says so when it is missing (§1.1, §3.4) ----------------------------
+
+
+def test_T92_importing_ctrlrun_pulls_in_no_jwt_module():
+    """T30's list grows by one. A subprocess, because in-process this would pass or fail on
+    whatever pytest happened to import first."""
+    import subprocess
+    import sys
+
+    finished = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import ctrlrun, sys;"
+            "print(sorted(n for n in sys.modules"
+            " if n.split('.')[0] in ('httpx', 'opentelemetry', 'jwt')"
+            " or n in ('ctrlrun.gateway', 'ctrlrun.otel', 'ctrlrun.acs', 'ctrlrun.jwt_identity')))",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert finished.stdout.strip() == "[]", finished.stdout
+
+
+def test_T92_constructing_without_the_extra_names_the_install_command():
+    """Never `ModuleNotFoundError`: an operator reads that as a broken package rather than as
+    an option they did not select (`v0.2 §1.1`)."""
+    import subprocess
+    import sys
+
+    script = (
+        "import sys, importlib.abc\n"
+        "class Block(importlib.abc.MetaPathFinder):\n"
+        "    def find_spec(self, name, path=None, target=None):\n"
+        "        if name.split('.')[0] == 'jwt':\n"
+        "            raise ImportError(name)\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, Block())\n"
+        "from ctrlrun import MissingDependency\n"
+        "from ctrlrun.jwt_identity import JWTIdentityProvider\n"
+        "try:\n"
+        "    JWTIdentityProvider(secret='s', algorithms=['HS256'], issuer='i',"
+        " audience='a', token_type='at+jwt')\n"
+        "except MissingDependency as exc:\n"
+        "    print(str(exc))\n"
+        "except BaseException as exc:\n"
+        "    print('WRONG:', type(exc).__name__, exc)\n"
+    )
+    finished = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=True
+    )
+
+    assert "pip install 'ctrlrun[identity]'" in finished.stdout, finished.stdout
+    assert "WRONG" not in finished.stdout
+
+
+def test_T92_the_module_itself_imports_without_the_extra():
+    """The check is at construction, not at import: `from ctrlrun.jwt_identity import ...` must
+    reach the class before it reaches the missing dependency, or the error is an ImportError
+    from halfway down an import chain rather than the one an operator can act on."""
+    import subprocess
+    import sys
+
+    finished = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys, importlib.abc\n"
+            "class Block(importlib.abc.MetaPathFinder):\n"
+            "    def find_spec(self, name, path=None, target=None):\n"
+            "        if name.split('.')[0] == 'jwt':\n"
+            "            raise ImportError(name)\n"
+            "        return None\n"
+            "sys.meta_path.insert(0, Block())\n"
+            "import ctrlrun.jwt_identity as m; print(m.JWTIdentityProvider.__name__)",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert finished.stdout.strip() == "JWTIdentityProvider"
+
+
+# --- The JWKS fetch follows nothing (SPEC-v0.3 §3.4) ------------------------------------
+
+
+@pytest.fixture
+def redirecting_issuer():
+    """A real HTTP server that 302s to a second real server, on a real socket.
+
+    Deliberately **not** the `_Jwks` double: that one replaces `urllib.request.build_opener`
+    wholesale, so the opener — which is where the redirect policy lives — is never built. A
+    guard nothing constructs is a guard nothing tests, and this one was wrong for exactly that
+    reason: `build_opener(HTTPSHandler(...))` keeps `HTTPRedirectHandler`, because the default
+    classes it drops are only those an argument is an instance or subclass of.
+    """
+    import threading
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    served: list[str] = []
+
+    class Attacker(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_GET(self):
+            served.append(self.path)
+            body = json.dumps({"keys": [{"kid": "ATTACKER-KEY"}]}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    attacker = ThreadingHTTPServer(("127.0.0.1", 0), Attacker)
+    threading.Thread(target=attacker.serve_forever, daemon=True).start()
+    stolen = f"http://127.0.0.1:{attacker.server_address[1]}/stolen"
+
+    class Issuer(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_GET(self):
+            served.append(self.path)
+            self.send_response(302)
+            self.send_header("Location", stolen)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, *args):
+            pass
+
+    issuer = ThreadingHTTPServer(("127.0.0.1", 0), Issuer)
+    threading.Thread(target=issuer.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{issuer.server_address[1]}/jwks", served
+    issuer.shutdown()
+    issuer.server_close()
+    attacker.shutdown()
+    attacker.server_close()
+
+
+def test_a_jwks_redirect_is_never_followed(keypair, clock, redirecting_issuer, monkeypatch):
+    """§3.4 — "the provider MUST NOT follow a redirect to a non-HTTPS URL".
+
+    An open redirect on the issuer's domain would otherwise make this process fetch its
+    signing keys, in cleartext, from wherever the redirect pointed — and cache them for the
+    life of the process, so every token the attacker then signs verifies with an arbitrary
+    `agent`. The scheme guard on the configured URL does not cover the URL actually fetched.
+
+    The `https://` requirement is lifted for the length of this test, because the guard under
+    test is the *redirect* one and the scheme guard would otherwise refuse before the socket
+    is opened — which is mutation pattern 3, a negative test against a refusal that would have
+    happened anyway.
+    """
+    private, _ = keypair
+    url, served = redirecting_issuer
+    # Only the scheme guard is lifted; `_fetch` itself — the opener, the redirect policy, the
+    # final-URL check and the exception mapping — is the real code.
+    monkeypatch.setattr("ctrlrun.jwt_identity.JWTIdentityProvider._checked_url", lambda self: url)
+    provider = _jwks_provider(clock, jwks_url=url)
+
+    with pytest.raises(IdentityError):
+        provider.resolve(_context(_sign(private, clock, kid=KID)))
+
+    assert served == ["/jwks"], f"the redirect was followed to {served}"
+
+
+def test_the_plaintext_server_would_otherwise_be_read(
+    keypair, clock, redirecting_issuer, monkeypatch
+):
+    """The control that makes the test above mean something.
+
+    Point the provider straight at a plaintext server and the document **is** fetched. So the
+    refusal above is the redirect policy doing its job, and not an environment in which a
+    plaintext fetch could never have succeeded anyway — which is mutation pattern 3, and
+    exactly how the old version of this guard shipped untested.
+    """
+    url, served = redirecting_issuer
+    direct = url.replace("/jwks", "/direct")
+    monkeypatch.setattr(
+        "ctrlrun.jwt_identity.JWTIdentityProvider._checked_url", lambda self: direct
+    )
+    provider = _jwks_provider(clock, jwks_url=direct)
+
+    with pytest.raises(IdentityError):  # the attacker's kid is not the token's; the fetch is
+        provider.resolve(_context(_sign(keypair[0], clock, kid=KID)))
+
+    assert "/direct" in served, f"the plaintext fetch never happened at all: {served}"
+
+
+def test_the_opener_the_provider_builds_has_no_redirect_handler(clock):
+    """The unit half, because the test above needs two sockets to say one thing.
+
+    `build_opener` drops a default class only when an argument is an instance or subclass of
+    it — so handing it an `HTTPSHandler` leaves `HTTPRedirectHandler` in place, which is the
+    defect this asserts against. Subclassing is what displaces it.
+    """
+    import urllib.request
+
+    handlers = {type(h).__name__ for h in _jwks_provider(clock)._opener().handlers}
+
+    assert "HTTPRedirectHandler" not in handlers
+    assert "_NoRedirects" in handlers
+    assert issubclass(
+        next(
+            h
+            for h in _jwks_provider(clock)._opener().handlers
+            if type(h).__name__ == "_NoRedirects"
+        ).__class__,
+        urllib.request.HTTPRedirectHandler,
+    )
+
+
+def test_a_duplicate_kid_is_refused_even_when_one_of_the_pair_cannot_be_read(
+    keypair, clock, monkeypatch
+):
+    """§3.4's reason for refusing a duplicate — "take the first match" is a silent trust
+    decision about which key signs — does not stop applying because one entry is malformed.
+
+    Recorded *before* the parse, so an unreadable duplicate cannot leave the readable one
+    looking unambiguous. Written after an independent review found the guard sitting behind
+    the parse, where a set claiming one `kid` twice quietly resolved to whichever half was
+    well-formed.
+    """
+    private, public = keypair
+    unreadable = {"kty": "RSA", "kid": KID, "n": "not-base64url", "e": "AQAB"}
+    jwks = _Jwks({"keys": [unreadable, _jwk(public, KID)]})
+    jwks.install(monkeypatch)
+
+    with pytest.raises(IdentityError):
+        _jwks_provider(clock).resolve(_context(_sign(private, clock, kid=KID)))
+
+
+def test_an_unreadable_key_under_its_own_kid_is_skipped_not_fatal(keypair, clock, monkeypatch):
+    """The control for the test above: an unparseable entry on its *own* `kid` is skipped and
+    the rest of the set still works. Without this, "refuse the whole document on any bad
+    entry" would satisfy the duplicate test for the wrong reason."""
+    private, public = keypair
+    unreadable = {"kty": "RSA", "kid": "broken", "n": "not-base64url", "e": "AQAB"}
+    jwks = _Jwks({"keys": [unreadable, _jwk(public, KID)]})
+    jwks.install(monkeypatch)
+
+    assert _jwks_provider(clock).resolve(_context(_sign(private, clock, kid=KID))) is not None

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -42,10 +42,14 @@ def test_T30_a_subprocess_importing_ctrlrun_pulls_in_no_module_from_an_extra():
         [
             sys.executable,
             "-c",
+            # SPEC-v0.3 §1.1 — `jwt` joins the list with build-list item 5. T92 asserts the
+            # same thing from the identity tests' side; this is the one place that names
+            # every extra at once, so a fourth cannot be added without editing it.
             "import ctrlrun, sys;"
             "print(sorted(n for n in sys.modules"
-            " if n.split('.')[0] in ('httpx', 'opentelemetry')"
-            " or n in ('ctrlrun.gateway', 'ctrlrun.otel', 'ctrlrun.acs')))",
+            " if n.split('.')[0] in ('httpx', 'opentelemetry', 'jwt')"
+            " or n in ('ctrlrun.gateway', 'ctrlrun.otel', 'ctrlrun.acs',"
+            " 'ctrlrun.jwt_identity')))",
         ],
         capture_output=True,
         text=True,
@@ -60,6 +64,12 @@ def test_T30_a_subprocess_importing_ctrlrun_pulls_in_no_module_from_an_extra():
     [
         ("from ctrlrun.gateway import serve; serve(upstream='http://x', alias='a')", "gateway"),
         ("from ctrlrun.otel import OTelEventSink; OTelEventSink()", "otel"),
+        (
+            "from ctrlrun.jwt_identity import JWTIdentityProvider;"
+            "JWTIdentityProvider(secret='s', algorithms=['HS256'], issuer='i', audience='a',"
+            " token_type='at+jwt')",
+            "identity",
+        ),
     ],
 )
 def test_T30_a_missing_extra_says_which_one_to_install(factory, extra, tmp_path):
@@ -69,7 +79,7 @@ def test_T30_a_missing_extra_says_which_one_to_install(factory, extra, tmp_path)
         "import sys, importlib.abc\n"
         "class Block(importlib.abc.MetaPathFinder):\n"
         "    def find_spec(self, name, path=None, target=None):\n"
-        f"        if name.split('.')[0] in ('httpx', 'opentelemetry'):\n"
+        f"        if name.split('.')[0] in ('httpx', 'opentelemetry', 'jwt'):\n"
         "            raise ImportError(name)\n"
         "        return None\n"
         "sys.meta_path.insert(0, Block())\n"
@@ -87,6 +97,25 @@ def test_T30_a_missing_extra_says_which_one_to_install(factory, extra, tmp_path)
 
     assert f"pip install 'ctrlrun[{extra}]'" in finished.stdout, finished.stdout
     assert "WRONG" not in finished.stdout
+
+
+def test_the_identity_extra_declares_pyjwt_with_its_crypto_extra():
+    """§3.4 — without `[crypto]`, PyJWT can only do `HS*`, and every asymmetric algorithm
+    raises at verification time rather than at install time. An extra that installs cleanly
+    and then cannot verify an RS256 token is worse than one that names its dependency."""
+    declared = " ".join(_pyproject()["project"]["optional-dependencies"]["identity"])
+
+    assert "pyjwt" in declared.lower()
+    assert "crypto" in declared.lower()
+
+
+def test_the_core_dependencies_have_not_grown():
+    """§1.1 — `pip install ctrlrun` installs `pyyaml` and `click`, and v0.3 changes that by
+    exactly nothing: the whole authority model is stdlib plus the YAML parser already there."""
+    declared = _pyproject()["project"]["dependencies"]
+    names = {re.split(r"[<>=!~\[ ]", line.strip())[0].lower() for line in declared}
+
+    assert names == CORE_DEPENDENCIES
 
 
 def test_the_otel_extra_declares_the_api_sdk_and_exporter():


### PR DESCRIPTION
Build-list item 5. SPEC-v0.3 §3.4, §8. Tests T88, T88b, T89, T90, T91, T91b, T91c, T91d, T92.

## What it does

`JWTIdentityProvider` in `ctrlrun[identity]` (`pyjwt[crypto]`), imported by naming it. It reads a bearer token, verifies it against a JWKS or a static key, and maps the verified claims onto a `Principal`. **It issues nothing** — no OAuth flow, no refresh, no token exchange, no introspection.

At the gateway: `--principal` and `--principal-header` become constructors, `--identity-jwt` joins them, `--authority` loads grants from their own document, and a call outside the grant is `-41012 ctrlrun.unauthorized`. The ACS hook takes an `identity` of its own and stops reading `agent_id` off the envelope.

## The independent review found six defects, and they are why this took a second pass

CLAUDE.md requires an independent review for this item, in a session that did not write the code. It found:

### 1. CRITICAL — the JWKS fetch followed redirects

`urllib.request.build_opener(HTTPSHandler(...))` **keeps** its `HTTPRedirectHandler`: `build_opener` drops a default class only for an argument that is an instance or subclass of it, and `HTTPSHandler` is unrelated. A code comment in this PR asserted the opposite and was simply wrong.

An open redirect on the issuer's domain would have made CTRLRun fetch its signing keys, in cleartext over `http://`, from an attacker-chosen host — then cache them for the life of the process, so every token that attacker signed verified with an arbitrary `agent` and `user`. A complete bypass of the authority model, at the one input that decides who everybody is.

Fixed with an `HTTPRedirectHandler` subclass that refuses (subclassing is what actually displaces the default) plus a re-check of the URL that answered. **The old guard had no test because `_Jwks.install` replaced `build_opener` wholesale** — the opener, where the policy lives, was never constructed. The new test uses two real HTTP servers on real sockets and asserts the attacker's server was never reached, with a control proving a plaintext fetch *would* otherwise succeed.

### 2. HIGH — three refusals reached the client as a dropped connection

`do_POST` has no top-level exception boundary, so `socketserver` answers an escaping exception by closing the socket with **nothing written**. A client reads that as a transport failure — the one signal it retries on, and the thing this library exists to prevent.

| Path | Raised by | Now |
|---|---|---|
| `_continue` — authority revoked mid-elicitation | `Control.resume` → `_suspend` | `-41012` |
| `_continue` — credential expired mid-round-trip | same | `-41007` |
| `_through_control` — expired principal | `Control.execute` (`IdentityError`, deliberately not an `ActionDenied`) | `-41007` |
| `_intercept` — provider raises anything else | any custom `IdentityProvider` | `-41007`, per §3.2's wrapping rule |

The expired-principal path is **routine, not adversarial**: the JWT provider admits a token up to `leeway` (60 s) past its `exp` and then stamps `Principal.expires_at` with that exact `exp`, so every token presented in that window was affected.

### 3–6

- `--identity-jwt-leeway` and `--identity-jwt-jwks-min-refresh` were accepted without `--identity-jwt`. The test enumerated the implementation's own map, so it **structurally could not fail** for the flags the code forgot; it reads the list off the command now.
- The JWKS timeout silently borrowed `--upstream-timeout` (30 s vs §3.4's 5 s), coupling two unrelated knobs in the fail-slow direction on a fetch that runs before any decision. It has its own flag.
- A duplicate `kid` was recorded *after* the `PyJWK` parse, so a set claiming one `kid` twice quietly resolved to whichever half was well-formed.
- The ACS hook answered an expired credential `no_principal` while the receipt it had just written said `principal_expired`. Told apart structurally now — the two are raised on different sides of the `try` — never by matching on a message.

## Mutation table: 42 rows

Every row red except two recorded as **equivalent**:

- **M17** — the single-refresh bound. The mutant's loop breaks after one pass, which is what the code already does.
- **M25** — the ACS hook's combined decision. `Control.execute` evaluates authority *before* the approval gate (§4.3), so an action the grant forbids is refused before an approval is consumed whichever decision sent the hook looking. §8.3's change is right and is made; it is not observable at this hook. The gateway **is** the asymmetric case and **M24** isolates it: with the policy axis alone, an action the grant forbids reaches `_before_asking_a_human`, which answers `-41004 duplicate_effect` off the effect record before authority is consulted — the wrong reason, and a disclosure that the effect exists to a principal with no grant over it.

Two rows came back green on the first pass, and both were real test-quality gaps rather than passing checks:

- **M13** duplicate `kid` — the test could not tell "refused the set" from "took the other match", because the token fails its signature check either way. Now parametrized over **both orders**, so removing the guard makes one of them succeed.
- **M20** Bearer scheme — every case still raised, for a different reason (an API key is not a readable JWT header either). Now asserts *which* refusal, by log fragment.

## A process failure worth recording

I ran three mutation runners concurrently on one working tree. They patched and restored the same files, so early rows measured *another runner's* mutation, and two were killed mid-row leaving three guards disabled on disk. The review caught the tree in that state. Everything was restored and re-verified against a 38-anchor check; the runner now takes a lockfile and restores `src/` from git after every row, and the work is committed first so git can. This is CLAUDE.md's "commit WIP before mutation runs", learned the hard way.

## Also

`docs/ACS.md`'s mapping table is amended (§8.4): `agent_id` and `environment` are ignored with a provider, the branch is on the *provider* rather than on the authority section, and §3.1's repeated-header rule is stated as a real gap the hook does not import rather than an argued omission. T30's `sys.modules` assertion grows to `jwt`. T89's token table became a module fixture — 28s to 5s, because PyJWT re-parses the PEM for every signature.

## Verification

`ruff format --check`, `ruff check`, `mypy --strict src/` clean. **1845 tests pass.** No network in any test: keys are generated in-process, the JWKS is served from a local fixture or a loopback socket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)