### PR TITLE
release: 0.3.0rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ any change to one appears here.
 
 Nothing yet.
 
-## [0.3.0] — 2026-09-04 — Authority
+## [0.3.0] — unreleased — Authority
+
+`0.3.0rc1` is this section, published to TestPyPI only, so the wheel and the sdist can be
+installed from a real index before a version number that can never be reused is spent on
+PyPI. The date lands when `0.3.0` is cut.
 
 **Who is acting, and what are they entitled to?** v0.1 built the kernel and v0.2 put it in the
 network path; both could see the action and nothing else. This release adds a second axis —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ctrlrun"
-version = "0.3.0"
+version = "0.3.0rc1"
 description = "Make consequential AI-agent actions safe to execute."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version `0.3.0` → `0.3.0rc1`. Changelog heading dated `unreleased` until the real cut.

## Why an rc

`0.3.0` is the largest surface this project has shipped — authority, delegation, JWT verification, gateway rewiring — and it is the release where an independent review found a **critical hole in code that carried a comment asserting it was safe** (the JWKS fetch followed redirects, because `build_opener(HTTPSHandler(...))` keeps its `HTTPRedirectHandler`). The fix is in and tested. The release is still young.

A PyPI version number can never be reused. An rc costs one version bump and buys an install of the real wheel and the real sdist, from a real index, into a clean venv.

## What the tag will do

`publish.yml` reads the version out of `pyproject.toml` and refuses a tag that does not match it, then:

- `Version('0.3.0rc1').is_prerelease` → **true**, so the `testpypi` job runs and the `pypi` job is skipped by its own `if`. **Nothing reaches PyPI.**
- Before either, it re-runs the release gates against the artifacts about to be uploaded rather than against the working tree: `twine check --strict`, the sdist installing with all extras and running its own tests, and the README quick start from the built wheel.

## Verification on this branch

1876 tests pass; `ruff check` clean. Already verified from a fresh clone into a temp directory at #30: full suite, `mypy --strict`, demo in 0.65s, core install pulling exactly `PyYAML` and `click`, `import ctrlrun` leaking no extra, all three extras installing alone, quick start from a wheel, sdist running its own tests.

## After this

Tag `v0.3.0rc1`, confirm the TestPyPI install by hand, then bump back to `0.3.0` and cut `v0.3.0` — which is the one that publishes, and which I will not do without being told.

🤖 Generated with [Claude Code](https://claude.com/claude-code)