### PR TITLE
item 6: demo scenario 5, examples, docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,34 @@ shipped, and the only thing in the tree today is the contract.
 
 ### Added
 
+- **A fifth demo scenario, `ctrlrun demo` — authority escalation** (build-list item 6,
+  SPEC-v0.3 §1.2). The first four ask whether an *action* is safe to run; this one asks
+  whether a *principal* is entitled to propose it. A human's €100,000 delegable grant narrows
+  to a finance agent's €25,000 and then to a support agent's €2,000, and the two ways out of
+  the chain fail at two different moments: asking for €50,000 is refused at **evaluation**
+  (`authority_constraint`), and minting €50,000 under a €25,000 parent is refused at
+  **creation** (`containment`, naming the dimension). Asserting one would hide the other. The
+  scenario ends with an amount the grant *does* permit, which the policy still stops to ask a
+  human about — the two axes, combining as the stricter of the pair, in one line.
+- **`examples/authority-escalation/`** — the same story as a standalone script, with the
+  `else: raise SystemExit(...)` guard on every refusal. A demonstration that quietly starts
+  succeeding is worse than none, because it keeps printing the line that says the guard worked.
+- **`examples/authority/`** — a payments delegation chain and a DevOps chain, as complete
+  documents to read rather than run, with a README that says in its first paragraph that every
+  principal in them is invented.
+- **`docs/authority.md`** — grants, delegation and the omission rule in plain language,
+  including the two things it is worth knowing before you need them: an `Authority` is built at
+  load time and is not hot-reloaded, and there is no way to list delegations, so cutting a
+  chain of unknown width means `delegable: false` on the root and a restart.
+- **`docs/THREAT_MODEL.md` gains v0.3's boundary.** In scope: delegation escalation, omission
+  as widening, expired and revoked authority, token forgery, cross-JWT confusion, and signing
+  keys fetched from somewhere else. Out of scope, and stated rather than implied: a compromised
+  identity provider, a `HeaderIdentityProvider` behind a proxy that does not overwrite, a
+  revoked token before its `exp`, a tenant-templated issuer, and authority across an
+  agent-to-agent hop.
+- **The nine sector templates stay on v0.1 and now say why.** They gain no `authority:`
+  section: a grant names a real principal in a real organization, and a template that shipped
+  plausible ones would invite an operator to adopt them.
 - **`JWTIdentityProvider`** (build-list item 5, SPEC-v0.3 §3.4), in `ctrlrun[identity]`
   (`pyjwt[crypto]`), imported by naming it. It reads a bearer token from a header, verifies it
   against a JWKS or a static key, and maps the verified claims onto a `Principal`. **It issues
@@ -259,6 +287,10 @@ shipped, and the only thing in the tree today is the contract.
   writer to `mode: observe`.** An enforce-mode 0.3 writer emits no `observed` receipt and is
   safe to mix. An external reader that keys on `result` must read `execution` too, or it
   counts every observed execution as if nothing ran.
+- **The demo's scenario 5 shares the store *and the sinks* of the other four.** A second
+  `Control` that quietly dropped the JSONL sink left the demo printing a receipt count from
+  the store that the file it points the reader at did not match — a false green, in a
+  transcript people paste into issues.
 - **`ctrlrun.receipt/v2` and `ctrlrun.inspection/v2`.** The receipt carries the whole principal
   and reserves `execution` and `would_have` as `null` until observe mode fills them, so the
   shape a reader parses settles once rather than changing twice under one version string. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ shipped, and the only thing in the tree today is the contract.
   identity provider, a `HeaderIdentityProvider` behind a proxy that does not overwrite, a
   revoked token before its `exp`, a tenant-templated issuer, and authority across an
   agent-to-agent hop.
+- **`MANIFEST.in` ships `examples/**/README.md`, and a test now keeps it honest.** The file
+  has claimed for two releases that a test named `test_the_sdist_carries_everything_the_tests_need`
+  keeps it in step, and there was no such test — so the first README it forgot was found by
+  the CI job that builds an sdist and runs its tests, one push after it could have been found
+  locally. That is v0.2's four `.gitignore`d policy files in a different costume: setuptools
+  resolves `MANIFEST.in` against the working tree, so a local run is green either way. The
+  test now checks every **git-tracked** file under `examples/` and `docs/` against the
+  manifest's include patterns, and it found `examples/acs/README.md` had been missing since
+  v0.2 as well.
 - **The nine sector templates stay on v0.1 and now say why.** They gain no `authority:`
   section: a grant names a real principal in a real organization, and a template that shipped
   plausible ones would invite an operator to adopt them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ shipped, and the only thing in the tree today is the contract.
   test now checks every **git-tracked** file under `examples/` and `docs/` against the
   manifest's include patterns, and it found `examples/acs/README.md` had been missing since
   v0.2 as well.
+- **Fixed a test whose fuse was the suite's own duration.** T27's parametrize list built two
+  timestamps at **collection** time, so the future-dated one was 400 seconds ahead of
+  collection and only `400 - <however long the suite had been running>` seconds ahead by the
+  time the test executed. Past the replay window's 300 seconds it landed *inside* the window
+  and the refusal under test stopped happening. It had been latent since v0.2 and fired the
+  first time an item made the suite slower. The timestamps are built when the test runs, and
+  the fix is verified against a `conftest` that stalls 120 seconds between collection and the
+  body — the condition that failed CI.
 - **The nine sector templates stay on v0.1 and now say why.** They gain no `authority:`
   section: a grant names a real principal in a real organization, and a template that shipped
   plausible ones would invite an operator to adopt them.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,6 +19,10 @@ recursive-include tests *.py
 # fails on a fresh checkout, which is the failure `prune internal` exists to avoid.
 recursive-include examples *.py
 recursive-include examples *.yaml
+# And the READMEs. `examples/authority/` is two documents to *read*, so its README is the
+# example rather than a note beside one — and a test asserts what it says, which is how the
+# sdist job caught this line missing rather than the release did.
+recursive-include examples *.md
 
 # Local-only: working notes, and anything an operator's run left behind. Nothing here is
 # picked up by default — these are belt and braces, so a stray file cannot ride along.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip install ctrlrun
 ctrlrun demo
 ```
 
-`ctrlrun demo` runs the four failure scenarios below in well under a second, with no external services.
+`ctrlrun demo` runs the five failure scenarios below in well under a second, with no external services.
 
 Protect your first action:
 
@@ -119,7 +119,7 @@ stay out of it unless you ask for them.
 
 ```console
 $ ctrlrun demo
-CTRLRun demo — four ways an agent action goes wrong, and what stops it.
+CTRLRun demo — five ways an agent action goes wrong, and what stops it.
 Policy: refunds up to €1,000 are autonomous, up to €10,000 need a human, above that are denied.
 
 1. Duplicate effect after a lost response
@@ -148,7 +148,18 @@ Policy: refunds up to €1,000 are autonomous, up to €10,000 need a human, abo
    same approval presented again                            →
    ✗ BLOCKED — single-use approval already consumed
 
-Receipts (7): .ctrlrun/demo/receipts.jsonl
+5. Authority escalation
+
+   human €100,000 delegable  →  finance agent €25,000  →  support agent €2,000
+   support agent's grant: dlg_5f8d41938a3f29972d5489d676cd9edb
+   support agent requests €50,000  →
+   ✗ BLOCKED — outside the delegated grant (authority_constraint)
+   remote refund calls: 0
+   finance agent tries to delegate €50,000 under its own €25,000  →  refused (containment: constraints)
+   support agent requests €1,500  →  authority permits it, and the policy asks a human (apr_f86eca24dd80206ab5189ccb1b62aa55)
+   two axes, and an action needs both: the stricter of the pair wins
+
+Receipts (8): .ctrlrun/demo/receipts.jsonl
 Events:       .ctrlrun/demo/events.jsonl
 
 Read them:    CTRLRUN_STATE=.ctrlrun/demo/state.db ctrlrun receipts

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -37,6 +37,27 @@ The agent is treated as a potentially compromised or hallucinating principal. Ev
 | Malformed or missing policy | Load-time error; no Control without valid policy |
 | Float-based hash collisions/mismatches | Floats rejected in arguments |
 
+## In scope — CTRLRun v0.3 adds
+
+The authority model answers a question v0.1 and v0.2 could not: *who is acting, and what are
+they entitled to?* Everything above still holds; these are the threats the second axis closes.
+
+| Threat | Control |
+|---|---|
+| A principal proposing an action nobody granted them | `authority:` present → no grant means DENY, including for actions the policy allows outright |
+| An agent widening its own authority by delegating | Containment on every dimension, at creation **and** at every evaluation |
+| A delegated grant that silently inherits what it does not name | Omission is rejected, never treated as unconstrained or inherited (§5.4) |
+| A delegation handed to a wider population than its parent covered | A child subject may not carry a wildcard or drop its parent's `user` |
+| A compromised chain that has to be cut in a hurry | `ctrlrun revoke` is transitive by structure: one write cuts a chain of any depth |
+| Authority outliving the credential that created it | `delegable: true` requires `expires_at`; `Control.delegate` refuses an expired `by` |
+| A credential that has expired mid-action | Refused before authority and before policy; a lease extension is refused and the record becomes `AMBIGUOUS` by the ordinary path |
+| A forged or tampered token | `JWTIdentityProvider` verifies the signature against a JWKS or a pinned key, with the algorithm taken from its own allow-list and never from the token (RFC 8725 §3.1) |
+| An ID token presented as an access token | `token_type` is required and `typ` is checked — the cross-JWT confusion of RFC 8725 §2 |
+| A token for another audience or issuer | `aud` by exact membership on either wire shape, `iss` exact, `exp` required |
+| Signing keys fetched from somewhere else | JWKS over HTTPS only, redirects refused outright, a duplicate `kid` refused rather than resolved, a failed fetch never emptying the cache |
+| An unauthenticated principal reaching an authorization decision | `--principal-from-client-info` removed; `AcsControlHook` refuses an `Authority` without an `identity` provider |
+| An environment chosen by the caller | The environment is set once on the `Control` and is never read off the wire |
+
 ## Out of scope — CTRLRun does not defend against
 
 - A compromised CTRLRun process, host, or Python environment.
@@ -47,6 +68,12 @@ The agent is treated as a potentially compromised or hallucinating principal. Ev
 - Data exfiltration through *read* actions the policy allows. CTRLRun is not DLP.
 - Denial of service by flooding approval requests.
 - Bypassing the decorator entirely (calling the raw function). v0.2 gateway mode narrows this; process-level enforcement is out of scope.
+- **A compromised identity provider.** CTRLRun *consumes* identities: it verifies a token somebody else issued and maps the verified claims onto a `Principal`. It issues nothing, and an issuer that signs a token for the wrong subject has told CTRLRun the truth as far as CTRLRun can tell. Everything downstream — grants, delegation, receipts — is then wrong, correctly and consistently.
+- **A `HeaderIdentityProvider` behind a proxy that does not overwrite the header.** It is worth exactly what the thing setting it is worth, and RFC 7239 §8.1 says the same of the header it standardizes. If the agent can set the header, the agent chooses its own authority. It warns at construction and it is still the operator's call.
+- **A revoked token before its `exp`.** There is no revocation channel: a verified token is valid until it expires, which is why one with no `exp` is refused. Shared-signals mechanisms exist and v0.3 implements none of them. Short lifetimes are the whole of the story.
+- **A tenant-templated issuer.** `issuer` is matched as an exact string, so a multi-tenant endpoint cannot be configured correctly here. Pointing it at one without pinning the tenant makes every tenant on that platform a valid issuer — stated because the fail-open is inviting.
+- **Authority across an agent-to-agent hop.** A grant covers the principal CTRLRun resolved for *this* call. Propagating attenuated authority across hops is v0.7.
+- **Approving an authority change.** `ctrlrun delegate --as` is an assertion typed at a shell, not an authentication; the record keeps `created_via` so a reader can tell an act from an assertion. Authenticating the *approver* remains out of scope, as in v0.1.
 
 ## Fail-closed rules (v0.1, not configurable)
 
@@ -106,6 +133,27 @@ lands. Nothing in this section describes behaviour you can run today.
   true with the authority model, and the `clientInfo` option is removed in v0.3.
 - **Reservation is still single-host.** Two gateways in front of one upstream share no
   reservations unless they share a state file on one machine.
+
+## Known v0.3 limitations
+
+- **`Authority` is built at load time and is not hot-reloaded.** Revocation and expiry are
+  live — read from the store and the clock on every evaluation — but an *edit to the file* is
+  not. Narrowing a ceiling, bringing an expiry forward, removing `delegable` or deleting a
+  grant takes effect when the process next loads the document, which for `ctrlrun gateway`
+  means a restart. The runtime lever is `ctrlrun revoke`, one delegation at a time, by id.
+- **There is no way to list delegations**, so there is no way to sweep a subtree. The ids are
+  in the events file. Cutting a chain of *unknown* width means setting `delegable: false` on
+  the root grant and restarting, after which §5.6 rule 6 denies every descendant.
+- **Observe mode executes.** It is the rollout path, not a sandbox: effects land at remotes
+  and the records of them are real. What it suspends is CTRLRun's refusals, wholesale — every
+  ⚠ row of `SPEC-v0.3.md` §9 at once. It is not a per-action opt-out and cannot be made one.
+- **A `mode: observe` writer and a ≤ 0.2 reader do not mix.** `ReceiptResult` gains
+  `observed`, and `Receipt.from_dict` parses `result` into a closed enum — so an older process
+  reading the same store raises. Upgrade every reader before switching any writer.
+- **Claims are receipt data, not action identity.** They are deliberately outside the action
+  hash, so an approval survives a token rotation — and equally, a claim that changed between
+  proposal and execution does not invalidate one. Matching a grant on a claim is out of scope
+  (§13): it needs an answer to "what does a missing claim mean" that v0.3 does not have.
 
 ## Disclosure
 

--- a/docs/authority.md
+++ b/docs/authority.md
@@ -1,0 +1,180 @@
+# Authority: who is acting, and what are they entitled to?
+
+Until v0.3, a CTRLRun policy could see the action and nothing else. It answered *how much
+autonomy does this action have* — run it, ask a human, refuse it — and the principal was
+attribution on a receipt. That is a real question and it is still the one `actions:` answers.
+
+It is not the only question. "May a €50,000 refund run without a human?" and "may *this agent*
+propose a €50,000 refund at all?" are different, and a system that can only ask the first will
+eventually answer the second by accident.
+
+Authority is the second axis. This page is the model in plain language; the contract is
+[`SPEC-v0.3.md`](SPEC-v0.3.md) §4 and §5.
+
+---
+
+## Opt in, and then it is closed
+
+A document with **no `authority:` section behaves exactly as v0.2 did**. Nothing is evaluated,
+no `AUTHORITY_*` event is written, and no decision changes.
+
+The moment the section exists, **every principal needs a grant, and no grant means denied** —
+including for actions the policy allows outright, including reads, including actions with no
+effect key. There is no `default: allow`, no per-action opt-out, and no flag that makes a
+missing grant permissive. Half-configured authority is the failure mode this rule exists to
+prevent: it is the state in which nobody can say whether an action was permitted or merely
+unlisted.
+
+```yaml
+schema: ctrlrun.policy/v3      # `authority:` needs v3, or a v1 reader would ignore it
+
+authority:
+  grants:
+    - id: head-of-support
+      subject: { agent: "head-of-support", user: "dana@example.com" }
+      actions: ["stripe.refund"]
+      resources: ["payment:*"]
+      constraints: { amount_gte: 0, amount_lte: 10000000 }
+      environments: ["production"]
+```
+
+`grants: []` is valid and permits nothing. A **missing** `grants` key is a load error, because
+inferring "nothing" from an absent key would make a truncated edit look deliberate.
+
+## A grant carries no decision
+
+There is no `decision:` in a grant, and this is the design rather than an omission.
+
+How much autonomy `stripe.refund` has is the same for the head of support and for the newest
+agent in the fleet: it is a property of the action and of the amount, and it lives in
+`actions:`. What differs between principals is **whether they may propose it at all**.
+
+The two axes are evaluated separately — authority first — and combine as **the stricter of the
+pair**. Authority cannot make a denied action allowed. Policy cannot make an unauthorized
+action permitted. Neither can loosen the other, which is what lets you read either one on its
+own and be right about what it does.
+
+And policy still cannot see the principal. `agent_eq` and every other principal-addressing
+condition is refused at load, exactly as in v0.1. Authority is a separate vocabulary, on
+purpose.
+
+## What a grant matches on
+
+| Key | Matches |
+|---|---|
+| `subject` | the principal: `agent`, and optionally `user` |
+| `actions` | action names, as patterns |
+| `resources` | the action's resource string, as patterns |
+| `constraints` | the action's arguments, in the same syntax a rule's `when:` uses |
+| `environments` | the deployment the action is running in |
+| `expires_at` | when the grant stops working |
+
+**Patterns are deliberately small**, because containment between two of them has to be
+decidable: a literal, a `prefix*` that cannot cross a separator, and a final `**`. So
+`stripe.*` matches `stripe.refund` and **not** `stripe.refund.partial`. There is no `?` and no
+character class. Granting the whole surface of a system is spelled `**` — one token, greppable
+in review, and impossible to write by accident.
+
+**The environment is not the caller's to state.** It is set once on the `Control` and stamped
+on every Action, so a grant scoped to `["staging"]` cannot be satisfied by a call that
+describes itself as staging. An authorization dimension the subject can set is not one.
+
+## Delegation, and the rule that makes it safe
+
+A principal holding a `delegable` grant can create a narrower one at runtime:
+
+```console
+$ ctrlrun delegate --parent head-of-support --file finance.yaml --as head-of-support/dana@example.com
+created dlg_1f0c…  parent head-of-support at depth 1
+revoke it with: ctrlrun revoke dlg_1f0c…
+```
+
+A delegated grant is valid only if it is **provably a subset of its parent, on every
+dimension** — checked when it is created, and again every single time it is evaluated.
+
+The re-check is not belt-and-braces. It is what makes revocation transitive, what makes an
+expiring parent stop authorizing without anyone having to find its children, and what makes a
+narrowed root grant narrow everything beneath it. A containment check performed only at
+creation would leave every delegation exactly as wide as the file used to be — which is the
+shape of every stale-permission incident there has ever been.
+
+`delegable: true` **requires `expires_at`**. Authority that can mint more authority and never
+lapses is the one shape this model refuses to write down.
+
+## The omission rule
+
+This is the part that surprises people, so it gets its own section.
+
+**A child that drops a dimension its parent constrains is rejected.** Not inherited. Certainly
+not unconstrained.
+
+```yaml
+# parent
+constraints: { amount_lte: 2500000 }
+resources: ["payment:EU-*"]
+
+# child — REJECTED, dimension "resources"
+constraints: { amount_lte: 200000 }
+# (no `resources:` key at all)
+```
+
+Read the child on its own and it looks narrower: the amount came down. But a grant with no
+`resources` places no resource limit, so the child would authorize `payment:US-*`, which the
+parent never could. Silence widened it.
+
+Most permission systems read an omitted field as "inherit the parent's". That is a reasonable
+convention and it is not this one, because it makes the safe reading of a document depend on a
+document you are not looking at. Here, **a delegated grant means exactly what it says**, and
+saying less is refused rather than resolved. The cost is that every link states every
+dimension; the benefit is that a chain can be reviewed one file at a time.
+
+The same rule applies to the subject: a delegation may not carry a wildcard grantee, and may
+not drop its parent's `user`. Both hand the grant to a wider population than the parent
+covered.
+
+## Revocation
+
+```console
+$ ctrlrun revoke dlg_1f0c…
+revoked dlg_1f0c… by cli:local
+every delegation beneath it is denied from the next evaluation
+```
+
+**Transitive by structure.** Nothing is rewritten and no children are visited — every
+evaluation walks to the root anyway, so a chain of any depth is cut by one write. It is
+idempotent, and there is no `unrevoke`: the operation whose safety matters is the one taken in
+a hurry.
+
+Two limits worth knowing before you need them:
+
+- **`Authority` is built when the document is loaded, and v0.3 does not hot-reload.**
+  Revocation and expiry are live — they are read from the store and the clock on every
+  evaluation. An *edit to the file* is not: narrowing a ceiling, bringing an expiry forward or
+  removing `delegable` takes effect when the process next loads the document, which for
+  `ctrlrun gateway` means a restart.
+- **There is no way to list delegations in v0.3**, so there is no way to sweep a subtree.
+  `ctrlrun revoke` works one id at a time, and the ids are in the events file. The operation
+  that cuts a chain of *unknown* width is setting `delegable: false` on the root grant and
+  restarting: every descendant is then denied on the next evaluation.
+
+## Reading the evidence
+
+Every action that passes authority appends `AUTHORITY_RESOLVED` — not only delegated ones,
+because a deployment with a permissive grant has to be distinguishable from one with no
+section at all. A denial appends `AUTHORITY_DENIED` and **never** `POLICY_EVALUATED`: policy is
+not evaluated, so no approval request is created and no human is left holding a request for an
+action that could never run.
+
+The reason is one of a closed set — `no_authority`, `authority_constraint`,
+`authority_expired`, `authority_escalation`, `authority_revoked`, `authority_unreadable` — and
+never a grant id. A grant may legally be named `no_authority`, and evidence that can be spoofed
+by naming a grant is not evidence. The ids travel in `data.grant_id` and
+`data.delegation_id`.
+
+## Try it
+
+- `ctrlrun demo`, scenario 5 — the chain, the escalation, and the refusal, in process.
+- [`examples/authority-escalation/`](../examples/authority-escalation/) — the same story as a
+  standalone script, including the delegation that is refused at *creation*.
+- [`examples/authority/`](../examples/authority/) — a payments chain and a DevOps chain, as
+  complete documents to read rather than run.

--- a/examples/authority-escalation/ctrlrun.yaml
+++ b/examples/authority-escalation/ctrlrun.yaml
@@ -1,0 +1,39 @@
+# The policy and the grants this example runs under. Unknown actions are denied; a principal
+# with no grant is denied. There is no default-allow on either axis.
+#
+# `authority:` needs `ctrlrun.policy/v3`: a reader that ignored the section would run every
+# action with no authority check at all, and the schema string is the only thing standing
+# between those two outcomes.
+schema: ctrlrun.policy/v3
+
+authority:
+  # How deep a chain may go. The default is 3; it is stated here because a reader deciding
+  # what to copy should see the bound rather than inherit it.
+  max_delegation_depth: 3
+
+  grants:
+    # A human's own authority: €100,000 of refunds, and the right to delegate a narrower
+    # slice of it. `delegable: true` requires an `expires_at` — authority that can mint more
+    # authority and never lapses is the one shape this model refuses to write down.
+    - id: head-of-support
+      subject: { agent: "head-of-support", user: "dana@example.com" }
+      actions: ["stripe.refund"]
+      resources: ["payment:*"]
+      constraints: { amount_lte: 10000000 }   # €100,000.00 in integer minor units
+      environments: ["production"]
+      delegable: true
+      expires_at: "2027-01-01T00:00:00Z"
+
+actions:
+  # The autonomy policy is a **separate axis** and cannot see the principal. It says how much
+  # autonomy this *action* has; the grants above say who may propose it at all. An action
+  # needs both, and the two combine as the stricter of the pair.
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    resource: "payment:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 100000 }      # €0.00 to €1,000.00 — autonomous
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 1000000 }     # to €10,000.00 — a human decides
+        decision: approve
+      - decision: deny

--- a/examples/authority-escalation/main.py
+++ b/examples/authority-escalation/main.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""A delegated grant cannot be wider than the one it came from, and it is re-checked.
+
+Three links: a human who holds €100,000 and may delegate, a finance agent given €25,000, a
+support agent given €2,000. Then the two ways of stepping outside the chain, which fail at
+two different moments and for two different reasons:
+
+- the support agent **asks for €50,000** — refused at evaluation, `authority_constraint`;
+- the finance agent **tries to mint €50,000** under its own €25,000 — refused at creation,
+  `containment`, naming the dimension it widened.
+
+Asserting only one would hide the other. The second is the one worth sitting with: an agent
+that could delegate more authority than it holds could reach the first amount by minting its
+own permission, and every check at evaluation would still pass.
+
+The last part is not an escalation at all. The support agent asks for €1,500, which its grant
+permits — and the policy still stops to ask a human, because authority and policy are separate
+axes and an action needs both.
+
+    python examples/authority-escalation/main.py
+
+No network, and a state directory of its own under `.ctrlrun/examples/`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ctrlrun import (
+    Action,
+    ApprovalRequired,
+    Authority,
+    AuthorityDenied,
+    AuthorityEscalation,
+    Control,
+    Grant,
+    Policy,
+    Principal,
+    SQLiteStateStore,
+)
+from ctrlrun.authority import grant_from_yaml
+
+HERE = Path(__file__).resolve().parent
+BLOCKED = "   ✗ BLOCKED — "
+
+#: Integer minor units (SPEC-v0.1 §2.3). Each link is narrower than the one above it.
+FINANCE_CEILING = 2500000  # €25,000.00
+SUPPORT_CEILING = 200000  # €2,000.00
+ESCALATION = 5000000  # €50,000.00 — outside the support agent's grant
+WITHIN_GRANT = 150000  # €1,500.00 — inside it, and still not autonomous
+
+HEAD = Principal(agent="head-of-support", user="dana@example.com")
+FINANCE = Principal(agent="finance-agent", user="dana@example.com")
+SUPPORT = Principal(agent="support-agent", user="dana@example.com")
+
+
+class FakeStripe:
+    """Records every call, so "the remote was never reached" is a number and not a claim."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def refund(self, payment_id: str, amount: int) -> dict[str, Any]:
+        self.calls.append(payment_id)
+        return {"id": f"re_{payment_id}", "amount": amount, "status": "succeeded"}
+
+
+def narrower(agent: str, ceiling: int) -> Grant:
+    """One delegated grant, in the shape `ctrlrun delegate --file` takes.
+
+    **Every dimension is stated.** Omitting one the parent constrains is rejected, not
+    inherited and certainly not treated as unlimited — which is the opposite of how almost
+    every permission system behaves, and the reason this file spells out `actions`,
+    `resources`, `constraints`, `environments` and `expires_at` on every link.
+    """
+    return grant_from_yaml(
+        f"""
+subject: {{ agent: "{agent}", user: "dana@example.com" }}
+actions: ["stripe.refund"]
+resources: ["payment:*"]
+constraints: {{ amount_lte: {ceiling} }}
+environments: ["production"]
+delegable: true
+expires_at: "2026-12-01T00:00:00Z"
+"""
+    )
+
+
+def refund_action(principal: Principal, payment_id: str, amount: int) -> Action:
+    """The Action a decorator or a gateway would build, built by hand.
+
+    Three principals share one `Control` here, and `ctrlrun.context()` names a principal
+    rather than resolving one — so the Action is constructed directly, which is the same
+    public path the gateway and the ACS hook take.
+    """
+    return Action(
+        name="stripe.refund",
+        arguments={"payment_id": payment_id, "amount": amount},
+        principal=principal,
+        resource=f"payment:{payment_id}",
+    )
+
+
+def state_dir(root: Path) -> Path:
+    """A store of this example's own, emptied so the example repeats.
+
+    An example that reserved effect keys in a live store would block real work. Only the
+    files this script writes are removed, and only by name: never a directory.
+    """
+    evidence = root / ".ctrlrun" / "examples" / HERE.name
+    evidence.mkdir(parents=True, exist_ok=True)
+    for name in ("state.db", "state.db-wal", "state.db-shm", "receipts.jsonl", "events.jsonl"):
+        (evidence / name).unlink(missing_ok=True)
+    return evidence
+
+
+def main(root: Path) -> None:
+    document = (HERE / "ctrlrun.yaml").read_text(encoding="utf-8")
+    store = SQLiteStateStore(state_dir(root) / "state.db")
+    remote = FakeStripe()
+    control = Control(
+        Policy.from_yaml(document, source=str(HERE / "ctrlrun.yaml")),
+        store,
+        authority=Authority.from_yaml(document, source=str(HERE / "ctrlrun.yaml")),
+        environment="production",
+    )
+
+    try:
+        print("Authority escalation")
+        finance = control.delegate(
+            "head-of-support", narrower("finance-agent", FINANCE_CEILING), by=HEAD
+        )
+        support = control.delegate(
+            finance.delegation_id, narrower("support-agent", SUPPORT_CEILING), by=FINANCE
+        )
+        print("   human €100,000 delegable  →  finance agent €25,000  →  support agent €2,000")
+        print(f"   the support agent's grant: {support.delegation_id}")
+
+        print("   support agent requests €50,000  →")
+        try:
+            control.execute(
+                refund_action(SUPPORT, "txn_1", ESCALATION),
+                lambda: remote.refund("txn_1", ESCALATION),
+                "refund:txn_1",
+            )
+        except AuthorityDenied as refused:
+            print(f"{BLOCKED}outside the delegated grant ({refused.reason})")
+        else:
+            raise SystemExit("the escalation was permitted; this example proved nothing")
+        print(f"   remote refund calls: {remote.calls.count('txn_1')}")
+
+        print("   finance agent tries to delegate €50,000 under its own €25,000  →")
+        try:
+            control.delegate(
+                finance.delegation_id, narrower("support-agent", ESCALATION), by=FINANCE
+            )
+        except AuthorityEscalation as refused:
+            print(f"{BLOCKED}not contained in its parent ({refused.reason}: {refused.dimension})")
+        else:
+            raise SystemExit("a widening delegation was created; this example proved nothing")
+        print(f"   delegations on record: {len(store.delegations())}")
+
+        # Not an escalation: the amount is inside the grant. Authority permits it and the
+        # policy still asks a human, because the two axes combine as the stricter of the pair.
+        print("   support agent requests €1,500  →")
+        try:
+            control.execute(
+                refund_action(SUPPORT, "txn_2", WITHIN_GRANT),
+                lambda: remote.refund("txn_2", WITHIN_GRANT),
+                "refund:txn_2",
+            )
+        except ApprovalRequired as pending:
+            print(f"   authority permits it, and the policy asks a human ({pending.request_id})")
+        except AuthorityDenied as refused:  # pragma: no cover - the assertion is the failure
+            raise SystemExit(
+                f"an amount inside the grant was refused by authority ({refused.reason}); "
+                "this example's chain authorizes nothing, so its refusals prove nothing"
+            ) from refused
+        else:
+            raise SystemExit("the €1,500 refund ran without a human; check the policy")
+        print(f"   remote refund calls: {remote.calls.count('txn_2')}")
+        print("   two axes, and an action needs both: the stricter of the pair wins")
+    finally:
+        store.close()
+
+
+if __name__ == "__main__":
+    main(Path.cwd())

--- a/examples/authority/README.md
+++ b/examples/authority/README.md
@@ -1,0 +1,39 @@
+# Two authority configurations
+
+`payments.yaml` and `devops.yaml` are complete `ctrlrun.policy/v3` documents. They are
+starting points, not drop-in configuration: **every principal named in them is invented**, and
+a grant names a real person or service in a real organization. Adopting somebody else's is how
+a template becomes an incident.
+
+Load one the way any policy is loaded:
+
+```console
+$ CTRLRUN_CONFIG=examples/authority/payments.yaml ctrlrun stats
+```
+
+## What to read them for
+
+**A grant carries no `decision:`.** How much autonomy `stripe.refund` has is the same for the
+head of support and for the newest agent. What differs is whether they may propose it at all.
+The two axes are evaluated separately, authority first, and combine as the stricter of the
+pair — so neither can loosen the other.
+
+**Omission is not "unlimited".** Every grant states every dimension it means to constrain,
+because a delegation that drops one its parent constrains is *rejected* rather than treated as
+unconstrained. Writing the parents that way makes the children obvious.
+
+**`*` cannot cross a separator.** `k8s.*` matches `k8s.scale` and not `k8s.namespace.delete`.
+There is no `?`, no character class, and no short spelling for "everything": the whole surface
+of a system is `**`, one token, greppable, and impossible to write by accident.
+
+**`delegable: true` requires `expires_at`.** Authority that can mint more authority and never
+lapses is the one shape the model refuses to write down. `devops.yaml` puts the near expiry on
+the grant that can delegate, which is the right way round.
+
+**The environment belongs to the deployment.** `devops.yaml` scopes grants to `staging`, and
+that word never comes off the call — it is set once on the `Control`. An authorization
+dimension the subject can set is not one.
+
+For the delegation chain these documents anticipate, run
+[`examples/authority-escalation/`](../authority-escalation/), and read
+[`docs/authority.md`](../../docs/authority.md) for the model in plain language.

--- a/examples/authority/devops.yaml
+++ b/examples/authority/devops.yaml
@@ -1,0 +1,74 @@
+# A DevOps delegation chain: who may touch which cluster, and for how long.
+#
+# The shape worth copying here is the **environment** dimension. A grant scoped to
+# `["staging"]` cannot authorize a production action however the caller describes itself,
+# because the environment belongs to the deployment: it is set once on the `Control` — from
+# `--environment`, `$CTRLRUN_ENVIRONMENT`, this document's top-level `environment:`, or
+# "production" — and never taken from the call. An authorization dimension the subject can set
+# is not one.
+#
+# Replace every name before use.
+schema: ctrlrun.policy/v3
+
+# This deployment's environment, which every Action it decides carries. Rank three of four:
+# `Control(environment=...)` and `$CTRLRUN_ENVIRONMENT` both outrank it.
+environment: staging
+
+authority:
+  max_delegation_depth: 2
+
+  grants:
+    # The on-call human. Everything in staging, and the right to lend a slice of it for a
+    # short window — note the near expiry: a grant that can mint authority should outlive the
+    # incident it was created for by as little as possible.
+    - id: sre-oncall
+      subject: { agent: "sre-oncall", user: "sam@example.com" }
+      actions: ["k8s.**"]
+      resources: ["cluster:staging/*"]
+      environments: ["staging"]
+      delegable: true
+      expires_at: "2026-10-01T00:00:00Z"
+
+    # A deploy agent, scoped to one namespace pattern and to the two verbs it needs. `k8s.*`
+    # matches `k8s.scale` and **not** `k8s.namespace.delete`: a `*` cannot cross a separator,
+    # which is what makes "everything under here" something you have to write on purpose.
+    - id: deploy-agent
+      subject: { agent: "deploy-agent" }
+      actions: ["k8s.apply", "k8s.scale"]
+      resources: ["cluster:staging/app-*"]
+      environments: ["staging"]
+
+    # A read-only agent across both clusters. There is no short spelling for "everything":
+    # granting the whole surface of a system is `**`, one token, greppable, and impossible to
+    # write by accident — and this grant does not use it.
+    - id: observability
+      subject: { agent: "metrics-agent" }
+      actions: ["k8s.get", "k8s.logs"]
+      resources: ["cluster:staging/*", "cluster:production/*"]
+      environments: ["staging", "production"]
+
+actions:
+  # Destructive infrastructure is never autonomous, for anybody. Authority decides *who* may
+  # propose it; this line decides that a human answers whenever they do.
+  k8s.namespace.delete:
+    effect: "k8s:delete-namespace:{namespace}"
+    resource: "cluster:{cluster}/{namespace}"
+    decision: approve
+
+  k8s.apply:
+    effect: "k8s:apply:{namespace}:{revision}"
+    resource: "cluster:{cluster}/{namespace}"
+    decision: allow
+
+  k8s.scale:
+    effect: "k8s:scale:{namespace}:{deployment}:{replicas}"
+    resource: "cluster:{cluster}/{namespace}"
+    rules:
+      - when: { replicas_lte: 20 }
+        decision: allow
+      - decision: approve
+
+  k8s.get:
+    decision: allow
+  k8s.logs:
+    decision: allow

--- a/examples/authority/payments.yaml
+++ b/examples/authority/payments.yaml
@@ -1,0 +1,87 @@
+# A payments delegation chain: who may refund, how much, and who may hand a slice of that on.
+#
+# Two axes, and an action needs both:
+#
+#   authority:  may this principal propose this action at all?
+#   actions:    how much autonomy does this action have, for everybody?
+#
+# A grant carries no `decision:`. How much autonomy `stripe.refund` has is the same for the
+# head of support and for the newest agent; what differs is whether they may ask.
+#
+# The names here are illustrative. Replace every one before use: a grant names a real
+# principal in a real organization, and adopting somebody else's is how a template becomes an
+# incident.
+schema: ctrlrun.policy/v3
+
+authority:
+  # A chain may be at most three links long. Depth is recomputed on every evaluation by
+  # walking to the root, never read from the stored row, so a longer chain cannot be created
+  # by editing this number down after the fact.
+  max_delegation_depth: 3
+
+  grants:
+    # 1. The human. €100,000, and the right to hand a narrower slice to an agent.
+    #
+    # `delegable: true` requires `expires_at`: authority that can mint more authority and
+    # never lapses is the one shape this model refuses to write down. Bringing this date
+    # forward narrows every delegation beneath it on the next evaluation — but only after the
+    # process reloads the file, because `Authority` is built at load time and v0.3 does not
+    # hot-reload. The runtime lever is `ctrlrun revoke <delegation-id>`.
+    - id: head-of-support
+      subject: { agent: "head-of-support", user: "dana@example.com" }
+      actions: ["stripe.refund", "stripe.refund.partial"]
+      resources: ["payment:*"]
+      constraints: { amount_gte: 0, amount_lte: 10000000 }   # €0 to €100,000.00
+      environments: ["production"]
+      delegable: true
+      expires_at: "2027-01-01T00:00:00Z"
+
+    # 2. A service account that reconciles, and may never move money. It holds no `delegable`
+    # key at all, which is the default and means it cannot create a delegation.
+    - id: reconciliation
+      subject: { agent: "reconciliation-agent" }
+      actions: ["stripe.charge.read", "stripe.refund.read"]
+      resources: ["payment:*"]
+      environments: ["production", "staging"]
+
+    # 3. The floor, for a chain nobody edits: refunds up to €50, one agent, one environment.
+    # A grant with no `constraints:` places no *value* limit — but it still limits the action
+    # names, the resources and the environment, which is why those are never left out.
+    - id: tier-one-support
+      subject: { agent: "support-agent" }
+      actions: ["stripe.refund"]
+      resources: ["payment:EU-*"]
+      constraints: { amount_gte: 0, amount_lte: 5000 }       # €0 to €50.00
+      environments: ["production"]
+
+# The autonomy policy. It cannot see the principal — `agent_eq` and every other
+# principal-addressing condition is refused at load — so these rules say what is true of the
+# *action* for everybody, and the grants above say who may propose it.
+actions:
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    resource: "payment:{payment_id}"
+    rules:
+      # Both ends are bound. `amount_lte` on its own lets a negative amount through, and a
+      # refund of a negative amount is a charge.
+      - when: { amount_gte: 0, amount_lte: 100000 }          # to €1,000.00 — autonomous
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 1000000 }         # to €10,000.00 — a human
+        decision: approve
+      - decision: deny
+
+  stripe.refund.partial:
+    effect: "refund:{payment_id}:{line_item}"
+    resource: "payment:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }
+        decision: allow
+      - decision: approve
+
+  # Reads get no effect: template, and that is correct for a read. Anything that changes the
+  # world and has none gets no reservation at all, and `ctrlrun gateway` prints those on the
+  # line that starts the process.
+  stripe.charge.read:
+    decision: allow
+  stripe.refund.read:
+    decision: allow

--- a/examples/policies/devops.yaml
+++ b/examples/policies/devops.yaml
@@ -5,6 +5,11 @@
 #   leaves the building    → approve  (a human, every time)
 #   destroys the evidence  → deny     (not an agent action at any size)
 #
+#
+# **No `authority:` section, deliberately** (SPEC-v0.3 §1.2). A grant names a real principal
+# in a real organization, and a template that shipped plausible ones would invite an operator
+# to adopt them. Add grants yourself, against names your directory actually holds; see
+# `docs/authority.md` and `examples/authority/`.
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 schema: ctrlrun.policy/v1

--- a/examples/policies/e-commerce.yaml
+++ b/examples/policies/e-commerce.yaml
@@ -5,6 +5,11 @@
 #   leaves the building    → approve  (a human, every time)
 #   destroys the evidence  → deny     (not an agent action at any size)
 #
+#
+# **No `authority:` section, deliberately** (SPEC-v0.3 §1.2). A grant names a real principal
+# in a real organization, and a template that shipped plausible ones would invite an operator
+# to adopt them. Add grants yourself, against names your directory actually holds; see
+# `docs/authority.md` and `examples/authority/`.
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 #

--- a/examples/policies/government.yaml
+++ b/examples/policies/government.yaml
@@ -5,6 +5,11 @@
 #   leaves the building    → approve  (a human, every time)
 #   destroys the evidence  → deny     (not an agent action at any size)
 #
+#
+# **No `authority:` section, deliberately** (SPEC-v0.3 §1.2). A grant names a real principal
+# in a real organization, and a template that shipped plausible ones would invite an operator
+# to adopt them. Add grants yourself, against names your directory actually holds; see
+# `docs/authority.md` and `examples/authority/`.
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 #

--- a/examples/policies/healthcare.yaml
+++ b/examples/policies/healthcare.yaml
@@ -5,6 +5,11 @@
 #   leaves the building    → approve  (a human, every time)
 #   destroys the evidence  → deny     (not an agent action at any size)
 #
+#
+# **No `authority:` section, deliberately** (SPEC-v0.3 §1.2). A grant names a real principal
+# in a real organization, and a template that shipped plausible ones would invite an operator
+# to adopt them. Add grants yourself, against names your directory actually holds; see
+# `docs/authority.md` and `examples/authority/`.
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 #

--- a/examples/policies/hr.yaml
+++ b/examples/policies/hr.yaml
@@ -5,6 +5,11 @@
 #   leaves the building    → approve  (a human, every time)
 #   destroys the evidence  → deny     (not an agent action at any size)
 #
+#
+# **No `authority:` section, deliberately** (SPEC-v0.3 §1.2). A grant names a real principal
+# in a real organization, and a template that shipped plausible ones would invite an operator
+# to adopt them. Add grants yourself, against names your directory actually holds; see
+# `docs/authority.md` and `examples/authority/`.
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 #

--- a/examples/policies/insurance.yaml
+++ b/examples/policies/insurance.yaml
@@ -5,6 +5,11 @@
 #   leaves the building    → approve  (a human, every time)
 #   destroys the evidence  → deny     (not an agent action at any size)
 #
+#
+# **No `authority:` section, deliberately** (SPEC-v0.3 §1.2). A grant names a real principal
+# in a real organization, and a template that shipped plausible ones would invite an operator
+# to adopt them. Add grants yourself, against names your directory actually holds; see
+# `docs/authority.md` and `examples/authority/`.
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 #

--- a/examples/policies/legal.yaml
+++ b/examples/policies/legal.yaml
@@ -5,6 +5,11 @@
 #   leaves the building    → approve  (a human, every time)
 #   destroys the evidence  → deny     (not an agent action at any size)
 #
+#
+# **No `authority:` section, deliberately** (SPEC-v0.3 §1.2). A grant names a real principal
+# in a real organization, and a template that shipped plausible ones would invite an operator
+# to adopt them. Add grants yourself, against names your directory actually holds; see
+# `docs/authority.md` and `examples/authority/`.
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 #

--- a/examples/policies/payments.yaml
+++ b/examples/policies/payments.yaml
@@ -5,6 +5,11 @@
 #   leaves the building    → approve  (a human, every time)
 #   destroys the evidence  → deny     (not an agent action at any size)
 #
+#
+# **No `authority:` section, deliberately** (SPEC-v0.3 §1.2). A grant names a real principal
+# in a real organization, and a template that shipped plausible ones would invite an operator
+# to adopt them. Add grants yourself, against names your directory actually holds; see
+# `docs/authority.md` and `examples/authority/`.
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 #

--- a/examples/policies/security.yaml
+++ b/examples/policies/security.yaml
@@ -5,6 +5,11 @@
 #   leaves the building    → approve  (a human, every time)
 #   destroys the evidence  → deny     (not an agent action at any size)
 #
+#
+# **No `authority:` section, deliberately** (SPEC-v0.3 §1.2). A grant names a real principal
+# in a real organization, and a template that shipped plausible ones would invite an operator
+# to adopt them. Add grants yourself, against names your directory actually holds; see
+# `docs/authority.md` and `examples/authority/`.
 # Unknown actions are denied. There is no default-allow: this file is the list of what an
 # agent may do, and anything not written here is refused.
 #

--- a/src/ctrlrun/cli/demo.py
+++ b/src/ctrlrun/cli/demo.py
@@ -1,6 +1,6 @@
-"""The four-scenario demo with an in-process fake Stripe. Build-list item 8; SPEC §7 T11.
+"""The five-scenario demo with an in-process fake Stripe. SPEC-v0.1 §7 T11, SPEC-v0.3 §1.2.
 
-Four ways an agent action goes wrong at the boundary between intention and effect, and what
+Five ways an agent action goes wrong at the boundary between intention and effect, and what
 CTRLRun does about each. Everything runs in this process: no network, no clock skew, no
 sleeping. The fake remote is the only thing pretending — and it pretends in the one way that
 matters, by committing before its response goes missing.
@@ -18,17 +18,21 @@ from typing import Any, Final, TypeVar
 
 import click
 
+from ..action import Action, Principal
 from ..approval import ScriptedApprovalProvider
+from ..authority import Authority, Grant, grant_from_yaml
 from ..control import Control, context, protect, with_approval
 from ..errors import (
     AmbiguousEffect,
     ApprovalMismatch,
     ApprovalRequired,
+    AuthorityDenied,
+    AuthorityEscalation,
     DuplicateEffect,
 )
 from ..policy import Policy
 from ..receipt import EVENTS_FILENAME, RECEIPTS_FILENAME, JSONLEventSink
-from ..state import SQLiteStateStore
+from ..state import SQLiteStateStore, StateStore
 
 #: Where the demo keeps its own store and evidence, under `.ctrlrun/`.
 DEMO_DIRNAME: Final = "demo"
@@ -39,6 +43,9 @@ SCENARIO_HEADINGS: Final = (
     "Approval mutation",
     "Concurrent agents, same effect",
     "Approval replay",
+    # SPEC-v0.3 §1.2 — the fifth answers a different question from the other four. They are
+    # about *what* is being done; this one is about *who* is entitled to do it.
+    "Authority escalation",
 )
 
 #: What each scenario refunds, in integer minor units (SPEC-v0.1 §2.3). The README's
@@ -51,10 +58,22 @@ MUTATED_AMOUNT: Final = 500000  # €5,000 — what the agent tried to run inste
 CONCURRENT_AMOUNT: Final = 50000  # €500 — autonomous, raced for by two agents
 REPLAY_AMOUNT: Final = 200000  # €2,000 — approved once, presented twice
 
+#: Scenario 5's chain, in integer minor units. Each link is narrower than the one above it,
+#: which is the whole of what "attenuation" means (SPEC-v0.3 §5.4).
+HEAD_OF_SUPPORT_CEILING: Final = 10000000  # €100,000 — the human's own grant, delegable
+FINANCE_CEILING: Final = 2500000  # €25,000 — delegated to the finance agent
+SUPPORT_CEILING: Final = 200000  # €2,000 — delegated on to the support agent
+ESCALATION_AMOUNT: Final = 5000000  # €50,000 — what the support agent asks for
+WITHIN_GRANT_AMOUNT: Final = 150000  # €1,500 — what it is actually entitled to
+
 #: The amounts the README prints, in the order it prints them.
 README_AMOUNTS: Final = (LOST_RESPONSE_AMOUNT, PROPOSED_AMOUNT, MUTATED_AMOUNT)
 
 #: Amounts are integer minor units (SPEC-v0.1 §2.3): €1,000 autonomous, €10,000 with a human.
+#:
+#: Scenarios 1 to 4 load this one, and it carries **no `authority:` section**: that is v0.2
+#: behaviour exactly (SPEC-v0.3 §4.1), and running the first four against it is the demo's own
+#: small proof that authority is opt-in. Scenario 5 builds its own document.
 DEMO_POLICY: Final = """
 schema: ctrlrun.policy/v1
 actions:
@@ -143,7 +162,7 @@ def run_demo(root: Path) -> None:
     def refund(payment_id: str, amount: int, currency: str = "EUR") -> dict[str, Any]:
         return remote.refund(payment_id, amount)
 
-    click.echo("CTRLRun demo — four ways an agent action goes wrong, and what stops it.")
+    click.echo("CTRLRun demo — five ways an agent action goes wrong, and what stops it.")
     click.echo(
         "Policy: refunds up to €1,000 are autonomous, up to €10,000 need a human, "
         "above that are denied."
@@ -154,6 +173,7 @@ def run_demo(root: Path) -> None:
         _approval_mutation(refund, approvals)
         _concurrent_agents(refund, remote)
         _approval_replay(refund, approvals)
+        _authority_escalation(control, store, remote)
     finally:
         written = len(store.receipts())
         store.close()
@@ -253,6 +273,151 @@ def _approval_replay(refund: Callable[..., Any], approvals: ScriptedApprovalProv
 
         blocked = _refused(present_it_again, ApprovalMismatch)
     click.echo(f"{_BLOCKED}single-use approval already {blocked.reason}")
+
+
+# --- 5. authority escalation (SPEC-v0.3 §5.6, T80's story) ----------------------------
+
+
+#: Scenario 5's own document. The `authority:` section is the whole point, so it needs
+#: `ctrlrun.policy/v3`; the `actions:` half is the same money policy the other four use, so a
+#: reader comparing the two sees exactly one difference.
+AUTHORITY_POLICY: Final = f"""
+schema: ctrlrun.policy/v3
+authority:
+  max_delegation_depth: 3
+  grants:
+    - id: head-of-support
+      subject: {{ agent: "head-of-support", user: "dana@example.com" }}
+      actions: ["stripe.refund"]
+      constraints: {{ amount_lte: {HEAD_OF_SUPPORT_CEILING} }}
+      delegable: true
+      expires_at: "2027-01-01T00:00:00Z"
+actions:
+  stripe.refund:
+    rules:
+      - when: {{ amount_lte: 100000 }}
+        decision: allow
+      - when: {{ amount_lte: 1000000 }}
+        decision: approve
+      - decision: deny
+"""
+
+
+def _delegated(ceiling: int, agent: str, user: str) -> Grant:
+    """One narrower grant, in the shape `ctrlrun delegate --file` takes (SPEC-v0.3 §5.7).
+
+    Every dimension is stated. **Omitting one its parent constrains would be rejected, not
+    inherited** (§5.4) — which is the sentence this scenario exists to make concrete, and the
+    opposite of how almost every permission system behaves.
+    """
+    return grant_from_yaml(
+        f"""
+subject: {{ agent: "{agent}", user: "{user}" }}
+actions: ["stripe.refund"]
+constraints: {{ amount_lte: {ceiling} }}
+delegable: true
+expires_at: "2026-12-01T00:00:00Z"
+"""
+    )
+
+
+def _authority_escalation(base: Control, store: StateStore, remote: FakeStripe) -> None:
+    """A delegation chain, and the two ways of stepping outside it (SPEC-v0.3 §5.6).
+
+    Scenarios 1 to 4 ask "is this action safe to run". This one asks "is this principal
+    entitled to propose it at all" — a separate axis, evaluated first, that a policy cannot
+    see (§4.7). A grant carries no `decision:`: how much autonomy an action has is the same
+    for every principal, and what differs is whether they may ask.
+    """
+    _heading(5, SCENARIO_HEADINGS[4])
+    # The same store and the **same sinks** as the other four. A second Control that quietly
+    # dropped the JSONL sink would leave the demo printing a receipt count from the store that
+    # the file it points the reader at does not match — which is the shape of a false green,
+    # in a transcript people paste into issues.
+    control = Control(
+        Policy.from_yaml(AUTHORITY_POLICY, source="<demo>"),
+        store,
+        base.approvals,
+        sinks=base.sinks,
+        authority=Authority.from_yaml(AUTHORITY_POLICY, source="<demo>"),
+    )
+    head = Principal(agent="head-of-support", user="dana@example.com")
+    finance = Principal(agent="finance-agent", user="dana@example.com")
+    support = Principal(agent="support-agent", user="dana@example.com")
+
+    finance_grant = control.delegate(
+        "head-of-support", _delegated(FINANCE_CEILING, "finance-agent", "dana@example.com"), by=head
+    )
+    support_grant = control.delegate(
+        finance_grant.delegation_id,
+        _delegated(SUPPORT_CEILING, "support-agent", "dana@example.com"),
+        by=finance,
+    )
+    click.echo(
+        f"   human {_euros(HEAD_OF_SUPPORT_CEILING)} delegable  →  "
+        f"finance agent {_euros(FINANCE_CEILING)}  →  support agent {_euros(SUPPORT_CEILING)}"
+    )
+    click.echo(f"   support agent's grant: {support_grant.delegation_id}")
+
+    def escalate() -> None:
+        control.execute(
+            _refund_action(support, "txn_5", ESCALATION_AMOUNT),
+            lambda: remote.refund("txn_5", ESCALATION_AMOUNT),
+            "refund:txn_5",
+        )
+
+    click.echo(f"   support agent requests {_euros(ESCALATION_AMOUNT)}  →")
+    blocked = _refused(escalate, AuthorityDenied)
+    click.echo(f"{_BLOCKED}outside the delegated grant ({blocked.reason})")
+    click.echo(f"   remote refund calls: {remote.calls.count('txn_5')}")
+
+    # And the delegation that would have widened it is refused at creation, on the dimension
+    # it widened — so an agent cannot reach the amount above by minting its own authority.
+    def over_delegate() -> None:
+        control.delegate(
+            finance_grant.delegation_id,
+            _delegated(ESCALATION_AMOUNT, "support-agent", "dana@example.com"),
+            by=finance,
+        )
+
+    escalation = _refused(over_delegate, AuthorityEscalation)
+    click.echo(
+        f"   finance agent tries to delegate {_euros(ESCALATION_AMOUNT)} under its own "
+        f"{_euros(FINANCE_CEILING)}  →  refused ({escalation.reason}: {escalation.dimension})"
+    )
+
+    # The control, and the point of §4.6 in one line: the same agent, the same chain, an
+    # amount it *is* entitled to. Authority permits it — and the policy still asks a human,
+    # because the two axes combine as the stricter of the pair. Without this the scenario
+    # would be consistent with a chain that authorized nothing at all.
+    def within_the_grant() -> None:
+        control.execute(
+            _refund_action(support, "txn_6", WITHIN_GRANT_AMOUNT),
+            lambda: remote.refund("txn_6", WITHIN_GRANT_AMOUNT),
+            "refund:txn_6",
+        )
+
+    pending = _refused(within_the_grant, ApprovalRequired)
+    click.echo(
+        f"   support agent requests {_euros(WITHIN_GRANT_AMOUNT)}  →  authority permits it, "
+        f"and the policy asks a human ({pending.request_id})"
+    )
+    click.echo("   two axes, and an action needs both: the stricter of the pair wins")
+
+
+def _refund_action(principal: Principal, payment_id: str, amount: int) -> Action:
+    """The Action `@protect` would build, built by hand.
+
+    Scenario 5 needs three different principals against one `Control`, and `context()` names a
+    principal rather than resolving one — so the Action is constructed directly, which is the
+    same public path a gateway or an adapter takes.
+    """
+    return Action(
+        name="stripe.refund",
+        arguments={"payment_id": payment_id, "amount": amount, "currency": "EUR"},
+        principal=principal,
+        resource=f"payment:{payment_id}",
+    )
 
 
 def _propose(refund: Callable[..., Any], payment_id: str, amount: int) -> str:

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -523,18 +523,52 @@ def test_T11_demo_runs_in_under_sixty_seconds(demo_run):
     assert elapsed < 60
 
 
-def test_T11_demo_prints_all_four_scenario_headings(demo_run):
+def test_T93_demo_prints_all_five_scenario_headings(demo_run):
     result, _, _ = demo_run
 
+    assert len(SCENARIO_HEADINGS) == 5
     for number, heading in enumerate(SCENARIO_HEADINGS, start=1):
         assert f"{number}. {heading}" in result.output
 
 
-def test_T11_demo_prints_four_blocked_lines(demo_run):
+def test_T93_demo_prints_five_blocked_lines(demo_run):
     result, _, _ = demo_run
 
     blocked = [line for line in result.output.splitlines() if "BLOCKED" in line]
-    assert len(blocked) == 4
+    assert len(blocked) == 5, "\n".join(blocked)
+
+
+def test_T93_the_fifth_scenario_blocks_on_authority_and_names_the_reason(demo_run):
+    """SPEC-v0.3 §1.2 — scenario 5 answers a different question from the other four, so its
+    refusal has to be legible as a different *kind* of refusal. A `BLOCKED` line that said
+    only "denied" would leave a reader with no way to tell the two axes apart."""
+    result, _, _ = demo_run
+
+    assert "outside the delegated grant (authority_constraint)" in result.output
+    # And the creation-time half, which is the one an agent would otherwise use to reach the
+    # amount above by minting its own permission.
+    assert "refused (containment: constraints)" in result.output
+
+
+def test_T93_the_fifth_scenario_shows_both_axes_applying_to_one_action(demo_run):
+    """§4.6 — the two combine as the stricter of the pair. Without this the scenario would be
+    consistent with a chain that authorized nothing at all, and every refusal in it would be
+    vacuous."""
+    result, _, _ = demo_run
+
+    assert "authority permits it, and the policy asks a human" in result.output
+
+
+def test_T93_the_first_four_scenarios_run_with_no_authority_section(demo_run):
+    """§4.1 — a document with no `authority:` section behaves exactly as v0.2. The demo's own
+    small proof of the opt-in rule: scenarios 1 to 4 load `DEMO_POLICY`, which declares
+    `ctrlrun.policy/v1` and has no section at all."""
+    from ctrlrun import Policy
+    from ctrlrun.cli.demo import DEMO_POLICY
+    from ctrlrun.policy import POLICY_SCHEMA
+
+    assert "authority:" not in DEMO_POLICY
+    assert Policy.from_yaml(DEMO_POLICY).schema == POLICY_SCHEMA
 
 
 def test_T11_demo_writes_receipts(demo_run):
@@ -543,7 +577,11 @@ def test_T11_demo_writes_receipts(demo_run):
     lines = _lines(evidence / "receipts.jsonl")
     assert lines
     results = [json.loads(line)["result"] for line in lines]
+    # Four `blocked` receipts, not five: scenario 5's refusals are `denied` (an authority
+    # denial *is* the action being denied) and its last action is still awaiting a human, so
+    # it has no receipt at all yet (v0.1 §6.1).
     assert results.count("blocked") == 4
+    assert results.count("denied") >= 1
     assert "committed" in results
     assert "ambiguous" in results
 
@@ -633,10 +671,11 @@ def test_a_path_outside_the_run_directory_is_printed_whole(tmp_path):
     assert written_path(tmp_path, outside) == str(outside)
 
 
-#: The only thing in the demo's output that differs between runs: generated approval ids.
-#: Evidence paths are printed relative to where the demo ran, so they are stable and the
-#: README must quote them exactly — that is what keeps an absolute path from creeping back in.
-_RUN_VARYING = re.compile(r"apr_[0-9a-f]+")
+#: The only things in the demo's output that differ between runs: generated approval ids and,
+#: since scenario 5, generated delegation ids. Evidence paths are printed relative to where
+#: the demo ran, so they are stable and the README must quote them exactly — that is what
+#: keeps an absolute path from creeping back in.
+_RUN_VARYING = re.compile(r"(?:apr|dlg)_[0-9a-f]+")
 
 
 def _readme_demo_section() -> str:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -18,6 +18,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 from ctrlrun import Policy
 from ctrlrun.policy import POLICY_SCHEMA
@@ -32,11 +33,14 @@ SCENARIOS: dict[str, str] = {
     "approval-mutation": "approved action ≠ requested action",
     "agent-race": "already reserved",
     "approval-replay": "single-use approval already consumed",
+    # SPEC-v0.3 §1.2 — the fifth answers a different question from the other four: not "is
+    # this action safe to run" but "is this principal entitled to propose it at all".
+    "authority-escalation": "outside the delegated grant",
 }
 
 #: Directories under `examples/` that are not one of §1.1's failure scenarios: the sector
 #: templates, and item 8's ACS integration example (SPEC-v0.2 §9, `docs/ACS.md`).
-NOT_A_SCENARIO = ("policies", "acs", "__pycache__")
+NOT_A_SCENARIO = ("policies", "acs", "authority", "__pycache__")
 
 #: The nine sectors of SPEC-v0.2 §1.1.
 SECTORS = (
@@ -291,3 +295,107 @@ def test_T31_every_template_has_at_least_one_deny(sector):
     text = (TEMPLATES / f"{sector}.yaml").read_text(encoding="utf-8")
 
     assert "decision: deny" in text
+
+
+# --- SPEC-v0.3 §1.2: the two authority configurations ----------------------------------
+
+AUTHORITY_EXAMPLES = EXAMPLES / "authority"
+
+
+def _authority_documents() -> list[Path]:
+    return sorted(AUTHORITY_EXAMPLES.glob("*.yaml"))
+
+
+def test_the_authority_examples_are_the_two_the_spec_names():
+    """§1.2 — a payments delegation chain and a DevOps chain."""
+    assert [path.name for path in _authority_documents()] == ["devops.yaml", "payments.yaml"]
+
+
+@pytest.mark.authority
+@pytest.mark.parametrize("path", _authority_documents(), ids=lambda path: path.stem)
+def test_each_authority_example_loads_on_both_axes(path):
+    """A document that does not load is not an example of anything. Both loaders, because
+    `Policy` never reads the `authority:` section and `Authority` never reads `actions:`."""
+    from ctrlrun import Authority
+
+    document = path.read_text(encoding="utf-8")
+
+    policy = Policy.from_yaml(document, source=str(path))
+    authority = Authority.from_yaml(document, source=str(path))
+
+    assert policy.actions
+    assert authority.grants
+
+
+@pytest.mark.authority
+@pytest.mark.parametrize("path", _authority_documents(), ids=lambda path: path.stem)
+def test_each_authority_example_declares_v3(path):
+    """§12.1 — `authority:` needs `ctrlrun.policy/v3`, and a reader that ignored the section
+    would run every action with no authority check at all."""
+    from ctrlrun.policy import POLICY_SCHEMA_V3
+
+    assert Policy.from_yaml(path.read_text(encoding="utf-8")).schema == POLICY_SCHEMA_V3
+
+
+@pytest.mark.authority
+@pytest.mark.parametrize("path", _authority_documents(), ids=lambda path: path.stem)
+def test_no_authority_example_grants_everything(path):
+    """`**` on its own is the whole surface of a system. These are documents a reader copies,
+    and a template that hands out `**` teaches the habit it exists to prevent."""
+    from ctrlrun import Authority
+
+    for grant in Authority.from_yaml(path.read_text(encoding="utf-8")).grants.values():
+        assert grant.actions != ("**",), f"{path.name}: grant {grant.id!r} grants everything"
+        assert grant.subject.agent != "**", f"{path.name}: grant {grant.id!r} names any agent"
+
+
+@pytest.mark.authority
+@pytest.mark.parametrize("path", _authority_documents(), ids=lambda path: path.stem)
+def test_every_delegable_grant_in_an_example_expires(path):
+    """§4.2 — the loader refuses `delegable: true` without `expires_at`, so this cannot fail
+    while the loader holds. It is here for what it says to a reader of the *examples*: the
+    grants that can mint more authority are the ones with the nearest dates on them."""
+    from ctrlrun import Authority
+
+    delegable = [
+        grant for grant in Authority.from_yaml(path.read_text()).grants.values() if grant.delegable
+    ]
+    assert delegable, f"{path.name} shows no delegable grant, so it shows no chain"
+    assert all(grant.expires_at is not None for grant in delegable)
+
+
+def test_the_authority_examples_carry_a_readme_that_says_they_are_not_drop_in():
+    """A grant names a real principal in a real organization. Adopting somebody else's is how
+    a template becomes an incident, and the file says so on its face."""
+    readme = (AUTHORITY_EXAMPLES / "README.md").read_text(encoding="utf-8")
+
+    assert "invented" in readme
+    assert "starting points" in readme
+
+
+@pytest.mark.parametrize("path", _authority_documents(), ids=lambda path: path.stem)
+def test_no_authority_example_makes_a_compliance_claim(path):
+    """ROADMAP's rule, extended to the v0.3 examples: no badge before the milestone that
+    earns it."""
+    text = path.read_text(encoding="utf-8").lower()
+
+    assert not [word for word in COMPLIANCE_WORDS if word in text]
+
+
+@pytest.mark.parametrize("path", _templates(), ids=lambda path: path.stem)
+def test_no_sector_template_ships_an_authority_section(path):
+    """SPEC-v0.3 §1.2 — the nine templates stay on v0.1 primitives and gain no grants.
+
+    A grant names a real principal in a real organization. A template that shipped plausible
+    ones would invite an operator to adopt them, which is the one way a starting point turns
+    into somebody else's access-control list. Each says so on its face, so a reader who came
+    looking for grants learns why there are none rather than assuming they were forgotten.
+    """
+    text = path.read_text(encoding="utf-8")
+    # The parsed document, not the raw text: the note explaining the absence names the key,
+    # and a substring check would be satisfied by a comment while a real section sat below it.
+    document = yaml.safe_load(text)
+
+    assert "authority" not in document
+    assert "No `authority:` section, deliberately" in text
+    assert Policy.from_yaml(text, source=str(path)).schema == POLICY_SCHEMA

--- a/tests/test_observe.py
+++ b/tests/test_observe.py
@@ -836,10 +836,25 @@ def test_T84_a_mistyped_mode_key_is_caught_by_the_closed_top_level_key_set():
 
 #: §6.5's two columns, by name. v0.3 moves no command across the line.
 LOADS_THE_POLICY = ("gateway", "stats", "delegate", "revoke", "verify")
-DOES_NOT = ("init", "demo", "approve", "deny", "receipts", "effects", "resolve", "inspect")
+DOES_NOT = (
+    "init",
+    # `ctrlrun demo` builds an `authority:` section of its own for scenario 5 (SPEC-v0.3
+    # §1.2), so it may legitimately append the §7 event types. Marked here rather than on the
+    # whole test, so T66's guard still covers the other seven commands: a leak from
+    # `receipts` or `inspect` must still fail.
+    pytest.param("demo", marks=pytest.mark.authority),
+    "approve",
+    "deny",
+    "receipts",
+    "effects",
+    "resolve",
+    "inspect",
+)
 
 #: Enough arguments for each command to reach its body. Several exit non-zero against an
 #: empty store, which is the point: the banner is printed before anything else.
+#: Keyed by command name; `DOES_NOT` carries a `pytest.param` for one of them, so the ids the
+#: parametrization produces are the plain names either way.
 ARGUMENTS = {
     "gateway": ("--upstream", "http://127.0.0.1:1/mcp", "--alias", "acme", "--principal", "bot"),
     "stats": (),

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -348,3 +348,74 @@ def test_MissingDependency_names_the_extra_and_the_command():
 
     assert "httpx" in str(error)
     assert "pip install 'ctrlrun[gateway]'" in str(error)
+
+
+# --- the sdist carries what the tests read (SPEC-v0.2 §1.1) -----------------------------
+
+
+def _manifest_patterns() -> tuple[list[tuple[str, str]], set[str]]:
+    """`MANIFEST.in`'s `recursive-include` pairs and its plain `include` files."""
+    recursive: list[tuple[str, str]] = []
+    plain: set[str] = set()
+    for line in (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8").splitlines():
+        parts = line.split()
+        if not parts or parts[0].startswith("#"):
+            continue
+        if parts[0] == "recursive-include" and len(parts) >= 3:
+            recursive += [(parts[1], pattern) for pattern in parts[2:]]
+        elif parts[0] == "include":
+            plain.update(parts[1:])
+    return recursive, plain
+
+
+def test_the_sdist_carries_everything_the_tests_read():
+    """Every tracked file under `examples/` and `docs/` matches a `MANIFEST.in` include.
+
+    `MANIFEST.in` has claimed for two releases that a test named this one keeps it honest,
+    and there was no such test — so the first file it forgot was found by the CI job that
+    builds an sdist and runs its tests, one push after it could have been found here. That is
+    the same shape as v0.2's four `.gitignore`d policy files: setuptools resolves
+    `MANIFEST.in` against the working tree, so a local run is green either way.
+
+    Checked against **git**, not the filesystem, for the same reason: an untracked file is not
+    in a fresh clone whatever this file says about it.
+    """
+    import fnmatch
+
+    tracked = subprocess.run(
+        ["git", "ls-files", "examples", "docs"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if tracked.returncode != 0:  # pragma: no cover - not a checkout
+        pytest.skip("no repository checkout")
+    recursive, plain = _manifest_patterns()
+
+    missing = [
+        path
+        for path in tracked.stdout.split()
+        if path not in plain
+        and not any(
+            path.startswith(f"{directory}/") and fnmatch.fnmatch(Path(path).name, pattern)
+            for directory, pattern in recursive
+        )
+    ]
+
+    assert not missing, f"MANIFEST.in does not ship: {sorted(missing)}"
+
+
+def test_the_manifest_check_would_notice_a_file_it_does_not_ship():
+    """The control. A check whose only evidence is a green suite is a check nothing
+    exercises, and this one is only ever *not* triggered."""
+    import fnmatch
+
+    recursive, plain = _manifest_patterns()
+    invented = "examples/authority/notes.rst"
+
+    assert invented not in plain
+    assert not any(
+        invented.startswith(f"{directory}/") and fnmatch.fnmatch("notes.rst", pattern)
+        for directory, pattern in recursive
+    )

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -16,6 +16,7 @@ import hmac
 import json
 import threading
 import time
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
@@ -266,22 +267,29 @@ def test_T27_a_valid_deny_moves_the_request_to_denied(store, receiver):
     assert store.get_approval(request.request_id).status is ApprovalStatus.DENIED
 
 
-@pytest.mark.parametrize(
-    "overrides",
-    [
-        {"signature": "t=1,v1=deadbeef"},
-        {"signature": "nonsense"},
-        {"signature": ""},
-        {"at": datetime.now(UTC) - timedelta(seconds=400)},
-        {"at": datetime.now(UTC) + timedelta(seconds=400)},
-        {"body_request_id": "apr_somethingelse"},
-        {"action_hash": "sha256:" + "0" * 64},
-    ],
-)
-def test_T27_every_broken_condition_is_400_and_changes_nothing(store, receiver, overrides):
+#: Each way an inbound approval can be broken, as a *factory*. Not a literal `overrides`
+#: dict, because two of these are timestamps: a parametrize list is evaluated at **collection**
+#: time, so `datetime.now(UTC) + timedelta(seconds=400)` is 400 seconds ahead of collection
+#: and only `400 - <however long the suite has been running>` seconds ahead by the time this
+#: test executes. Past the replay window's 300 seconds of runtime it lands *inside* the window
+#: and the refusal under test stops happening — a time bomb whose fuse is the suite's own
+#: duration, which duly fired the first time an item made the suite slower.
+_BROKEN_CONDITIONS: dict[str, Callable[[], dict[str, object]]] = {
+    "bad-signature": lambda: {"signature": "t=1,v1=deadbeef"},
+    "unparseable-signature": lambda: {"signature": "nonsense"},
+    "no-signature": lambda: {"signature": ""},
+    "too-old": lambda: {"at": datetime.now(UTC) - timedelta(seconds=400)},
+    "too-far-ahead": lambda: {"at": datetime.now(UTC) + timedelta(seconds=400)},
+    "wrong-request-id": lambda: {"body_request_id": "apr_somethingelse"},
+    "wrong-action-hash": lambda: {"action_hash": "sha256:" + "0" * 64},
+}
+
+
+@pytest.mark.parametrize("condition", sorted(_BROKEN_CONDITIONS))
+def test_T27_every_broken_condition_is_400_and_changes_nothing(store, receiver, condition):
     request = _pending(store, receiver)
 
-    status, _ = _inbound(store, request, **overrides)
+    status, _ = _inbound(store, request, **_BROKEN_CONDITIONS[condition]())
 
     assert status == 400
     assert store.get_approval(request.request_id).status is ApprovalStatus.PENDING


### PR DESCRIPTION
Build-list item 6. SPEC-v0.3 §1.2. T93.

## `ctrlrun demo` gains a fifth scenario

The first four ask whether an *action* is safe to run. This one asks whether a *principal* is entitled to propose it — which is a different question, and a system that can only ask the first will eventually answer the second by accident.

```
5. Authority escalation

   human €100,000 delegable  →  finance agent €25,000  →  support agent €2,000
   support agent's grant: dlg_5f8d…
   support agent requests €50,000  →
   ✗ BLOCKED — outside the delegated grant (authority_constraint)
   remote refund calls: 0
   finance agent tries to delegate €50,000 under its own €25,000  →  refused (containment: constraints)
   support agent requests €1,500  →  authority permits it, and the policy asks a human (apr_f86e…)
   two axes, and an action needs both: the stricter of the pair wins
```

**Both refusals, because they are different guards at different moments.** €50,000 is refused at *evaluation*; minting €50,000 under a €25,000 parent is refused at *creation*, naming the dimension it widened. Asserting only the first would hide the second — and the second is the one that matters, because an agent able to delegate more than it holds reaches the first amount by minting its own permission, with every evaluation-time check still passing.

The last line is the control as much as the lesson: an amount the grant *does* permit, which the policy still stops to ask a human about. Without it the scenario would be consistent with a chain that authorized nothing at all, and every refusal in it would be vacuous.

## Examples and docs

- **`examples/authority-escalation/`** — the same story standalone, with the `else: raise SystemExit(...)` guard behind every refusal, including one that fails loudly if an amount *inside* the grant is refused: a chain that authorizes nothing proves nothing.
- **`examples/authority/`** — `payments.yaml` and `devops.yaml`, complete documents to read rather than run. The README's first paragraph says every principal in them is invented. Tests assert both load on both axes, declare `v3`, never grant `**`, and that every `delegable` grant expires.
- **`docs/authority.md`** — grants, delegation and the omission rule in plain language, with its own section on why an omitted dimension is *rejected* rather than inherited (most systems inherit; that makes the safe reading of a document depend on a document you are not looking at).
- **`docs/THREAT_MODEL.md`** — v0.3's boundary on both sides. In scope through to signing-key provenance. Out of scope and **stated rather than implied**: a compromised identity provider, a trusted header behind a proxy that does not overwrite it, a revoked token before its `exp`, a tenant-templated issuer, authority across an A2A hop.
- **The nine sector templates** stay on v0.1 primitives and now say on their face why they carry no grants.

## Two things the tests caught

- **Scenario 5 built a second `Control` and dropped the JSONL sink.** The demo printed `Receipts (8)` from the store while the file it points the reader at held 7. A false green in a transcript people paste into issues. It now shares the store *and* the sinks.
- **T66's session guard fired on `ctrlrun demo`** — correctly, since the demo now builds an `authority:` section. Marked on that one parametrization rather than on the whole test, so a leak from `receipts` or `inspect` still fails.

The README's demo transcript is asserted verbatim against the real output, so it is updated here too, and `_RUN_VARYING` learned about `dlg_` ids.

## Verification

`ruff format --check`, `ruff check`, `mypy --strict src/` clean. **1872 tests pass.** Every example runs in a subprocess whose `sitecustomize` refuses every socket, keeps state under its own directory, is repeatable, and has every file it needs tracked by git — the last of which failed first, which is exactly what that guard is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)