### PR TITLE
verify: the guarantee catalogue, the scenario engine and all ten guarantees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,48 @@ any change to one appears here.
 
 ### Added
 
+- **`ctrlrun verify`** — the guarantee catalogue, the scenario engine and all ten guarantees
+  (SPEC-v0.4 §2, §3). `ctrlrun.verify` is **core**: stdlib, `pyyaml` and `click`, because a
+  verification tool that needed an extra installed is one half the deployments never run. It is
+  not re-exported from `ctrlrun` and `import ctrlrun` does not import it.
+
+  It reads the operator's policy document, and the authority document beside it where
+  `--authority` names one, derives concrete actions, principals and delegations the
+  configuration actually admits, and runs the failure scenarios of `v0.1 §7`, `v0.2 §10` and
+  `v0.3 §10` against them — in a scratch store, with in-process fake executors, reaching no
+  network. `G1` mutated approval refused · `G2` replayed approval refused · `G3` duplicate
+  effect refused · `G4` one winner under concurrency, across real OS processes · `G5` ambiguous
+  blocks a blind retry · `G6` unknown action refused · `G7` no principal refused · `G8` expired
+  authority refused · `G9` delegation cannot escalate, on every dimension the parent constrains
+  including the omission case · `G10` unknown exception is ambiguous, never failed.
+
+  **Every guarantee carries a positive control.** A refusal is satisfied just as well by a
+  scenario in which nothing ever ran, and that scenario passes against a kernel with the guard
+  deleted — so each scenario runs a companion establishing that the observable would have been
+  visible had the guard not fired. A control that does not behave as specified makes the
+  guarantee `fail` with `reason: "control failed"`: never a pass, and never an N/A.
+
+  There is no randomness anywhere — not seeded randomness, none. Selection is sorted by
+  codepoint, values come from a fixed table, the candidate search is bounded at 64, and two runs
+  against one document produce byte-identical JSON once the timestamps are removed.
+
+- `ctrlrun verify [--authority PATH] [--json] [--junit PATH] [--only G1,G3] [--store-url URL]`,
+  replacing the v0.3 stub. Exit codes: 0 every applicable guarantee passed and at least one was
+  applicable, 1 a guarantee failed, 2 the configuration was refused or is unusable, 3 an
+  internal error in verify itself.
+
+### Changed
+
+- **`docs/SPEC-v0.3.md` §10 T85 is amended**, as SPEC-v0.4 §9.4 item 2 requires and in the
+  commit that made it true: `ctrlrun verify` exits 2 under `mode: observe` with a message naming
+  the mode, and runs under `mode: enforce`. The banner assertions for every other command are
+  untouched. A frozen test whose subject was explicitly temporary is amended rather than
+  deleted.
+- **`docs/SPEC-v0.3.md` §4.3.1 gains an informational row** for `ctrlrun.verify.run` (SPEC-v0.4
+  §3.9, §9.4 item 3). Verify is not a new entry point: it proposes no action of its own and
+  drives the rows already there. The row exists because a reader will look for one.
+- `docs/ARCHITECTURE.md` §6's module map gains `verify/`, above `control.py` and beside `cli/`.
+
 - **`docs/SPEC-v0.4.md`** — the v0.4 contract, a delta over v0.1, v0.2 and v0.3. v0.4 answers
   the question the first three releases could not: *does it hold in **my** setup?* Everything
   CTRLRun guarantees is proven today by this repository's tests against this repository's

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -156,9 +156,15 @@ Pragmas: `journal_mode=WAL`, `busy_timeout=5000`, `synchronous=NORMAL`.
 | `state.py` | `StateStore` protocol + SQLite/in-memory impls | policy, decorator, sinks |
 | `control.py` | `Control` orchestration, decorator, context, suspend/resume | CLI |
 | `receipt.py` | Receipt/Event models, `EventSink`, JSONL sink | everything else |
+| `verify/` | the guarantee registry, scenario derivation, the scratch store, reporting | the gateway, `otel`, `jwt_identity`; anything from an extra |
 | `cli/` | click commands, demo | internals beyond `Control` |
 
 Dependencies point downward only. `Control` is the only module that composes the others.
+
+`verify/` (v0.4) sits **above** `control.py`, beside `cli/`: it composes `Control`, `Policy` and
+`Authority` the way an application does, and nothing in the kernel imports it. `import ctrlrun`
+does not import `ctrlrun.verify`, which is asserted in a subprocess — a verification tool in the
+execution path is a dependency nobody meant to take.
 
 The gateway (v0.2) does not change this. It builds an Action and calls `Control` — including
 `Control.resume` for an elicitation's second leg — rather than reserving and committing for

--- a/docs/SPEC-v0.3.md
+++ b/docs/SPEC-v0.3.md
@@ -1046,6 +1046,12 @@ implementer that delegation is authenticated.
 | `Control.delegate` / `Control.revoke` | no — creates authority | checks `by` is unexpired (§5.3 rule 0) | the six checks of §5.3 |
 | The gateway's `tools/call` | yes | yes (§8.2) | yes, before the approval gate (§8.3) |
 | `ctrlrun.acs`'s request hook | yes | yes (§8.4) | yes, before the approval gate (§8.3) |
+| `ctrlrun.verify.run` | no - it drives the rows above | no - it synthesizes principals for a scratch store | no - it asserts that the rows above do |
+
+The last row is **informational**, added by `SPEC-v0.4.md` §3.9 and §9.4. `ctrlrun verify`
+proposes no action of its own: it constructs `Control` objects against a scratch store and calls
+the entry points already listed, asserting that each applies the checks this table requires. It
+is in the table because a reader will look for it, not because it is a new way in.
 
 **A new entry point is a specification amendment before it is code.** Adding one — a framework
 adapter, a second protocol, a batch runner — means adding a row here and saying what it does about

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,12 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "ANN", "SIM", "RUF"]
 # importing it at module scope. The claims themselves are untyped JSON off somebody else's
 # wire, validated at the boundary before anything reaches a `Principal`.
 "src/ctrlrun/jwt_identity.py" = ["ANN401"]
+# `verify` drives the kernel with values it synthesized from somebody's YAML: an argument is
+# `str | int | bool | None` by SPEC-v0.1 §2.3 and nothing narrower, and a fake executor's
+# return value has no type at all — the same reasoning that exempts `state.py`. N818: the
+# refusal names follow this codebase's convention (DuplicateEffect, AmbiguousEffect), not the
+# suffix rule, as `errors.py` already does.
+"src/ctrlrun/verify/*.py" = ["ANN401", "N818"]
 # Type hints are a src/ constraint; tests stay cheap to write. N802 lets acceptance
 # tests carry the SPEC §7 identifier verbatim (test_T7_...).
 "tests/*" = ["ANN", "N802"]

--- a/src/ctrlrun/cli/main.py
+++ b/src/ctrlrun/cli/main.py
@@ -25,7 +25,7 @@ from ..approval import ApprovalRecord
 from ..authority import Delegation, grant_from_yaml
 from ..control import DEFAULT_STATE_DIR, Control, state_path
 from ..effect import RESOLVED_BY_HUMAN, EffectRecord, EffectState
-from ..errors import AuthorityEscalation, CTRLRunError
+from ..errors import AuthorityEscalation, CTRLRunError, PolicyError
 from ..policy import DEFAULT_POLICY_FILENAME, OBSERVE, Decision, Policy
 from ..receipt import (
     BLOCKED_APPROVAL_REQUIRED,
@@ -640,20 +640,80 @@ def _breakdown(counts: Mapping[str, int]) -> list[str]:
 
 
 @main.command()
-def verify() -> None:
-    """Not yet: verification of an evidence file lands in v0.4.
+@click.option(
+    "--authority",
+    "authority_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="A standalone authority document, as `ctrlrun gateway --authority` takes.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit one ctrlrun.verify/v1 document.")
+@click.option(
+    "--junit",
+    "junit_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Also write a JUnit XML file for CI.",
+)
+@click.option("--only", default="", help="Comma-separated guarantee ids, e.g. G1,G3.")
+@click.option("--store-url", "store_url", default=None, help="Reserved; v0.4 accepts 'sqlite'.")
+def verify(
+    authority_path: Path | None,
+    as_json: bool,
+    junit_path: Path | None,
+    only: str,
+    store_url: str | None,
+) -> None:
+    """Run the declared guarantees against this configuration (SPEC-v0.4).
 
-    It exists here because observe mode's whole purpose is to lead somewhere, and the command
-    an operator reaches for next should not be a `No such command` error that suggests they
-    mistyped (SPEC-v0.3 §6.5). It runs nothing, checks nothing, and claims nothing.
+    Every scenario runs against a scratch store created and destroyed for the run. The store
+    an agent is using is not opened, not read and not created.
+
+    Exit codes: 0 every applicable guarantee passed and at least one was applicable; 1 a
+    guarantee FAILED; 2 the configuration was refused or is unusable — which includes
+    `mode: observe` and a configuration in which nothing could be exercised; 3 an internal
+    error in verify itself.
     """
-    _loaded_policy()
-    click.echo(
-        "ctrlrun verify lands in 0.4. It does not exist yet: nothing was checked and nothing "
-        "is claimed about this store.",
-        err=True,
-    )
-    raise SystemExit(2)
+    # Imported here, not at module scope: verify is an operator's tool and not part of the
+    # action path, and `import ctrlrun` must not reach it (SPEC-v0.4 §1, T125b).
+    from ..verify import VerifyInternalError, VerifyRefused
+    from ..verify import run as run_verify
+
+    try:
+        # The banner first, for every invocation, exactly as SPEC-v0.3 §6.5 requires — and
+        # then, under observe mode, `run` refuses. `ctrlrun verify` stays in the left column.
+        _loaded_policy()
+    except PolicyError as exc:
+        click.echo(f"ctrlrun verify: {exc}", err=True)
+        raise SystemExit(2) from exc
+
+    try:
+        report = run_verify(
+            None,
+            authority=authority_path,
+            only=(only,) if only else (),
+            store_url=store_url,
+        )
+    except VerifyRefused as refused:
+        click.echo(f"ctrlrun verify: {refused}", err=True)
+        raise SystemExit(2) from refused
+    except VerifyInternalError as internal:
+        click.echo(f"ctrlrun verify: internal error: {internal}", err=True)
+        raise SystemExit(3) from internal
+
+    if junit_path is not None:
+        junit_path.write_text(report.to_junit(), encoding="utf-8")
+    click.echo(report.to_json() if as_json else report.to_text())
+    if report.exit_code == 2:
+        # §3.8 — the only exit-2 the report itself can produce. Said on stderr, so a `--json`
+        # stdout stays parseable: `0/0` reported as success is the same false green as `8/8`
+        # with five N/As.
+        click.echo(
+            "ctrlrun verify: no guarantee in the catalogue is applicable to this "
+            "configuration, so nothing was checked and nothing is claimed.",
+            err=True,
+        )
+    raise SystemExit(report.exit_code)
 
 
 @main.command()

--- a/src/ctrlrun/verify/__init__.py
+++ b/src/ctrlrun/verify/__init__.py
@@ -1,0 +1,165 @@
+"""`ctrlrun verify` — the operator's own configuration, against the kernel's own refusals.
+
+SPEC-v0.4 §1, §9.1. Core: stdlib, `pyyaml` and `click`, and **not** re-exported from
+`ctrlrun`. A verification tool behind an extra is one half the deployments never run, so this
+is not optional; but it is an operator's tool and not part of the action path, so `import
+ctrlrun` must not import it and nothing in the kernel may come to depend on it (T125b).
+
+`verify/` sits **above** `control.py`, beside `cli/`: it composes `Control`, `Policy` and
+`Authority` the way an application does, and it proposes no action of its own — it drives the
+entry points `v0.3 §4.3.1` already enumerates and asserts that each applies the checks that
+table requires (§3.9).
+
+There is **no flag that relaxes a check**. No argument, no environment variable, nothing that
+makes verify's `Control` behave differently from the operator's. The moment one exists, the
+thing being verified is not the thing that ships.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+
+from ..policy import OBSERVE
+from . import guarantees as reg
+from .report import Counterexample, GuaranteeResult, Report, Status
+from .scenarios import (
+    SQLITE_STORE_URL,
+    Engine,
+    VerifyInternalError,
+    VerifyRefused,
+    load,
+)
+
+__all__ = [
+    "Counterexample",
+    "GuaranteeResult",
+    "Report",
+    "Status",
+    "VerifyInternalError",
+    "VerifyRefused",
+    "run",
+]
+
+
+def _version() -> str:
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        return version("ctrlrun")
+    except PackageNotFoundError:  # pragma: no cover - a source tree with no install
+        return "0.0.0"
+
+
+def _selected(only: Sequence[str]) -> tuple[str, ...] | None:
+    """§4.6 — the ids `--only` names, or `None` for the whole catalogue.
+
+    An id outside the registry exits 2 naming the id and the registry: silently ignoring one
+    would run fewer guarantees than the operator asked for and report success.
+    """
+    if not only:
+        return None
+    chosen: list[str] = []
+    for raw in only:
+        for part in str(raw).split(","):
+            name = part.strip()
+            if not name:
+                continue
+            if name not in reg.BY_ID:
+                raise VerifyRefused(
+                    f"--only names {name!r}, which is not in {reg.CATALOGUE}. The registry is "
+                    f"{', '.join(reg.BY_ID)}"
+                )
+            if name not in chosen:
+                chosen.append(name)
+    if not chosen:
+        raise VerifyRefused("--only was given no guarantee id")
+    return tuple(chosen)
+
+
+def run(
+    config: str | os.PathLike[str] | None = None,
+    *,
+    authority: str | os.PathLike[str] | None = None,
+    only: Sequence[str] = (),
+    store_url: str | None = None,
+) -> Report:
+    """Run the applicable guarantees against this configuration and report (§9.1).
+
+    Raises `VerifyRefused` where the configuration is refused or unusable (exit 2) and
+    `VerifyInternalError` where verify itself is at fault (exit 3). Everything else — a
+    guarantee that failed, a guarantee that could not be exercised — is in the `Report`.
+
+    The scratch directory is removed when the run ends, **including when it ends by
+    exception**. The operator's store is not opened, not read and not created (§3.5, T103).
+    """
+    selection = _selected(only)
+    if store_url is not None and store_url.strip() not in ("", SQLITE_STORE_URL):
+        raise VerifyRefused(
+            f"--store-url {store_url!r} names a backend v0.4 does not have. The only value is "
+            f"{SQLITE_STORE_URL!r}; a second store backend is v0.6 (SPEC-v0.4 §3.1)"
+        )
+    loaded = load(config, authority)
+    if loaded.policy.mode == OBSERVE:
+        # §3.8 — running the scenarios and reporting ten failures would be true and useless;
+        # running them in a synthetic enforce mode would report guarantees about a
+        # configuration nobody deployed. The message names the one-line edit.
+        raise VerifyRefused(
+            f"{loaded.policy_path} declares 'mode: observe'. Observe mode enforces nothing, so "
+            "there is nothing to verify: every refusal these guarantees assert would be "
+            "recorded rather than made. Change the top-level 'mode:' to 'enforce' and run "
+            "again (SPEC-v0.4 §3.8)"
+        )
+
+    started_at = datetime.now(UTC)
+    scratch = Path(tempfile.mkdtemp(prefix="ctrlrun-verify-"))
+    results: list[GuaranteeResult] = []
+    try:
+        engine = Engine(loaded, scratch)
+        for guarantee in reg.GUARANTEES:
+            if selection is not None and guarantee.id not in selection:
+                results.append(
+                    GuaranteeResult(
+                        id=guarantee.id,
+                        title=guarantee.title,
+                        status=Status.SKIPPED,
+                        reason=reg.NOT_SELECTED,
+                        descends_from=guarantee.descends_from,
+                    )
+                )
+                continue
+            scenario = getattr(engine, guarantee.id.lower())
+            results.append(scenario())
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+    finished_at = datetime.now(UTC)
+
+    return Report(
+        guarantees=tuple(results),
+        policy={
+            "path": str(loaded.policy_path),
+            "sha256": loaded.policy_sha,
+            "schema": loaded.policy.schema,
+            "mode": loaded.policy.mode,
+            "actions": len(loaded.policy.actions),
+        },
+        authority=(
+            None
+            if loaded.authority is None
+            else {
+                "path": str(loaded.authority_path),
+                "sha256": loaded.authority_sha,
+                "grants": len(loaded.authority.grants),
+                "max_delegation_depth": loaded.authority.max_delegation_depth,
+            }
+        ),
+        store={"backend": SQLITE_STORE_URL, "scratch": True},
+        started_at=started_at,
+        finished_at=finished_at,
+        ctrlrun_version=_version(),
+        partial=selection is not None,
+    )

--- a/src/ctrlrun/verify/guarantees.py
+++ b/src/ctrlrun/verify/guarantees.py
@@ -1,0 +1,127 @@
+"""The closed guarantee catalogue, `ctrlrun.guarantees/v1`. SPEC-v0.4 §2.
+
+Ten entries, ordered, versioned, and permanent: a guarantee that is removed leaves its number
+retired, and a guarantee that is added takes the next one (§2.3). Nothing here runs anything —
+the registry states *what* is claimed, `scenarios.py` states how it is exercised, and
+`report.py` states how it is rendered.
+
+Every N/A reason in this module is a statement about the operator's **document**. A scenario
+that could not be built for any other cause is an internal error and exits 3 (§3.2, §3.8), so
+none of these strings is ever reachable from a failure of verify itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+#: SPEC-v0.4 §2.3 — the catalogue identifier. It appears in every report and on nothing else.
+CATALOGUE: Final = "ctrlrun.guarantees/v1"
+
+
+@dataclass(frozen=True)
+class Guarantee:
+    """One entry: a permanent id, the line a report prints, and its ancestry (§2.1).
+
+    `descends_from` is not decoration. §2.3 makes a guarantee "a refusal the specification
+    already requires", so every entry names the acceptance tests it is the deployed form of;
+    an entry that could not name one would be a feature request wearing a guarantee's clothes.
+    """
+
+    id: str
+    title: str
+    descends_from: tuple[str, ...]
+
+
+GUARANTEES: Final = (
+    Guarantee("G1", "mutated approval refused", ("v0.1 §7 T2",)),
+    Guarantee("G2", "replayed approval refused", ("v0.1 §7 T4", "v0.1 §7 T12")),
+    Guarantee("G3", "duplicate effect refused", ("v0.1 §5.3 E2", "v0.2 §10 T14")),
+    Guarantee("G4", "one winner under concurrency", ("v0.1 §7 T3",)),
+    Guarantee("G5", "ambiguous blocks a blind retry", ("v0.1 §7 T1", "v0.1 §7 T8")),
+    Guarantee("G6", "unknown action refused", ("v0.1 §7 T6",)),
+    Guarantee("G7", "no principal refused", ("v0.1 §2.1", "v0.2 §10 T21", "v0.3 §10 T62")),
+    Guarantee("G8", "expired authority refused", ("v0.3 §10 T71",)),
+    Guarantee("G9", "delegation cannot escalate", ("v0.3 §10 T76", "v0.3 §10 T81", "v0.3 §10 T75")),
+    Guarantee("G10", "unknown exception is ambiguous", ("v0.1 §5.5", "v0.1 §7 T1", "v0.1 §7 T8")),
+)
+
+#: By id, for `--only` and for the report. Insertion order is catalogue order.
+BY_ID: Final = {guarantee.id: guarantee for guarantee in GUARANTEES}
+
+#: How many OS processes G4 contends with (§2.2, §3.6 — every loop is bounded).
+PROCESSES: Final = 8
+
+#: How many candidate argument vectors the synthesizer tries per action (§3.3).
+CANDIDATE_BOUND: Final = 64
+
+#: The prefix on every value verify invents, so a value that ever appeared where it should not
+#: have is recognizable on sight (§3.3).
+SYNTHETIC_PREFIX: Final = "ctrlrun-verify"
+
+
+# --- N/A reasons: statements about the configuration, never about a failed run (§2.1) ---
+
+NO_APPROVE_RULE: Final = "no action requires approval"
+NO_EFFECT_TEMPLATE: Final = "no action declares an `effect:` template"
+
+#: The sentence that makes G3's N/A actionable rather than mysterious (§2.2). It travels in
+#: `detail.note` on every guarantee the missing template takes out, and the human report
+#: prints it once, where §4.1's example puts it.
+EFFECT_TEMPLATE_NOTE: Final = (
+    "in a `ctrlrun.policy/v1` document the template lives in the @protect decorator, "
+    "which verify does not read"
+)
+
+NO_ACTIONS: Final = (
+    "the policy lists no action, so an unknown action is indistinguishable from a known one"
+)
+EVERY_ACTION_DENIED: Final = "every action in the policy is denied"
+NO_AUTHORITY_SECTION: Final = "no authority section"
+NO_EXPIRES_AT: Final = "no grant declares an expires_at"
+NO_GRANT_MATCHES: Final = "no grant matches any action in the policy"
+NO_DELEGABLE_GRANT: Final = "no grant is delegable"
+
+#: G4's second N/A (§2.2). No backend in v0.4 reaches it — `SQLiteStateStore` refuses
+#: `:memory:` precisely so that it cannot — and the row exists so a v0.6 backend that cannot
+#: make the guarantee reports N/A rather than a green it did not earn.
+PER_CONNECTION_BACKEND: Final = (
+    "the configured store backend is per-connection and cannot reserve across processes"
+)
+
+#: G4 runs its children under the real clock (§2.2), so a grant that lapsed before this run
+#: cannot cover them. A statement about the document plus the wall clock, and reported rather
+#: than run into a false red.
+GRANT_ALREADY_EXPIRED: Final = (
+    "the grant covering this action expired before this run, and G4's processes cannot share "
+    "an injected clock"
+)
+
+#: `--only` (§4.6).
+NOT_SELECTED: Final = "not selected"
+
+#: §1.3 — the fourth rule. Never a pass, and never an N/A.
+CONTROL_FAILED: Final = "control failed"
+
+__all__ = [
+    "BY_ID",
+    "CANDIDATE_BOUND",
+    "CATALOGUE",
+    "CONTROL_FAILED",
+    "EFFECT_TEMPLATE_NOTE",
+    "EVERY_ACTION_DENIED",
+    "GRANT_ALREADY_EXPIRED",
+    "GUARANTEES",
+    "NOT_SELECTED",
+    "NO_ACTIONS",
+    "NO_APPROVE_RULE",
+    "NO_AUTHORITY_SECTION",
+    "NO_DELEGABLE_GRANT",
+    "NO_EFFECT_TEMPLATE",
+    "NO_EXPIRES_AT",
+    "NO_GRANT_MATCHES",
+    "PER_CONNECTION_BACKEND",
+    "PROCESSES",
+    "SYNTHETIC_PREFIX",
+    "Guarantee",
+]

--- a/src/ctrlrun/verify/report.py
+++ b/src/ctrlrun/verify/report.py
@@ -1,0 +1,402 @@
+"""The report and its three renderings. SPEC-v0.4 §4.
+
+`run()` performs the work and returns a `Report`; rendering it costs nothing and can be done
+more than once. `exit_code` lives here rather than in the CLI so §4.4 has one implementation,
+and so a caller embedding verify in their own tool reaches the same answer the command does.
+
+Every enum renders **by value** (§4, T117), which is `v0.1 §6.1`'s rule applied to a new
+document: evidence has to be readable by something that never imported CTRLRun.
+"""
+
+from __future__ import annotations
+
+import json
+import xml.etree.ElementTree as ElementTree
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, Final
+
+from .guarantees import CATALOGUE, EFFECT_TEMPLATE_NOTE, GUARANTEES
+
+#: SPEC-v0.4 §4.2 — the schema of one `ctrlrun verify --json` document.
+REPORT_SCHEMA: Final = "ctrlrun.verify/v1"
+
+#: §4.3 — the JUnit suite and class names, fixed so a CI dashboard's history is stable.
+SUITE_NAME: Final = "ctrlrun.verify"
+CLASS_NAME: Final = "ctrlrun.guarantees"
+
+#: §5.2 — the two Shields colours. There is no amber for N/A: the badge's colour is about
+#: failures, and the N/A count lives in the report the badge links to.
+BADGE_PASS_COLOR: Final = "brightgreen"
+BADGE_FAIL_COLOR: Final = "red"
+BADGE_LABEL: Final = "CTRLRun"
+
+_TITLE_WIDTH: Final = 32
+
+
+class Status(StrEnum):
+    """The closed set of four (§4). `SKIPPED` exists only under `--only` (§4.6)."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    NOT_APPLICABLE = "not_applicable"
+    SKIPPED = "skipped"
+
+
+@dataclass(frozen=True)
+class Counterexample:
+    """Enough evidence to reproduce a violation without rerunning verify (§4.5).
+
+    `receipts` and `events` are the portable JSON of `receipt.py` — the same documents
+    `ctrlrun inspect` emits — in `event_id` order, for the scenario's actions only. One
+    receipt cannot show a double execution, which is why T104 asserts both are present.
+    """
+
+    expected: str
+    observed: str
+    receipts: tuple[Mapping[str, Any], ...] = ()
+    events: tuple[Mapping[str, Any], ...] = ()
+    effects: tuple[Mapping[str, Any], ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "expected": self.expected,
+            "observed": self.observed,
+            "receipts": [dict(item) for item in self.receipts],
+            "events": [dict(item) for item in self.events],
+            "effects": [dict(item) for item in self.effects],
+        }
+
+    def to_text(self) -> str:
+        """The rendered form the human report indents and the JUnit failure text carries."""
+        lines = [f"expected: {self.expected}", f"observed: {self.observed}"]
+        for receipt in self.receipts:
+            lines.append(
+                f"receipt {receipt.get('receipt_id')} {receipt.get('action')} "
+                f"result={receipt.get('result')} decision={receipt.get('decision')} "
+                f"effect_key={receipt.get('effect_key')} attempt={receipt.get('attempt')}"
+            )
+        for effect in self.effects:
+            lines.append(
+                f"effect {effect.get('effect_key')} state={effect.get('state')} "
+                f"attempt={effect.get('attempt')}"
+            )
+        for event in self.events:
+            lines.append(f"event {event.get('event_id')} {event.get('type')} {event.get('data')}")
+        return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class GuaranteeResult:
+    """One line of the report (§2.1, §4.2).
+
+    `reason` is non-null for `not_applicable`, `fail` and `skipped`, and null for `pass`.
+    `counterexample` is present **only** on `fail`: a counterexample on a pass would be
+    evidence of a failure that did not happen (§4.2, T114).
+    """
+
+    id: str
+    title: str
+    status: Status
+    reason: str | None = None
+    action: str | None = None
+    arguments: Mapping[str, Any] | None = None
+    effect_key: str | None = None
+    grant_id: str | None = None
+    descends_from: tuple[str, ...] = ()
+    detail: Mapping[str, Any] = field(default_factory=dict)
+    counterexample: Counterexample | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "status": str(self.status),
+            "reason": self.reason,
+            "action": self.action,
+            "arguments": None if self.arguments is None else dict(self.arguments),
+            "effect_key": self.effect_key,
+            "grant_id": self.grant_id,
+            "descends_from": list(self.descends_from),
+            "detail": dict(self.detail),
+            "counterexample": (
+                None if self.counterexample is None else self.counterexample.to_dict()
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class Report:
+    """What one verify run found, as a value (§9.1)."""
+
+    guarantees: tuple[GuaranteeResult, ...]
+    policy: Mapping[str, Any]
+    authority: Mapping[str, Any] | None
+    store: Mapping[str, Any]
+    started_at: datetime
+    finished_at: datetime
+    ctrlrun_version: str
+    partial: bool = False
+
+    # --- counts (§4.1: passes over applicable, and N/A is never summed in) --------------
+
+    @property
+    def passed(self) -> int:
+        return sum(1 for result in self.guarantees if result.status is Status.PASS)
+
+    @property
+    def failed(self) -> int:
+        return sum(1 for result in self.guarantees if result.status is Status.FAIL)
+
+    @property
+    def not_applicable(self) -> int:
+        return sum(1 for result in self.guarantees if result.status is Status.NOT_APPLICABLE)
+
+    @property
+    def skipped(self) -> int:
+        return sum(1 for result in self.guarantees if result.status is Status.SKIPPED)
+
+    @property
+    def applicable(self) -> int:
+        """Passes plus failures. `not_applicable` and `skipped` are excluded, by §1's rule."""
+        return self.passed + self.failed
+
+    @property
+    def badge_message(self) -> str:
+        """`verified N/M`, where M is **applicable** and never the catalogue size (§5.2)."""
+        return f"verified {self.passed}/{self.applicable}"
+
+    @property
+    def exit_code(self) -> int:
+        """SPEC-v0.4 §4.4. N/A never changes it by itself; zero applicable is never a pass."""
+        if self.failed:
+            return 1
+        if self.applicable == 0:
+            # §3.8 — `0/0` reported as success is the same false green as `8/8` with five N/As.
+            return 2
+        return 0
+
+    @property
+    def badge(self) -> dict[str, Any] | None:
+        """The Shields endpoint document, or `None` where §5.2 forbids one.
+
+        A partial run writes no badge, and neither does an exit of 2 or 3. The `None` is the
+        rule, expressed once: a fraction computed over a subset somebody chose is the false
+        green this release exists to prevent, wearing a different costume.
+        """
+        if self.partial or self.exit_code not in (0, 1):
+            return None
+        return {
+            "schemaVersion": 1,
+            "label": BADGE_LABEL,
+            "message": self.badge_message,
+            "color": BADGE_PASS_COLOR if self.failed == 0 else BADGE_FAIL_COLOR,
+        }
+
+    # --- renderings ---------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": REPORT_SCHEMA,
+            "catalogue": CATALOGUE,
+            "ctrlrun_version": self.ctrlrun_version,
+            "started_at": self.started_at.isoformat(),
+            "finished_at": self.finished_at.isoformat(),
+            "policy": dict(self.policy),
+            "authority": None if self.authority is None else dict(self.authority),
+            "store": dict(self.store),
+            "partial": self.partial,
+            "summary": {
+                "passed": self.passed,
+                "failed": self.failed,
+                "applicable": self.applicable,
+                "not_applicable": self.not_applicable,
+                "skipped": self.skipped,
+                "badge": f"{self.passed}/{self.applicable}",
+            },
+            "guarantees": [result.to_dict() for result in self.guarantees],
+        }
+
+    def to_json(self) -> str:
+        """One object, schema `ctrlrun.verify/v1` (§4.2)."""
+        return json.dumps(self.to_dict(), ensure_ascii=False, indent=2, sort_keys=False)
+
+    def to_text(self) -> str:
+        """The human report of §4.1. The summary is the last line, so `tail -1` means something."""
+        lines = [
+            f"CTRLRun verify — ctrlrun {self.ctrlrun_version}, catalogue {CATALOGUE}",
+            f"policy     {self.policy['path']} ({self.policy['schema']}, "
+            f"mode: {self.policy['mode']})",
+        ]
+        if self.authority is None:
+            lines.append("authority  none")
+        else:
+            where = (
+                "same document"
+                if self.authority["path"] == self.policy["path"]
+                else str(self.authority["path"])
+            )
+            lines.append(f"authority  {where}, {self.authority['grants']} grants")
+        lines.append(
+            f"store      {self.store['backend']}, scratch (created and destroyed for this run)"
+        )
+        lines.append("")
+        noted = False
+        for result in self.guarantees:
+            lines.append(_result_line(result))
+            note = result.detail.get("note")
+            if note and not noted:
+                # §4.1's example prints the `@protect` sentence once, under the first
+                # guarantee the missing template takes out. Every one of them carries it in
+                # `detail.note` (T102); repeating it on three consecutive lines would push
+                # the rows that differ off the reader's screen.
+                noted = True
+                lines += _wrapped_note(str(note))
+            if result.counterexample is not None:
+                lines += [f"     {line}" for line in result.counterexample.to_text().split("\n")]
+        lines.append("")
+        lines.append(self.summary_line())
+        return "\n".join(lines)
+
+    def summary_line(self) -> str:
+        """§4.1 — passes over applicable, then the N/A ids as a separate sentence."""
+        na = [result.id for result in self.guarantees if result.status is Status.NOT_APPLICABLE]
+        summary = f"{self.passed}/{self.applicable} declared guarantees pass."
+        summary += f" {len(na)} not applicable"
+        summary += f": {', '.join(na)}." if na else "."
+        if self.skipped:
+            skipped = [result.id for result in self.guarantees if result.status is Status.SKIPPED]
+            summary += f" {len(skipped)} not selected: {', '.join(skipped)}."
+        return summary
+
+    def to_junit(self) -> str:
+        """§4.3. N/A is `<skipped>` — reported as skipped and never as a pass."""
+        duration = (self.finished_at - self.started_at).total_seconds()
+        suite = ElementTree.Element(
+            "testsuite",
+            {
+                "name": SUITE_NAME,
+                "tests": str(len(self.guarantees)),
+                "failures": str(self.failed),
+                "errors": "0",
+                "skipped": str(self.not_applicable + self.skipped),
+                "time": f"{duration:.3f}",
+                "timestamp": self.started_at.replace(tzinfo=None).isoformat(),
+            },
+        )
+        for result in self.guarantees:
+            case = ElementTree.SubElement(
+                suite,
+                "testcase",
+                {"classname": CLASS_NAME, "name": f"{result.id} {result.title}", "time": "0.000"},
+            )
+            if result.status is Status.FAIL:
+                failure = ElementTree.SubElement(
+                    case,
+                    "failure",
+                    {"message": result.reason or "failed", "type": result.id},
+                )
+                failure.text = (
+                    "" if result.counterexample is None else result.counterexample.to_text()
+                )
+            elif result.status in (Status.NOT_APPLICABLE, Status.SKIPPED):
+                ElementTree.SubElement(
+                    case, "skipped", {"message": result.reason or str(result.status)}
+                )
+        suites = ElementTree.Element(
+            "testsuites",
+            {
+                "name": SUITE_NAME,
+                "tests": str(len(self.guarantees)),
+                "failures": str(self.failed),
+                "errors": "0",
+                "time": f"{duration:.3f}",
+            },
+        )
+        suites.append(suite)
+        return ElementTree.tostring(suites, encoding="unicode", xml_declaration=True)
+
+    def job_summary(self) -> str:
+        """§5.4 — a Markdown table, with the N/A rows in full."""
+        lines = [
+            f"### CTRLRun verify — {self.policy['path']}",
+            "",
+            "| id | guarantee | status | action | reason |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+        for result in self.guarantees:
+            lines.append(
+                f"| {result.id} | {result.title} | `{result.status}` | "
+                f"{result.action or ''} | {result.reason or ''} |"
+            )
+        lines += ["", self.summary_line()]
+        return "\n".join(lines)
+
+
+def _subject(result: GuaranteeResult) -> str:
+    """What a line names: the grant where the guarantee is about one, else the action.
+
+    §3.2 requires the chosen action to appear in every output format, and it does — on
+    `action`, in the JSON. This is the human column, and §4.1 puts the grant there for G8 and
+    G9 because those two are about a grant rather than about the action they used to reach it.
+    """
+    return result.grant_id or result.action or ""
+
+
+def _result_line(result: GuaranteeResult) -> str:
+    label = f"{result.id:<4} {result.title:<{_TITLE_WIDTH}}"
+    status = {
+        Status.PASS: "PASS",
+        Status.FAIL: "FAIL",
+        Status.NOT_APPLICABLE: "N/A ",
+        Status.SKIPPED: "SKIP",
+    }[result.status]
+    if result.status is Status.PASS:
+        trailer = _subject(result)
+        extra = result.detail.get("summary")
+        if extra:
+            trailer = f"{trailer} ({extra})".strip()
+    elif result.status is Status.FAIL:
+        subject = _subject(result)
+        trailer = f"{result.reason} — {subject}" if subject else str(result.reason)
+    else:
+        trailer = result.reason or ""
+    return f"{label} {status}  {trailer}".rstrip()
+
+
+def _wrapped_note(note: str) -> list[str]:
+    """The continuation lines of §4.1's N/A block, aligned under the reason."""
+    indent = " " * (5 + _TITLE_WIDTH + 7)
+    lines: list[str] = []
+    current = "("
+    for word in note.split():
+        candidate = word if current == "(" else f"{current} {word}"
+        if current != "(" and len(candidate) > 58:
+            lines.append(indent + current)
+            current = word
+        else:
+            current = f"({word}" if current == "(" else candidate
+    lines.append(indent + current + ")")
+    return lines
+
+
+def catalogue_ids() -> tuple[str, ...]:
+    return tuple(guarantee.id for guarantee in GUARANTEES)
+
+
+__all__ = [
+    "BADGE_FAIL_COLOR",
+    "BADGE_LABEL",
+    "BADGE_PASS_COLOR",
+    "CLASS_NAME",
+    "EFFECT_TEMPLATE_NOTE",
+    "REPORT_SCHEMA",
+    "SUITE_NAME",
+    "Counterexample",
+    "GuaranteeResult",
+    "Report",
+    "Status",
+    "catalogue_ids",
+]

--- a/src/ctrlrun/verify/scenarios.py
+++ b/src/ctrlrun/verify/scenarios.py
@@ -1,0 +1,2103 @@
+"""Deriving scenarios from a configuration, and running them. SPEC-v0.4 §3.
+
+Everything here is derived from the two documents verify reads. There is **no randomness** —
+not seeded randomness, none: selection is sorted by codepoint, values come from a fixed table,
+and two runs against one document choose the same actions with the same arguments (§3.2, T105).
+
+Three rules this module is written against, and each has a place below where it would be easy
+to break:
+
+- **N/A is a statement about the document.** A guarantee whose scenario cannot be built from
+  the configuration is `not_applicable` with the reason from §2.2. A scenario that could not be
+  built for any other cause — a synthesized vector landing in the wrong rule, a store that
+  would not open — is an internal error and exits 3 (§3.8). The two are never conflated.
+- **Verify never touches the operator's store.** Every scenario runs against a scratch store in
+  a temporary directory removed when the run ends. `state_path()` is never called and
+  `Control.from_file()` is never used (§3.5, T103).
+- **Every guarantee carries a positive control.** A refusal asserted against a scenario in
+  which nothing ran passes on a kernel with the guard deleted, so each scenario establishes
+  that the observable would have been visible had the guard not fired. A control that does not
+  behave as specified is `fail` with `reason: "control failed"` — never a pass, never an N/A
+  (§1.3, T125).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import itertools
+import json
+import logging
+import os
+import subprocess
+import sys
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import suppress
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Final
+
+from ..action import Action, Principal
+from ..approval import DEFAULT_APPROVAL_TTL, ApprovalStatus, LocalApprovalProvider
+from ..authority import (
+    AUTHORITY_EXPIRED,
+    CONTAINMENT,
+    DEEP_WILDCARD,
+    DIMENSIONS,
+    Authority,
+    Grant,
+    Subject,
+    contained_dimension,
+)
+from ..control import Control, context, protect
+from ..effect import EffectRecord, EffectState, resolve_effect_key, resolve_resource
+from ..errors import (
+    ActionDenied,
+    AmbiguousEffect,
+    ApprovalMismatch,
+    AuthorityDenied,
+    AuthorityEscalation,
+    CTRLRunError,
+    DuplicateEffect,
+    InvalidArgument,
+    NotExecuted,
+    PolicyError,
+)
+from ..policy import Condition, Decision, Policy, _ActionPolicy, _Rule, discover_policy_path
+from ..receipt import Event, EventType, Receipt, ReceiptResult, iso_timestamp
+from ..state import InMemoryStateStore, SQLiteStateStore
+from . import guarantees as reg
+from .report import Counterexample, GuaranteeResult, Status
+from .worker import OUTCOME_COMMITTED
+
+_LOG = logging.getLogger(__name__)
+
+#: Who verify records as the author of the approvals it grants itself (§3.5). Not a person,
+#: and named so no reader of the evidence mistakes it for one.
+APPROVER: Final = "ctrlrun-verify"
+
+#: §3.6 — the base instant where no grant carries an `expires_at`.
+FALLBACK_T0: Final = datetime(2026, 1, 1, tzinfo=UTC)
+
+#: §3.1 — the one `--store-url` value v0.4 accepts. Everything else exits 2 naming v0.6.
+SQLITE_STORE_URL: Final = "sqlite"
+
+#: §3.4's derivation of a principal from a grant's subject.
+WILDCARD: Final = "*"
+
+_ONE_HOUR: Final = timedelta(hours=1)
+_ONE_MICROSECOND: Final = timedelta(microseconds=1)
+
+#: Every loop is bounded (§3.6). A child that wedges makes G4 fail red rather than hanging CI.
+_CHILD_TIMEOUT_SECONDS: Final = 120
+
+#: An extra N/A reason §2.2 does not name, because it does not arise in a single-grant
+#: configuration: where a *second* grant covers the same action past the first one's expiry,
+#: the expired grant refuses nothing observable and G8 would report a failure that is really a
+#: property of a layered document. A statement about the configuration, so N/A and not FAIL.
+EXPIRY_NOT_DECISIVE: Final = (
+    "no grant's expiry is the last authority for an action it covers; another grant still "
+    "permits the action after it lapses"
+)
+
+
+# --- refusals verify itself makes (§3.8, §10) -------------------------------------------
+
+
+class VerifyRefused(CTRLRunError):
+    """The configuration was refused or is unusable: exit 2 (§3.8).
+
+    Private to the package by convention — SPEC-v0.4 §9.1 freezes `run`, `Status`, `Report`,
+    `GuaranteeResult` and `Counterexample` and no other public name — and imported by
+    `cli/main.py`, which is the only caller that needs to turn it into an exit code.
+    """
+
+
+class VerifyInternalError(CTRLRunError):
+    """A defect in verify itself: exit 3 (§3.8).
+
+    Never a FAIL and never an N/A. A defect in verify must not read as a defect in the kernel,
+    and it must not read as a property of the configuration either.
+    """
+
+
+class _ControlFailed(Exception):
+    """§1.3 — the positive control did not behave as specified."""
+
+    def __init__(self, observed: str, expected: str) -> None:
+        super().__init__(observed)
+        self.observed = observed
+        self.expected = expected
+
+
+class _Violation(Exception):
+    """The guarantee's own refusal did not happen, or did not happen for the stated reason."""
+
+    def __init__(self, expected: str, observed: str) -> None:
+        super().__init__(observed)
+        self.expected = expected
+        self.observed = observed
+
+
+# --- the clock, the sink and the fake executors -----------------------------------------
+
+
+class _Clock:
+    """An injected clock, moved explicitly by the scenario that needs time to pass (§3.6).
+
+    No scenario sleeps. G8's "one microsecond after `expires_at`" is a step, not a wait.
+    """
+
+    def __init__(self, base: datetime) -> None:
+        self.now = base
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def at(self, moment: datetime) -> None:
+        self.now = moment
+
+    def advance(self, delta: timedelta) -> None:
+        self.now += delta
+
+
+class _Recorder:
+    """The one sink a scenario registers (§3.5): in memory, so a counterexample has evidence.
+
+    No `JSONLEventSink`. Verify writes no evidence files, because evidence of a scenario that
+    never happened, filed beside evidence of actions that did, is a receipt trail nobody can
+    read.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[Event] = []
+        self.receipts: list[Receipt] = []
+
+    def on_event(self, event: Event) -> None:
+        self.events.append(event)
+
+    def on_receipt(self, receipt: Receipt) -> None:
+        self.receipts.append(receipt)
+
+    def types(self) -> list[str]:
+        return [str(event.type) for event in self.events]
+
+
+class _Executor:
+    """An in-process fake. It counts, and it does whatever the scenario told it to do.
+
+    Verify never calls the operator's executor (§1.2) and no fake opens a socket (§3.7).
+    """
+
+    def __init__(self, behaviour: Callable[[], Any] | None = None) -> None:
+        self.calls = 0
+        self._behaviour = behaviour
+
+    def __call__(self) -> Any:
+        self.calls += 1
+        if self._behaviour is not None:
+            return self._behaviour()
+        return f"{APPROVER}-result"
+
+
+def _raises(exception: BaseException) -> Callable[[], Any]:
+    def behaviour() -> Any:
+        raise exception
+
+    return behaviour
+
+
+# --- the loaded configuration -----------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Loaded:
+    policy: Policy
+    policy_path: Path
+    policy_sha: str
+    authority: Authority | None
+    authority_path: Path | None
+    authority_sha: str | None
+    authority_text: str | None
+    authority_standalone: bool
+
+
+def _digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def load(
+    config: str | os.PathLike[str] | None, authority: str | os.PathLike[str] | None
+) -> _Loaded:
+    """Read the policy document, and the authority document beside it (§3.1).
+
+    Those two and nothing else. Verify does not import the operator's package, does not read
+    `$CTRLRUN_STATE`, and does not open the operator's store.
+    """
+    from ..authority import _optional_from_yaml
+
+    policy_path = Path(config) if config is not None else discover_policy_path()
+    try:
+        policy_text = policy_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise VerifyRefused(f"policy file {policy_path} could not be read: {exc}") from exc
+    try:
+        policy = Policy.from_yaml(policy_text, source=str(policy_path))
+    except PolicyError as exc:
+        raise VerifyRefused(str(exc)) from exc
+
+    try:
+        in_document = _optional_from_yaml(policy_text, source=str(policy_path))
+    except PolicyError as exc:
+        raise VerifyRefused(str(exc)) from exc
+    if authority is None:
+        return _Loaded(
+            policy=policy,
+            policy_path=policy_path,
+            policy_sha=_digest(policy_text),
+            authority=in_document,
+            authority_path=policy_path if in_document is not None else None,
+            authority_sha=_digest(policy_text) if in_document is not None else None,
+            authority_text=policy_text if in_document is not None else None,
+            authority_standalone=False,
+        )
+
+    authority_path = Path(authority)
+    if in_document is not None:
+        # §3.1 — declaring authority in two places is refused, naming both, exactly as
+        # `ctrlrun gateway --authority` refuses it. Choosing one silently would leave two
+        # answers to "which grants are in force" on one machine.
+        raise VerifyRefused(
+            f"authority is declared twice: an 'authority:' section in {policy_path} and "
+            f"--authority {authority_path}. Remove one; a configuration with two answers to "
+            "'which grants are in force' is one nobody can resolve later"
+        )
+    try:
+        authority_text = authority_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise VerifyRefused(
+            f"authority document {authority_path} could not be read: {exc}"
+        ) from exc
+    try:
+        loaded = Authority.from_yaml(authority_text, source=str(authority_path), standalone=True)
+    except PolicyError as exc:
+        raise VerifyRefused(str(exc)) from exc
+    return _Loaded(
+        policy=policy,
+        policy_path=policy_path,
+        policy_sha=_digest(policy_text),
+        authority=loaded,
+        authority_path=authority_path,
+        authority_sha=_digest(authority_text),
+        authority_text=authority_text,
+        authority_standalone=True,
+    )
+
+
+# --- argument synthesis (§3.3) ----------------------------------------------------------
+
+
+def _is_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _negate_value(operand: object) -> Any:
+    """§3.3's `X_neq` row: a value that is not the operand, in the operand's own shape."""
+    if isinstance(operand, int) and not isinstance(operand, bool):
+        return operand + 1
+    if isinstance(operand, str):
+        return f"{operand}-x"
+    return APPROVER
+
+
+def _bounds(conditions: Sequence[Condition]) -> tuple[int | None, int | None]:
+    lower: int | None = None
+    upper: int | None = None
+    for condition in conditions:
+        if condition.op in ("gte", "gt"):
+            candidate = condition.operand + (0 if condition.op == "gte" else 1)
+            lower = candidate if lower is None else max(lower, candidate)
+        elif condition.op in ("lte", "lt"):
+            candidate = condition.operand - (0 if condition.op == "lte" else 1)
+            upper = candidate if upper is None else min(upper, candidate)
+    return lower, upper
+
+
+def _argument_value(conditions: Sequence[Condition]) -> tuple[bool, Any]:
+    """§3.3's per-argument table, applied to every condition naming one argument.
+
+    Returns `(satisfiable, value)`. Contradictory bounds are a normal outcome and not an
+    error: they mean this action cannot be driven to that decision.
+    """
+    equals = [c for c in conditions if c.op == "eq"]
+    members = [c for c in conditions if c.op == "in"]
+    excluded = [c.operand for c in conditions if c.op == "neq"]
+    lower, upper = _bounds(conditions)
+
+    if equals:
+        return True, equals[0].operand
+    if members:
+        for item in members[0].operand:
+            if not any(item == other and type(item) is type(other) for other in excluded):
+                return True, item
+        return False, None
+    if lower is not None or upper is not None:
+        if lower is not None and upper is not None and lower > upper:
+            return False, None
+        # §3.3 — the lower bound of the satisfiable interval, the upper where there is no
+        # lower. A fixed choice, so two runs agree.
+        value = lower if lower is not None else upper
+        assert value is not None
+        while any(_is_int(other) and other == value for other in excluded):
+            if upper is not None and value >= upper:
+                return False, None
+            value += 1
+        return True, value
+    if excluded:
+        return True, _negate_value(excluded[0])
+    return False, None
+
+
+def _solve(conditions: Sequence[Condition]) -> dict[str, Any] | None:
+    """An argument mapping satisfying every condition of one rule, or `None`."""
+    grouped: dict[str, list[Condition]] = {}
+    for condition in conditions:
+        grouped.setdefault(condition.argument, []).append(condition)
+    vector: dict[str, Any] = {}
+    for argument in sorted(grouped):
+        satisfiable, value = _argument_value(grouped[argument])
+        if not satisfiable:
+            return None
+        vector[argument] = value
+    return vector
+
+
+def _negations(condition: Condition) -> list[tuple[str, Any]]:
+    """§3.3's negation table: how to make one condition false.
+
+    Negating a rule's conjunction gives a disjunction, so failing an earlier rule means
+    failing **one** of its conditions, and the engine tries each in a fixed order.
+    """
+    operand = condition.operand
+    if condition.op == "gte":
+        return [(condition.argument, operand - 1)]
+    if condition.op == "gt":
+        return [(condition.argument, operand)]
+    if condition.op == "lte":
+        return [(condition.argument, operand + 1)]
+    if condition.op == "lt":
+        return [(condition.argument, operand)]
+    if condition.op == "eq":
+        return [(condition.argument, _negate_value(operand))]
+    if condition.op == "neq":
+        return [(condition.argument, operand)]
+    if condition.op == "in":
+        first = operand[0] if operand else APPROVER
+        return [(condition.argument, _negate_value(first))]
+    return []
+
+
+def _candidates(rules: Sequence[_Rule], index: int) -> Iterator[dict[str, Any]]:
+    """Vectors that aim at `rules[index]`, in a fixed order, bounded at 64 (§3.3).
+
+    `v0.1 §3.2` is first-match-wins, so a vector that satisfies rule *i* must also fail every
+    rule before it. A bound rather than a solver: the work is finite, the failure mode is
+    legible, and a configuration whose rules cannot be driven within it reports N/A rather
+    than running long.
+    """
+    base = _solve(rules[index].conditions)
+    if base is None:
+        return
+    options: list[list[tuple[str, Any]]] = []
+    for rule in rules[:index]:
+        ways = [pair for condition in rule.conditions for pair in _negations(condition)]
+        if not ways:
+            # An earlier rule with no conditions always matches, so this one is unreachable.
+            return
+        options.append(ways)
+    for count, combination in enumerate(itertools.product(*options)):
+        if count >= reg.CANDIDATE_BOUND:
+            return
+        vector = dict(base)
+        for argument, value in combination:
+            vector[argument] = value
+        yield vector
+
+
+def _placeholders(policy: Policy, name: str) -> dict[str, Any]:
+    """§3.3's last row: an argument named only by a template gets `ctrlrun-verify-<name>`.
+
+    Every value verify invents carries the prefix, so a value that ever appeared anywhere it
+    should not have is recognizable on sight.
+    """
+    from ..effect import template_placeholders
+
+    values: dict[str, Any] = {}
+    for template in (policy.effect_template(name), policy.resource_template(name)):
+        if template is None:
+            continue
+        for placeholder in template_placeholders(template):
+            values.setdefault(placeholder, f"{reg.SYNTHETIC_PREFIX}-{placeholder}")
+    return values
+
+
+# --- selection (§3.2, §3.4) -------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Selection:
+    """One guarantee's concrete scenario: what to run, as whom, and where it lands."""
+
+    action: str
+    arguments: Mapping[str, Any]
+    decision: Decision
+    resource: str | None
+    effect_key: str | None
+    principal: Principal
+    environment: str
+    grant: Grant | None = None
+    rule_reason: str = ""
+
+    def build(self) -> Action:
+        return Action(
+            name=self.action,
+            arguments=dict(self.arguments),
+            principal=self.principal,
+            resource=self.resource,
+            environment=self.environment,
+        )
+
+
+def _principal_for(subject: Subject) -> Principal:
+    """§3.4 — the principal comes from the grant under test, never from the policy."""
+    return Principal(
+        agent=str(_from_pattern(subject.agent or WILDCARD)),
+        user=_from_pattern(subject.user),
+    )
+
+
+def _from_pattern(pattern: str | None) -> str | None:
+    if pattern is None:
+        return None
+    if pattern == WILDCARD:
+        return APPROVER
+    if pattern.endswith(WILDCARD):
+        return f"{pattern[:-1]}{APPROVER}"
+    return pattern
+
+
+class Engine:
+    """Derives and runs the scenarios for one configuration (§3).
+
+    One instance per `run()`. It owns the scratch directory, and removes it when the run ends
+    — including when it ends by exception (§3.5).
+    """
+
+    def __init__(self, loaded: _Loaded, scratch: Path) -> None:
+        self._loaded = loaded
+        self._scratch = scratch
+        self._t0 = _base_instant(loaded.authority)
+        self._default_environment = (loaded.policy.environment or "production").strip()
+
+    # --- derivation ---------------------------------------------------------------------
+
+    @property
+    def policy(self) -> Policy:
+        return self._loaded.policy
+
+    @property
+    def authority(self) -> Authority | None:
+        return self._loaded.authority
+
+    def _synthesize(
+        self, name: str, decision: Decision, mutation: Mapping[str, Any] | None = None
+    ) -> tuple[dict[str, Any], str] | None:
+        """An argument vector driving `name` to `decision`, and the rule reason it reached.
+
+        **The vector is checked before it is used** (§3.3). Having built one, the engine
+        evaluates the action it just constructed and asserts the decision is the one it was
+        aiming for; a vector that lands in a different rule is an internal error, not a FAIL,
+        because it would run, refuse something, and report a guarantee that was never
+        exercised.
+        """
+        entry: _ActionPolicy | None = self.policy.actions.get(name)
+        if entry is None:
+            return None
+        extras = _placeholders(self.policy, name)
+        if entry.decision is not None:
+            if entry.decision is not decision:
+                return None
+            vector = dict(extras)
+            if mutation:
+                vector.update(mutation)
+            return self._checked(name, vector, decision, "decision")
+        for index, rule in enumerate(entry.rules):
+            if rule.decision is not decision:
+                continue
+            for candidate in _candidates(entry.rules, index):
+                vector = {**extras, **candidate}
+                if mutation:
+                    vector.update(mutation)
+                checked = self._checked(name, vector, decision, f"rule[{index}]")
+                if checked is not None:
+                    return checked
+        return None
+
+    def _checked(
+        self, name: str, vector: dict[str, Any], decision: Decision, expected_reason: str
+    ) -> tuple[dict[str, Any], str] | None:
+        try:
+            action = Action(
+                name=name,
+                arguments=vector,
+                principal=Principal(agent=APPROVER),
+                resource=self._resource(name, vector),
+                environment=self._default_environment,
+            )
+        except (InvalidArgument, CTRLRunError):
+            return None
+        evaluation = self.policy.evaluate(action)
+        if evaluation.decision is not decision:
+            return None
+        if evaluation.reason != expected_reason:
+            raise VerifyInternalError(
+                f"{name}: a synthesized vector aimed at {expected_reason} landed in "
+                f"{evaluation.reason!r} (SPEC-v0.4 §3.3)"
+            )
+        return vector, evaluation.reason
+
+    def _resource(self, name: str, arguments: Mapping[str, Any]) -> str | None:
+        template = self.policy.resource_template(name)
+        if template is None:
+            return None
+        return resolve_resource(template, arguments)
+
+    def _effect_key(self, action: Action) -> str | None:
+        template = self.policy.effect_template(action.name)
+        if template is None:
+            return None
+        return resolve_effect_key(template, action)
+
+    def select(
+        self,
+        *,
+        decisions: Sequence[Decision] = (Decision.ALLOW, Decision.APPROVE),
+        needs_effect: bool = False,
+        grant_filter: Callable[[Grant], bool] | None = None,
+        mutation: Mapping[str, Any] | None = None,
+    ) -> _Selection | None:
+        """§3.2 — the first action, sorted by codepoint, that satisfies the requirements.
+
+        Where an `authority:` section exists the principal comes from a grant that actually
+        covers the action (§3.4), because an action nothing authorizes is refused by the
+        authority axis before the policy axis is ever reached (`v0.3 §4.3`), and a scenario
+        built on one would exercise a different guarantee than the one it claims.
+        """
+        for name in sorted(self.policy.actions):
+            if needs_effect and self.policy.effect_template(name) is None:
+                continue
+            for decision in decisions:
+                synthesized = self._synthesize(name, decision, mutation)
+                if synthesized is None:
+                    continue
+                arguments, reason = synthesized
+                selection = self._bind(name, arguments, decision, reason, grant_filter)
+                if selection is not None:
+                    return selection
+        return None
+
+    def _bind(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        decision: Decision,
+        reason: str,
+        grant_filter: Callable[[Grant], bool] | None,
+    ) -> _Selection | None:
+        resource = self._resource(name, arguments)
+        if self.authority is None:
+            selection = _Selection(
+                action=name,
+                arguments=arguments,
+                decision=decision,
+                resource=resource,
+                effect_key=None,
+                principal=Principal(agent=APPROVER),
+                environment=self._default_environment,
+                rule_reason=reason,
+            )
+            return replace(selection, effect_key=self._effect_key(selection.build()))
+        for grant_id in sorted(self.authority.grants):
+            grant = self.authority.grants[grant_id]
+            if grant_filter is not None and not grant_filter(grant):
+                continue
+            principal = _principal_for(grant.subject)
+            environment = grant.environments[0] if grant.environments else self._default_environment
+            action = Action(
+                name=name,
+                arguments=arguments,
+                principal=principal,
+                resource=resource,
+                environment=environment,
+            )
+            if not grant.matches_shape(action) or not grant.constraints_hold(action):
+                continue
+            selection = _Selection(
+                action=name,
+                arguments=arguments,
+                decision=decision,
+                resource=resource,
+                effect_key=self._effect_key(action),
+                principal=principal,
+                environment=environment,
+                grant=grant,
+                rule_reason=reason,
+            )
+            return selection
+        return None
+
+    # --- the scratch store, and the Control every scenario drives -----------------------
+
+    def control(
+        self, gid: str, *, clock: _Clock | None = None, authority: bool = True
+    ) -> tuple[Control, SQLiteStateStore, _Recorder, _Clock]:
+        """One scratch store per guarantee, and a `Control` composed the way an app composes one.
+
+        `Control.from_file()` is not used: it would open the operator's store. The store is a
+        file, because `SQLiteStateStore` refuses `:memory:` precisely so that G4 can mean
+        something.
+        """
+        directory = self._scratch / gid
+        directory.mkdir(parents=True, exist_ok=True)
+        moving = clock if clock is not None else _Clock(self._t0)
+        store = SQLiteStateStore(directory / "state.db", clock=moving)
+        recorder = _Recorder()
+        control = Control(
+            self.policy,
+            store,
+            LocalApprovalProvider(store, clock=moving),
+            clock=moving,
+            sinks=[recorder],
+            authority=self.authority if authority else None,
+            environment=self._default_environment,
+        )
+        return control, store, recorder, moving
+
+    def _control_for(
+        self, gid: str, selection: _Selection, *, clock: _Clock | None = None
+    ) -> tuple[Control, SQLiteStateStore, _Recorder, _Clock]:
+        directory = self._scratch / gid
+        directory.mkdir(parents=True, exist_ok=True)
+        moving = clock if clock is not None else _Clock(self._t0)
+        store = SQLiteStateStore(directory / "state.db", clock=moving)
+        recorder = _Recorder()
+        control = Control(
+            self.policy,
+            store,
+            LocalApprovalProvider(store, clock=moving),
+            clock=moving,
+            sinks=[recorder],
+            authority=self.authority,
+            environment=selection.environment,
+        )
+        return control, store, recorder, moving
+
+    def approve(
+        self, control: Control, store: SQLiteStateStore, action: Action, selection: _Selection
+    ) -> str | None:
+        """Grant verify's own approval, through the call `ctrlrun approve` makes (§3.5).
+
+        G1 and G2 are *about* this mechanism; every other scenario that meets an approval gate
+        uses it to get on with the guarantee it is actually testing, and the report names the
+        action as approved so a reader is not left thinking a human was involved.
+        """
+        if selection.decision is not Decision.APPROVE:
+            return None
+        request = control.approvals.request(action, DEFAULT_APPROVAL_TTL)
+        store.grant_approval(request.request_id, APPROVER)
+        return request.request_id
+
+    def execute(
+        self,
+        control: Control,
+        action: Action,
+        executor: _Executor,
+        effect_key: str | None,
+        approval_id: str | None,
+    ) -> Receipt:
+        if approval_id is None:
+            return control.execute(action, executor, effect_key)
+        from ..control import with_approval
+
+        with with_approval(approval_id):
+            return control.execute(action, executor, effect_key)
+
+    def refused(
+        self,
+        thunk: Callable[[], Any],
+        refusals: tuple[type[BaseException], ...],
+        expected: str,
+        ran: str,
+    ) -> BaseException:
+        """Run one attempt that MUST be refused, and hand back the refusal.
+
+        The `else` branch is the point: an attempt that was not refused is a `_Violation`
+        naming what happened, and so is one that raised something else. Without this, a kernel
+        with the guard deleted would let the executor's own exception escape the scenario, and
+        verify would report an internal error — a defect in the kernel reading as a defect in
+        verify.
+        """
+        try:
+            thunk()
+        except refusals as refusal:
+            return refusal
+        except (VerifyRefused, VerifyInternalError):
+            raise
+        except Exception as escaped:
+            raise _Violation(
+                expected,
+                f"{ran}, and raised {type(escaped).__name__}: {escaped}",
+            ) from escaped
+        raise _Violation(expected, ran)
+
+    # --- results ------------------------------------------------------------------------
+
+    def na(self, gid: str, reason: str, **detail: Any) -> GuaranteeResult:
+        """`not_applicable`, with the reason that made it so (§1, §2.1).
+
+        Excluded from the denominator and shown separately. There is no flag that folds one
+        into the count, and there is no path from a failed run to this status.
+        """
+        guarantee = reg.BY_ID[gid]
+        return GuaranteeResult(
+            id=gid,
+            title=guarantee.title,
+            status=Status.NOT_APPLICABLE,
+            reason=reason,
+            descends_from=guarantee.descends_from,
+            detail=detail,
+        )
+
+    def _passed(
+        self, gid: str, selection: _Selection | None, detail: Mapping[str, Any]
+    ) -> GuaranteeResult:
+        guarantee = reg.BY_ID[gid]
+        carried = dict(detail)
+        return GuaranteeResult(
+            id=gid,
+            title=guarantee.title,
+            status=Status.PASS,
+            reason=None,
+            action=None if selection is None else selection.action,
+            arguments=None if selection is None else dict(selection.arguments),
+            effect_key=None if selection is None else selection.effect_key,
+            grant_id=carried.pop("grant_id", None),
+            descends_from=guarantee.descends_from,
+            detail=carried,
+        )
+
+    def _failed(
+        self,
+        gid: str,
+        selection: _Selection | None,
+        reason: str,
+        example: Counterexample,
+        detail: Mapping[str, Any],
+    ) -> GuaranteeResult:
+        guarantee = reg.BY_ID[gid]
+        carried = dict(detail)
+        return GuaranteeResult(
+            id=gid,
+            title=guarantee.title,
+            status=Status.FAIL,
+            reason=reason,
+            action=None if selection is None else selection.action,
+            arguments=None if selection is None else dict(selection.arguments),
+            effect_key=None if selection is None else selection.effect_key,
+            grant_id=carried.pop("grant_id", None),
+            descends_from=guarantee.descends_from,
+            detail=carried,
+            counterexample=example,
+        )
+
+    def graded(
+        self,
+        gid: str,
+        selection: _Selection | None,
+        store: SQLiteStateStore,
+        recorder: _Recorder,
+        body: Callable[[dict[str, Any]], None],
+    ) -> GuaranteeResult:
+        """Run one scenario body and turn what it raised into a result.
+
+        `_ControlFailed` is `fail` with `reason: "control failed"` — §1.3's rule, in one
+        place, so no scenario can accidentally report a broken control as a pass. Anything
+        else that escapes is an internal error and exits 3: a defect in verify must not read
+        as a defect in the kernel.
+        """
+        detail: dict[str, Any] = {}
+        try:
+            body(detail)
+        except _ControlFailed as failure:
+            return self._failed(
+                gid,
+                selection,
+                reg.CONTROL_FAILED,
+                counterexample(store, recorder, failure.expected, failure.observed),
+                detail,
+            )
+        except _Violation as violation:
+            return self._failed(
+                gid,
+                selection,
+                violation.observed,
+                counterexample(store, recorder, violation.expected, violation.observed),
+                detail,
+            )
+        except (VerifyRefused, VerifyInternalError):
+            raise
+        except Exception as exc:
+            raise VerifyInternalError(f"{gid}: {type(exc).__name__}: {exc}") from exc
+        return self._passed(gid, selection, detail)
+
+    # --- G1: a mutated action cannot present a granted approval -------------------------
+
+    def _mutation(self, selection: _Selection) -> dict[str, Any] | None:
+        """A different action that still reaches the same rule, and the same grant.
+
+        A mutation that changed the decision would be refused by the policy before the
+        approval was ever consulted, and G1 would report a refusal it never tested. Every
+        candidate is re-checked against `Policy.evaluate` and against the grant.
+        """
+        candidates: list[dict[str, Any]] = []
+        for name in sorted(selection.arguments):
+            value = selection.arguments[name]
+            if isinstance(value, str):
+                candidates.append({name: f"{value}-mutated"})
+        # The fallback is an argument no rule and no grant mentions, so the decision cannot
+        # move: it changes the canonical form, which is the whole of what an approval binds to.
+        candidates.append({f"{reg.SYNTHETIC_PREFIX.replace('-', '_')}_mutation": "1"})
+        for mutation in candidates:
+            arguments = {**dict(selection.arguments), **mutation}
+            try:
+                action = Action(
+                    name=selection.action,
+                    arguments=arguments,
+                    principal=selection.principal,
+                    resource=self._resource(selection.action, arguments),
+                    environment=selection.environment,
+                )
+            except CTRLRunError:
+                continue
+            evaluation = self.policy.evaluate(action)
+            if evaluation.decision is not selection.decision:
+                continue
+            if evaluation.reason != selection.rule_reason:
+                continue
+            if selection.grant is not None and not (
+                selection.grant.matches_shape(action) and selection.grant.constraints_hold(action)
+            ):
+                continue
+            if action.action_hash == selection.build().action_hash:
+                continue
+            return arguments
+        return None
+
+    def g1(self) -> GuaranteeResult:
+        selection = self.select(decisions=(Decision.APPROVE,))
+        if selection is None:
+            return self.na("G1", reg.NO_APPROVE_RULE)
+        mutated_arguments = self._mutation(selection)
+        if mutated_arguments is None:
+            raise VerifyInternalError(
+                "G1: no mutation of the chosen action keeps the same decision; the fallback "
+                "argument should always have (SPEC-v0.4 §3.3)"
+            )
+        control, store, recorder, _ = self._control_for("G1", selection)
+
+        def body(detail: dict[str, Any]) -> None:
+            action = selection.build()
+            approval_id = self.approve(control, store, action, selection)
+            detail["approved_by_verify"] = True
+            mutated = Action(
+                name=selection.action,
+                arguments=mutated_arguments,
+                principal=selection.principal,
+                resource=self._resource(selection.action, mutated_arguments),
+                environment=selection.environment,
+            )
+            mutated_executor = _Executor()
+            refusal = self.refused(
+                lambda: self.execute(
+                    control, mutated, mutated_executor, self._effect_key(mutated), approval_id
+                ),
+                (ApprovalMismatch,),
+                "ApprovalMismatch(reason='mismatch') on the mutated action",
+                "the mutated action ran under an approval granted for a different action",
+            )
+            reason = getattr(refusal, "reason", "")
+            _expect(
+                reason == "mismatch",
+                "ApprovalMismatch(reason='mismatch')",
+                f"ApprovalMismatch(reason={reason!r})",
+            )
+            _expect(
+                mutated_executor.calls == 0,
+                "the executor is not reached",
+                f"the executor was called {mutated_executor.calls} times",
+            )
+            record = store.get_approval(str(approval_id))
+            _expect(
+                record is not None and record.status is ApprovalStatus.GRANTED,
+                "the approval is still granted and not consumed",
+                f"the approval is {None if record is None else record.status}",
+            )
+            _expect(
+                _named_event(recorder, EventType.APPROVAL_INVALIDATED, reason="mismatch"),
+                "APPROVAL_INVALIDATED with reason 'mismatch'",
+                f"events were {recorder.types()}",
+            )
+            executor = _Executor()
+            receipt = self.execute(control, action, executor, selection.effect_key, approval_id)
+            _expect_control(
+                receipt.result is ReceiptResult.COMMITTED and executor.calls == 1,
+                "the unmutated action, presenting the same approval, commits",
+                f"it ended {receipt.result} after {executor.calls} executor calls",
+            )
+
+        try:
+            return self.graded("G1", selection, store, recorder, body)
+        finally:
+            store.close()
+
+    # --- G2: a consumed approval cannot be presented again -------------------------------
+
+    def g2(self) -> GuaranteeResult:
+        selection = self.select(decisions=(Decision.APPROVE,))
+        if selection is None:
+            return self.na("G2", reg.NO_APPROVE_RULE)
+        control, store, recorder, _ = self._control_for("G2", selection)
+
+        def body(detail: dict[str, Any]) -> None:
+            action = selection.build()
+            approval_id = self.approve(control, store, action, selection)
+            detail["approved_by_verify"] = True
+            executor = _Executor()
+            first = self.execute(control, action, executor, selection.effect_key, approval_id)
+            _expect_control(
+                first.result is ReceiptResult.COMMITTED and executor.calls == 1,
+                "the first presentation commits",
+                f"it ended {first.result} after {executor.calls} executor calls",
+            )
+            replayed = selection.build()
+            refusal = self.refused(
+                lambda: self.execute(
+                    control, replayed, executor, selection.effect_key, approval_id
+                ),
+                (ApprovalMismatch,),
+                "ApprovalMismatch(reason='consumed') on the second presentation",
+                "the same approval authorized a second execution",
+            )
+            reason = getattr(refusal, "reason", "")
+            # `v0.1 §7` T4's note: where the action also carries an effect key,
+            # `DuplicateEffect` would apply as well, and the approval check runs first.
+            _expect(
+                reason == str(ApprovalStatus.CONSUMED),
+                "ApprovalMismatch(reason='consumed')",
+                f"ApprovalMismatch(reason={reason!r})",
+            )
+            _expect(
+                executor.calls == 1,
+                "the executor ran exactly once across both presentations",
+                f"the executor was called {executor.calls} times",
+            )
+            detail["also_duplicate_effect"] = selection.effect_key is not None
+
+        try:
+            return self.graded("G2", selection, store, recorder, body)
+        finally:
+            store.close()
+
+    # --- G3: a committed effect cannot be executed again ---------------------------------
+
+    def g3(self) -> GuaranteeResult:
+        selection = self.select(needs_effect=True)
+        if selection is None:
+            return self.na("G3", reg.NO_EFFECT_TEMPLATE, note=reg.EFFECT_TEMPLATE_NOTE)
+        control, store, recorder, _ = self._control_for("G3", selection)
+
+        def body(detail: dict[str, Any]) -> None:
+            key = str(selection.effect_key)
+            action = selection.build()
+            executor = _Executor()
+            first = self.execute(
+                control, action, executor, key, self.approve(control, store, action, selection)
+            )
+            record = store.get_effect(key)
+            _expect_control(
+                first.result is ReceiptResult.COMMITTED
+                and record is not None
+                and record.state is EffectState.COMMITTED,
+                "the first attempt commits and the record reaches COMMITTED",
+                f"it ended {first.result} with the record "
+                f"{None if record is None else record.state}",
+            )
+            second = selection.build()
+            refusal = self.refused(
+                lambda: self.execute(
+                    control, second, executor, key, self.approve(control, store, second, selection)
+                ),
+                (DuplicateEffect,),
+                "DuplicateEffect(state='committed') on the second attempt",
+                "the second attempt on a committed effect key executed",
+            )
+            state = getattr(refusal, "state", "")
+            _expect(
+                state == str(EffectState.COMMITTED),
+                "DuplicateEffect(state='committed')",
+                f"DuplicateEffect(state={state!r})",
+            )
+            _expect(
+                executor.calls == 1,
+                "the remote is not called a second time",
+                f"the executor was called {executor.calls} times",
+            )
+            after = store.get_effect(key)
+            _expect(
+                after is not None and after.attempt == 1 and after.action_id == action.action_id,
+                "the record still carries attempt 1 and the first attempt's action_id",
+                f"the record is {after}",
+            )
+
+        try:
+            return self.graded("G3", selection, store, recorder, body)
+        finally:
+            store.close()
+
+    # --- G4: concurrent attempts produce exactly one winner ------------------------------
+
+    def g4(self) -> GuaranteeResult:
+        selection = self.select(needs_effect=True)
+        if selection is None:
+            return self.na("G4", reg.NO_EFFECT_TEMPLATE, note=reg.EFFECT_TEMPLATE_NOTE)
+        # §2.2 — the children run under the **real** clock, because a callable is not
+        # picklable and `spawn` is the default start method on macOS and Windows. A grant that
+        # lapsed before this run therefore cannot cover them, and that is a property of the
+        # document plus the wall clock rather than a broken guarantee.
+        now = datetime.now(UTC)
+        if selection.grant is not None and selection.grant.is_expired(now):
+            return self.na("G4", reg.GRANT_ALREADY_EXPIRED)
+        clock = _Clock(now)
+        control, store, recorder, _ = self._control_for("G4", selection, clock=clock)
+
+        def body(detail: dict[str, Any]) -> None:
+            detail["processes"] = reg.PROCESSES
+            detail["summary"] = f"{reg.PROCESSES} processes"
+            key = str(selection.effect_key)
+            # The control first: 8 processes on 8 **distinct** keys, all committing. Without
+            # it the guarantee is satisfied by 8 children that failed to start, and the report
+            # would say so in green (§2.2).
+            control_keys = [
+                f"{key}-{reg.SYNTHETIC_PREFIX}-control-{index}" for index in range(reg.PROCESSES)
+            ]
+            control_results, control_calls, control_pids = self._contend(
+                control, store, selection, control_keys, "g4-control"
+            )
+            committed = [
+                item for item in control_results if item.get("outcome") == OUTCOME_COMMITTED
+            ]
+            _expect_control(
+                len(committed) == reg.PROCESSES and control_calls == reg.PROCESSES,
+                f"{reg.PROCESSES} processes on {reg.PROCESSES} distinct keys all commit",
+                f"{len(committed)} committed after {control_calls} executor calls; "
+                f"{[item.get('message') for item in control_results if item.get('message')]}",
+            )
+            _expect_control(
+                len(control_pids) == reg.PROCESSES and os.getpid() not in control_pids,
+                "every attempt ran in its own OS process",
+                f"{len(control_pids)} distinct child pids, parent {os.getpid()}",
+            )
+            detail["distinct_child_pids"] = len(control_pids)
+            detail["parent_pid_among_children"] = os.getpid() in control_pids
+
+            contended = [key] * reg.PROCESSES
+            results, calls, pids = self._contend(
+                control, store, selection, contended, "g4-contended"
+            )
+            winners = [item for item in results if item.get("outcome") == OUTCOME_COMMITTED]
+            _expect(
+                len(winners) == 1,
+                "exactly one of the concurrent attempts commits",
+                f"{len(winners)} of {reg.PROCESSES} attempts committed",
+            )
+            _expect(
+                calls == 1,
+                "the fake executor ran exactly once",
+                f"the executor ran {calls} times across {reg.PROCESSES} processes",
+            )
+            _expect(
+                len(pids) == reg.PROCESSES and os.getpid() not in pids,
+                "every contending attempt ran in its own OS process",
+                f"{len(pids)} distinct child pids, parent {os.getpid()}",
+            )
+            record = store.get_effect(key)
+            _expect(
+                record is not None and record.state is EffectState.COMMITTED,
+                "the contended key ends COMMITTED",
+                f"the record is {None if record is None else record.state}",
+            )
+
+        try:
+            return self.graded("G4", selection, store, recorder, body)
+        finally:
+            store.close()
+
+    def _contend(
+        self,
+        control: Control,
+        store: SQLiteStateStore,
+        selection: _Selection,
+        keys: Sequence[str],
+        label: str,
+    ) -> tuple[list[dict[str, Any]], int, set[int]]:
+        """Run one attempt per key in its own OS process, and read back what each did."""
+        directory = self._scratch / "G4" / label
+        counters = directory / "calls"
+        results = directory / "results"
+        counters.mkdir(parents=True, exist_ok=True)
+        results.mkdir(parents=True, exist_ok=True)
+        payloads: list[str] = []
+        for index, key in enumerate(keys):
+            action = selection.build()
+            approval_id = self.approve(control, store, action, selection)
+            payloads.append(
+                json.dumps(
+                    {
+                        "index": index,
+                        "policy_path": str(self._loaded.policy_path),
+                        "authority_yaml": self._loaded.authority_text,
+                        "authority_source": str(self._loaded.authority_path or ""),
+                        "authority_standalone": self._loaded.authority_standalone,
+                        "store_path": str(store.path),
+                        "environment": selection.environment,
+                        "action": selection.action,
+                        "arguments": dict(selection.arguments),
+                        "agent": selection.principal.agent,
+                        "user": selection.principal.user,
+                        "resource": selection.resource,
+                        "effect_key": key,
+                        "approval_id": approval_id,
+                        "counter_dir": str(counters),
+                        "result_dir": str(results),
+                    }
+                )
+            )
+        run_attempts(payloads)
+        read: list[dict[str, Any]] = []
+        pids: set[int] = set()
+        for path in sorted(results.glob("*.json")):
+            document = json.loads(path.read_text(encoding="utf-8"))
+            read.append(document)
+            pids.add(int(document["pid"]))
+        return read, len(list(counters.iterdir())), pids
+
+    # --- G5: an ambiguous outcome blocks a blind retry -----------------------------------
+
+    def g5(self) -> GuaranteeResult:
+        selection = self.select(needs_effect=True)
+        if selection is None:
+            return self.na("G5", reg.NO_EFFECT_TEMPLATE, note=reg.EFFECT_TEMPLATE_NOTE)
+        control, store, recorder, _ = self._control_for("G5", selection)
+
+        def body(detail: dict[str, Any]) -> None:
+            # The control carries more weight than any other in the catalogue: it is the only
+            # thing separating "CTRLRun blocks blind retries" from "CTRLRun blocks retries",
+            # and the second sentence describes a library nobody can deploy (§2.2).
+            control_key = f"{selection.effect_key!s}-{reg.SYNTHETIC_PREFIX}-control"
+            seen: list[int] = []
+
+            def not_executed_then_commit() -> Any:
+                seen.append(1)
+                if len(seen) == 1:
+                    raise NotExecuted("ctrlrun-verify: the remote did nothing")
+                return f"{APPROVER}-result"
+
+            honest = _Executor(not_executed_then_commit)
+            first = selection.build()
+            with suppress(NotExecuted):
+                self.execute(
+                    control,
+                    first,
+                    honest,
+                    control_key,
+                    self.approve(control, store, first, selection),
+                )
+            failed = store.get_effect(control_key)
+            _expect_control(
+                failed is not None and failed.state is EffectState.FAILED,
+                "an executor that raises NotExecuted leaves the record FAILED",
+                f"the record is {None if failed is None else failed.state}",
+            )
+            retry = selection.build()
+            admitted = self.execute(
+                control, retry, honest, control_key, self.approve(control, store, retry, selection)
+            )
+            _expect_control(
+                admitted.result is ReceiptResult.COMMITTED and honest.calls == 2,
+                "the retry after NotExecuted is admitted and executes",
+                f"it ended {admitted.result} after {honest.calls} executor calls",
+            )
+
+            key = str(selection.effect_key)
+            remote = _Executor(
+                _raises(
+                    TimeoutError("ctrlrun-verify: the response was lost after the remote acted")
+                )
+            )
+            lost = selection.build()
+            with suppress(TimeoutError):
+                self.execute(
+                    control, lost, remote, key, self.approve(control, store, lost, selection)
+                )
+            record = store.get_effect(key)
+            _expect(
+                record is not None and record.state is EffectState.AMBIGUOUS,
+                "the timed-out attempt leaves the record AMBIGUOUS",
+                f"the record is {None if record is None else record.state}",
+            )
+            receipt = _last_receipt(store, lost.action_id)
+            _expect(
+                receipt is not None and receipt.result is ReceiptResult.AMBIGUOUS,
+                "the timed-out attempt's receipt is `ambiguous`",
+                f"the receipt is {None if receipt is None else receipt.result}",
+            )
+            blind = selection.build()
+            self.refused(
+                lambda: self.execute(
+                    control, blind, remote, key, self.approve(control, store, blind, selection)
+                ),
+                (AmbiguousEffect,),
+                "AmbiguousEffect on the retry",
+                "the retry after an ambiguous outcome reached the remote",
+            )
+            _expect(
+                remote.calls == 1,
+                "the remote is called once, not twice",
+                f"the remote was called {remote.calls} times",
+            )
+            blocked = _last_receipt(store, blind.action_id)
+            _expect(
+                blocked is not None and blocked.result is ReceiptResult.BLOCKED,
+                "the retry's receipt is `blocked`",
+                f"the receipt is {None if blocked is None else blocked.result}",
+            )
+            after = store.get_effect(key)
+            _expect(
+                after is not None and after.state is EffectState.AMBIGUOUS,
+                "the record is still AMBIGUOUS afterwards",
+                f"the record is {None if after is None else after.state}",
+            )
+
+        try:
+            return self.graded("G5", selection, store, recorder, body)
+        finally:
+            store.close()
+
+    # --- G6: an action the policy does not list is refused -------------------------------
+
+    def g6(self) -> GuaranteeResult:
+        listed = sorted(self.policy.actions)
+        if not listed:
+            return self.na("G6", reg.NO_ACTIONS)
+        digest = hashlib.sha256("\n".join(listed).encode("utf-8")).hexdigest()[:12]
+        absent = f"ctrlrun.verify.absent.{digest}"
+        # SPEC: §2.2 fixes G6's observable as `ActionDenied(reason="unknown_action")`, and
+        # `v0.3 §4.3` evaluates authority **before** policy — so under an `authority:` section
+        # a name no grant covers is refused by the authority axis and the policy axis is never
+        # reached. G6 descends from `v0.1 §7` T6, which is about the policy axis and predates
+        # the authority model, so its scenario drives a `Control` composed from the policy
+        # alone. The kernel code under test is unchanged; what is left out is a second,
+        # independent refusal that G7 and G8 exercise directly.
+        control, store, recorder, _ = self.control("G6", authority=False)
+
+        def body(detail: dict[str, Any]) -> None:
+            detail["axis"] = "policy"
+            detail["absent_action"] = absent
+            executor = _Executor()
+            action = Action(
+                name=absent,
+                arguments={},
+                principal=Principal(agent=APPROVER),
+                environment=self._default_environment,
+            )
+            refusal = self.refused(
+                lambda: control.execute(action, executor, None),
+                (ActionDenied,),
+                "ActionDenied(reason='unknown_action')",
+                f"the unlisted action {absent} was not refused",
+            )
+            reason = getattr(refusal, "reason", "")
+            _expect(
+                reason == "unknown_action",
+                "ActionDenied(reason='unknown_action')",
+                f"ActionDenied(reason={reason!r})",
+            )
+            _expect(
+                executor.calls == 0,
+                "the executor is not reached",
+                f"the executor was called {executor.calls} times",
+            )
+            receipt = _last_receipt(store, action.action_id)
+            _expect(
+                receipt is not None and receipt.result is ReceiptResult.DENIED,
+                "a `denied` receipt is written",
+                f"the receipt is {None if receipt is None else receipt.result}",
+            )
+            known = Action(
+                name=listed[0],
+                arguments={},
+                principal=Principal(agent=APPROVER),
+                environment=self._default_environment,
+            )
+            evaluation = control.evaluate(known)
+            _expect_control(
+                evaluation.reason != "unknown_action",
+                f"the listed action {listed[0]} evaluates to something other than unknown_action",
+                f"it evaluated to {evaluation.decision}/{evaluation.reason}",
+            )
+
+        try:
+            return self.graded("G6", None, store, recorder, body)
+        finally:
+            store.close()
+
+    # --- G7: an action with no principal is refused --------------------------------------
+
+    def _protected(
+        self, selection: _Selection, control: Control, executor: _Executor
+    ) -> Callable[..., Any]:
+        """A `@protect`-decorated fake with the chosen action's argument names.
+
+        The decorator is the entry point G7 is about — `v0.1 §2.1`'s refusal happens in the
+        wrapper, before a `Control` is asked anything — so the scenario goes through it rather
+        than round it. `__signature__` gives the fake real parameter names without an `exec`;
+        `protect` reads it, and `_reject_variadic` sees named parameters, which is what a
+        protected function must have for policy to be able to address its arguments.
+        """
+        import inspect
+
+        parameters = [
+            inspect.Parameter(name, inspect.Parameter.KEYWORD_ONLY)
+            for name in sorted(selection.arguments)
+        ]
+
+        def fake(**kwargs: Any) -> Any:
+            return executor()
+
+        fake.__signature__ = inspect.Signature(parameters)  # type: ignore[attr-defined]
+        fake.__name__ = "ctrlrun_verify_action"
+        decorated: Callable[..., Any] = protect(selection.action, control=control)(fake)
+        return decorated
+
+    def g7(self) -> GuaranteeResult:
+        selection = self.select()
+        if selection is None:
+            # SPEC: §2.2 says G7 is never N/A, and §1.3 requires a positive control. Both
+            # cannot hold for a policy in which nothing can run: the control is "the identical
+            # call inside `context()` runs", and there is no such call. T101b requires an empty
+            # `actions:` to leave zero applicable guarantees, which settles it — this is a
+            # statement about the document, so N/A, and never a silent pass.
+            return self.na("G7", reg.EVERY_ACTION_DENIED)
+        control, store, recorder, _ = self._control_for("G7", selection)
+
+        def body(detail: dict[str, Any]) -> None:
+            executor = _Executor()
+            call = self._protected(selection, control, executor)
+            arguments = dict(selection.arguments)
+            refusal = self.refused(
+                lambda: call(**arguments),
+                (ActionDenied,),
+                "ActionDenied(reason='no_principal') outside context()",
+                "an action proposed with no principal ran",
+            )
+            reason = getattr(refusal, "reason", "")
+            _expect(
+                reason == "no_principal",
+                "ActionDenied(reason='no_principal')",
+                f"ActionDenied(reason={reason!r})",
+            )
+            _expect(
+                executor.calls == 0,
+                "the executor is not reached",
+                f"the executor was called {executor.calls} times",
+            )
+            _expect(
+                store.receipts() == () and store.events() == (),
+                "no receipt and no event are written",
+                f"{len(store.receipts())} receipts and {len(store.events())} events exist",
+            )
+            with context(selection.principal.agent, selection.principal.user):
+                try:
+                    call(**arguments)
+                except Exception as pending:
+                    from ..errors import ApprovalRequired
+
+                    if not isinstance(pending, ApprovalRequired):
+                        raise
+                    # §3.5 — verify grants its own approval, through the call
+                    # `ctrlrun approve` makes, and the report says so.
+                    detail["approved_by_verify"] = True
+                    store.grant_approval(pending.request_id, APPROVER)
+                    from ..control import with_approval
+
+                    with with_approval(pending.request_id):
+                        call(**arguments)
+            _expect_control(
+                executor.calls == 1,
+                "the identical call inside context() runs",
+                f"the executor was called {executor.calls} times inside context()",
+            )
+
+        try:
+            return self.graded("G7", selection, store, recorder, body)
+        finally:
+            store.close()
+
+    # --- G8: an expired grant refuses an action it would otherwise permit ----------------
+
+    def _expiry_is_decisive(self, selection: _Selection) -> bool:
+        """Does this grant's expiry actually decide the action, or does another grant cover it?
+
+        Asked before the scenario runs, against a throwaway in-memory store, so a layered
+        configuration reports N/A rather than a failure that is really a property of the
+        document (§2.2's N/A rule, applied one level down).
+
+        It asks only **whether** authority still passes, never **why** it stopped. The reason
+        is the guarantee's own observable, and a pre-check that filtered on it would turn a
+        kernel denying for the wrong cause into an N/A — a false N/A, which §9.2 calls a false
+        pass wearing the other costume.
+        """
+        grant = selection.grant
+        if grant is None or grant.expires_at is None or self.authority is None:
+            return False
+        store = InMemoryStateStore()
+        try:
+            result = self.authority.evaluate(
+                selection.build(), now=grant.expires_at + _ONE_MICROSECOND, store=store
+            )
+        finally:
+            store.close()
+        return not result.passed
+
+    def g8(self) -> GuaranteeResult:
+        if self.authority is None:
+            return self.na("G8", reg.NO_AUTHORITY_SECTION)
+        if not any(grant.expires_at is not None for grant in self.authority.grants.values()):
+            return self.na("G8", reg.NO_EXPIRES_AT)
+        excluded: set[str] = set()
+        selection: _Selection | None = None
+        matched_any = False
+        for _ in range(len(self.authority.grants) + 1):
+            candidate = self.select(
+                grant_filter=lambda grant: grant.expires_at is not None and grant.id not in excluded
+            )
+            if candidate is None:
+                break
+            matched_any = True
+            if self._expiry_is_decisive(candidate):
+                selection = candidate
+                break
+            excluded.add(str(candidate.grant.id if candidate.grant else ""))
+        if selection is None:
+            return self.na("G8", EXPIRY_NOT_DECISIVE if matched_any else reg.NO_GRANT_MATCHES)
+        grant = selection.grant
+        assert grant is not None
+        expires_at = grant.expires_at
+        assert expires_at is not None
+        clock = _Clock(expires_at)
+        control, store, recorder, _ = self._control_for("G8", selection, clock=clock)
+
+        def body(detail: dict[str, Any]) -> None:
+            detail["grant_id"] = grant.id
+            detail["expires_at"] = iso_timestamp(expires_at)
+            # The before-expiry half **is** the control, and it is why the two halves are one
+            # scenario: a kernel that denied everything would satisfy the after half alone.
+            action = selection.build()
+            executor = _Executor()
+            receipt = self.execute(
+                control,
+                action,
+                executor,
+                selection.effect_key,
+                self.approve(control, store, action, selection),
+            )
+            _expect_control(
+                receipt.result is ReceiptResult.COMMITTED and executor.calls == 1,
+                "at expires_at exactly, the action passes authority and runs",
+                f"it ended {receipt.result} after {executor.calls} executor calls",
+            )
+            _expect_control(
+                _named_event(recorder, EventType.AUTHORITY_RESOLVED, grant_id=grant.id),
+                f"AUTHORITY_RESOLVED naming {grant.id}",
+                f"events were {recorder.types()}",
+            )
+            clock.at(expires_at + _ONE_MICROSECOND)
+            later = selection.build()
+            after_executor = _Executor()
+            refusal = self.refused(
+                lambda: self.execute(control, later, after_executor, selection.effect_key, None),
+                (AuthorityDenied,),
+                "AuthorityDenied(reason='authority_expired') one microsecond later",
+                "the action still ran after its grant expired",
+            )
+            reason = getattr(refusal, "reason", "")
+            _expect(
+                reason == AUTHORITY_EXPIRED,
+                "AuthorityDenied(reason='authority_expired')",
+                f"AuthorityDenied(reason={reason!r})",
+            )
+            _expect(
+                after_executor.calls == 0,
+                "the executor is not reached after the grant expires",
+                f"the executor was called {after_executor.calls} times",
+            )
+            denied_receipt = _last_receipt(store, later.action_id)
+            _expect(
+                denied_receipt is not None and denied_receipt.result is ReceiptResult.DENIED,
+                "a `denied` receipt is written",
+                f"the receipt is {None if denied_receipt is None else denied_receipt.result}",
+            )
+
+        try:
+            return self.graded("G8", selection, store, recorder, body)
+        finally:
+            store.close()
+
+    # --- G9: a delegation cannot widen its parent ----------------------------------------
+
+    def g9(self) -> GuaranteeResult:
+        if self.authority is None:
+            return self.na("G9", reg.NO_AUTHORITY_SECTION)
+        delegable = [
+            self.authority.grants[grant_id]
+            for grant_id in sorted(self.authority.grants)
+            if self.authority.grants[grant_id].delegable
+        ]
+        if not delegable:
+            return self.na("G9", reg.NO_DELEGABLE_GRANT)
+        parent = delegable[0]
+        selection = self.select(grant_filter=lambda grant: grant.id == parent.id)
+        if selection is None:
+            return self.na("G9", reg.NO_GRANT_MATCHES)
+        control, store, recorder, _ = self._control_for("G9", selection)
+
+        def body(detail: dict[str, Any]) -> None:
+            detail["grant_id"] = parent.id
+            by = _principal_for(parent.subject)
+            narrowed, child_principal, tightened = _narrow(parent, selection)
+            detail["constraints_tightened"] = tightened
+            delegation = control.delegate(parent.id, narrowed, by=by)
+            _expect_control(
+                store.get_delegation(delegation.delegation_id) is not None,
+                "a child narrowed on every dimension the parent constrains is accepted",
+                "the delegation row was not written",
+            )
+            _expect_control(
+                _named_event(
+                    recorder,
+                    EventType.DELEGATION_CREATED,
+                    delegation_id=delegation.delegation_id,
+                ),
+                "DELEGATION_CREATED reaches a registered sink",
+                f"events were {recorder.types()}",
+            )
+            isolated = not parent.subject.matches(child_principal)
+            detail["delegation_isolated"] = isolated
+            child_action = Action(
+                name=selection.action,
+                arguments=dict(selection.arguments),
+                principal=child_principal,
+                resource=selection.resource,
+                environment=selection.environment,
+            )
+            executor = _Executor()
+            child_key = (
+                None
+                if selection.effect_key is None
+                else f"{selection.effect_key}-{reg.SYNTHETIC_PREFIX}-child"
+            )
+            approval_id = self.approve(control, store, child_action, selection)
+            receipt = self.execute(control, child_action, executor, child_key, approval_id)
+            _expect_control(
+                receipt.result is ReceiptResult.COMMITTED,
+                "an action within the child's limits passes authority",
+                f"it ended {receipt.result}",
+            )
+            if isolated:
+                # Where the parent's subject does not match the child's, the delegation is
+                # the *only* authority for this action, so the event names it. Where it does
+                # — a parent addressed to `agent: "*"` — `v0.3 §4.6` picks the lowest grant
+                # id among those that passed, and naming the delegation would be asserting
+                # something the model does not promise.
+                _expect_control(
+                    _named_event(
+                        recorder,
+                        EventType.AUTHORITY_RESOLVED,
+                        delegation_id=delegation.delegation_id,
+                    ),
+                    f"AUTHORITY_RESOLVED naming {delegation.delegation_id}",
+                    f"events were {recorder.types()}",
+                )
+
+            exercised: list[str] = []
+            unconstrained: list[str] = []
+            omissions: dict[str, str] = {}
+            for dimension in DIMENSIONS:
+                widened = _widen(parent, narrowed, dimension)
+                if widened is None or contained_dimension(parent, widened) is None:
+                    unconstrained.append(dimension)
+                    continue
+                offending = contained_dimension(parent, widened)
+                if offending != dimension:
+                    raise VerifyInternalError(
+                        f"G9: the widened child for {dimension!r} fails containment on "
+                        f"{offending!r} instead (SPEC-v0.4 §3.4)"
+                    )
+                before = len(store.delegations(include_revoked=True))
+                self._refuse_delegation(
+                    control, store, recorder, parent, widened, dimension, before
+                )
+                omissions[dimension] = self._refuse_omission(
+                    control, store, recorder, parent, narrowed, dimension
+                )
+                exercised.append(dimension)
+            _expect(
+                bool(exercised),
+                "at least one dimension is exercised",
+                "the parent constrains no dimension a child could widen",
+            )
+            detail["dimensions_exercised"] = exercised
+            detail["dimensions_unconstrained"] = unconstrained
+            detail["omissions"] = omissions
+            detail["summary"] = f"{len(exercised)} of {len(DIMENSIONS)} dimensions"
+
+        try:
+            return self.graded("G9", selection, store, recorder, body)
+        finally:
+            store.close()
+
+    def _refuse_delegation(
+        self,
+        control: Control,
+        store: SQLiteStateStore,
+        recorder: _Recorder,
+        parent: Grant,
+        child: Grant,
+        dimension: str,
+        before: int,
+    ) -> None:
+        rejected = len(
+            [event for event in recorder.events if event.type is EventType.DELEGATION_REJECTED]
+        )
+        escalation = self.refused(
+            lambda: control.delegate(parent.id, child, by=_principal_for(parent.subject)),
+            (AuthorityEscalation,),
+            f"AuthorityEscalation(reason='containment', dimension={dimension!r})",
+            f"a child widened on {dimension} was accepted",
+        )
+        _expect(
+            getattr(escalation, "reason", "") == CONTAINMENT
+            and getattr(escalation, "dimension", None) == dimension,
+            f"AuthorityEscalation(reason='containment', dimension={dimension!r})",
+            f"AuthorityEscalation(reason={getattr(escalation, 'reason', None)!r}, "
+            f"dimension={getattr(escalation, 'dimension', None)!r})",
+        )
+        now = len(
+            [event for event in recorder.events if event.type is EventType.DELEGATION_REJECTED]
+        )
+        _expect(
+            now == rejected + 1,
+            "exactly one DELEGATION_REJECTED is appended",
+            f"{now - rejected} were appended",
+        )
+        _expect(
+            len(store.delegations(include_revoked=True)) == before,
+            "no delegation row is written for the child that was refused",
+            "a delegation row was written",
+        )
+
+    def _refuse_omission(
+        self,
+        control: Control,
+        store: SQLiteStateStore,
+        recorder: _Recorder,
+        parent: Grant,
+        narrowed: Grant,
+        dimension: str,
+    ) -> str:
+        """The omission half: a child that **drops** a dimension its parent constrains.
+
+        Two shapes, and both are the guarantee: `actions: []` and a subject with neither an
+        agent nor a user are refused by the model at construction, one layer below
+        containment; everything else reaches `Control.delegate` and is refused there. Omission
+        never means unlimited, whichever layer says so.
+        """
+        try:
+            omitting = _omit(narrowed, parent, dimension)
+        except InvalidArgument:
+            return "refused at construction"
+        if omitting is None:
+            return "the parent leaves nothing to omit on this dimension"
+        before = len(store.delegations(include_revoked=True))
+        self._refuse_delegation(control, store, recorder, parent, omitting, dimension, before)
+        return "refused by containment"
+
+    # --- G10: an unknown exception is an AMBIGUOUS outcome, never FAILED ------------------
+
+    def g10(self) -> GuaranteeResult:
+        selection = self.select()
+        if selection is None:
+            return self.na("G10", reg.EVERY_ACTION_DENIED)
+        control, store, recorder, _ = self._control_for("G10", selection)
+
+        rows: tuple[tuple[str, BaseException, ReceiptResult, EffectState], ...] = (
+            (
+                "timeout",
+                TimeoutError("ctrlrun-verify: the request timed out"),
+                ReceiptResult.AMBIGUOUS,
+                EffectState.AMBIGUOUS,
+            ),
+            (
+                "runtime_error",
+                RuntimeError("ctrlrun-verify: the executor raised"),
+                ReceiptResult.AMBIGUOUS,
+                EffectState.AMBIGUOUS,
+            ),
+            # The row that must not be dropped: `NotExecuted` is the control, and the
+            # guarantee is the asymmetry, so both directions are asserted or neither is.
+            (
+                "not_executed",
+                NotExecuted("ctrlrun-verify: the remote did nothing"),
+                ReceiptResult.FAILED,
+                EffectState.FAILED,
+            ),
+        )
+
+        def body(detail: dict[str, Any]) -> None:
+            observed: dict[str, str] = {}
+            for label, exception, expected_result, expected_state in rows:
+                action = selection.build()
+                key = (
+                    None
+                    if selection.effect_key is None
+                    else f"{selection.effect_key}-{reg.SYNTHETIC_PREFIX}-{label}"
+                )
+                executor = _Executor(_raises(exception))
+                try:
+                    self.execute(
+                        control,
+                        action,
+                        executor,
+                        key,
+                        self.approve(control, store, action, selection),
+                    )
+                except (VerifyRefused, VerifyInternalError):
+                    raise
+                except Exception:  # every row raises by design; the receipt is the observable
+                    # `v0.1 §5.5` propagates the executor's own exception, whatever it is.
+                    # What this row asserts is the *mapping*, which lives on the receipt and
+                    # on the effect record, so the exception's own type is not re-asserted
+                    # here — a check that did would go red for a kernel that mapped
+                    # correctly and merely wrapped.
+                    pass
+                receipt = _last_receipt(store, action.action_id)
+                observed[label] = "" if receipt is None else str(receipt.result)
+                is_control = label == "not_executed"
+                check = _expect_control if is_control else _expect
+                expectation = f"{type(exception).__name__} produces a {expected_result} receipt"
+                check(
+                    receipt is not None and receipt.result is expected_result,
+                    expectation,
+                    f"{type(exception).__name__} produced "
+                    f"{None if receipt is None else receipt.result}",
+                )
+                if key is not None:
+                    record = store.get_effect(key)
+                    check(
+                        record is not None and record.state is expected_state,
+                        f"{type(exception).__name__} leaves the record {expected_state}",
+                        f"the record is {None if record is None else record.state}",
+                    )
+            detail["rows"] = observed
+
+        try:
+            return self.graded("G10", selection, store, recorder, body)
+        finally:
+            store.close()
+
+
+def run_attempts(payloads: Sequence[str]) -> None:
+    """Launch one OS process per payload and wait for all of them (§2.2 G4).
+
+    `python -m ctrlrun.verify.worker`, payload on stdin. Not `multiprocessing`: `spawn`
+    re-imports the caller's `__main__` in every child, so a caller who ran `verify.run()` from
+    an unguarded script would fork-bomb itself, and requiring an `if __name__ == "__main__"`
+    guard in the program under verification is not a trade a verification tool gets to make.
+
+    Bounded, so a child that wedges fails red rather than hanging CI: a timeout is not a test
+    failure (§3.6).
+    """
+    started: list[subprocess.Popen[bytes]] = []
+    for payload in payloads:
+        process = subprocess.Popen(
+            [sys.executable, "-m", "ctrlrun.verify.worker"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        assert process.stdin is not None
+        process.stdin.write(payload.encode("utf-8"))
+        process.stdin.close()
+        started.append(process)
+    for process in started:
+        try:
+            process.wait(timeout=_CHILD_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:  # pragma: no cover - only on a wedged child
+            process.kill()
+            process.wait(timeout=10)
+
+
+def _base_instant(authority: Authority | None) -> datetime:
+    """§3.6 — `T0`, derived from the document so two runs agree.
+
+    The earliest `expires_at` among the grants minus one hour, so every grant is live when a
+    scenario needs one; `2026-01-01T00:00:00Z` where no grant carries an expiry.
+    """
+    if authority is None:
+        return FALLBACK_T0
+    expiries = [
+        grant.expires_at for grant in authority.grants.values() if grant.expires_at is not None
+    ]
+    if not expiries:
+        return FALLBACK_T0
+    return min(expiries) - _ONE_HOUR
+
+
+# --- evidence for a counterexample (§4.5) -----------------------------------------------
+
+
+def _effect_dict(record: EffectRecord) -> dict[str, Any]:
+    return {
+        "effect_key": record.effect_key,
+        "state": str(record.state),
+        "action_id": record.action_id,
+        "attempt": record.attempt,
+        "created_at": iso_timestamp(record.created_at),
+        "updated_at": iso_timestamp(record.updated_at),
+        "error": record.error,
+    }
+
+
+def counterexample(
+    store: SQLiteStateStore, recorder: _Recorder, expected: str, observed: str
+) -> Counterexample:
+    """The ordered evidence for one scenario, in `event_id` order (§4.5)."""
+    return Counterexample(
+        expected=expected,
+        observed=observed,
+        receipts=tuple(receipt.to_dict() for receipt in store.receipts()),
+        events=tuple(event.to_dict() for event in store.events()),
+        effects=tuple(_effect_dict(record) for record in store.list_effects()),
+    )
+
+
+__all__ = [
+    "APPROVER",
+    "EXPIRY_NOT_DECISIVE",
+    "SQLITE_STORE_URL",
+    "Engine",
+    "VerifyInternalError",
+    "VerifyRefused",
+    "_Clock",
+    "_ControlFailed",
+    "_Executor",
+    "_Recorder",
+    "_Selection",
+    "_Violation",
+    "counterexample",
+    "load",
+    "run_attempts",
+]
+
+
+# --- the scenarios (§2.2) ----------------------------------------------------------------
+#
+# Each is written the same way round: the *control* establishes that the observable would have
+# been visible had the guard not fired, and the refusal is asserted **by name** — the reason,
+# the receipt field, the event type — never by exception class alone (§2.1, §8). Five refusals
+# that all raise `AuthorityDenied` are five guards a check asserting only the type cannot tell
+# apart.
+
+
+def _expect(held: bool, expected: str, observed: str) -> None:
+    """The guarantee's own refusal did not happen, or not for the stated reason."""
+    if not held:
+        raise _Violation(expected, observed)
+
+
+def _expect_control(held: bool, expected: str, observed: str) -> None:
+    """§1.3 — a control that does not behave as specified is FAIL, never PASS, never N/A."""
+    if not held:
+        raise _ControlFailed(observed, expected)
+
+
+def _named_event(recorder: _Recorder, type_: EventType, **data: Any) -> bool:
+    return any(
+        event.type is type_ and all(event.data.get(key) == value for key, value in data.items())
+        for event in recorder.events
+    )
+
+
+def _last_receipt(store: SQLiteStateStore, action_id: str) -> Receipt | None:
+    for receipt in reversed(store.receipts()):
+        if receipt.action_id == action_id:
+            return receipt
+    return None
+
+
+# --- deriving a child grant, dimension by dimension (§3.4) -------------------------------
+
+
+def _tightened(condition: Condition) -> Condition | None:
+    """One numeric bound moved inward. `eq` and `in` are left as the parent's (§3.4)."""
+    if not _is_int(condition.operand):
+        return None
+    if condition.op in ("gte", "gt"):
+        return replace(condition, operand=condition.operand + 1)
+    if condition.op in ("lte", "lt"):
+        return replace(condition, operand=condition.operand - 1)
+    return None
+
+
+def _loosened(condition: Condition) -> Condition:
+    """One dimension moved outward — the widened child of §3.4's table."""
+    if condition.op in ("gte", "gt") and _is_int(condition.operand):
+        return replace(condition, operand=condition.operand - 1)
+    if condition.op in ("lte", "lt") and _is_int(condition.operand):
+        return replace(condition, operand=condition.operand + 1)
+    if condition.op == "in":
+        first = condition.operand[0] if condition.operand else APPROVER
+        return replace(condition, operand=(*condition.operand, _negate_value(first)))
+    return replace(condition, operand=_negate_value(condition.operand))
+
+
+def _narrow(parent: Grant, selection: _Selection) -> tuple[Grant, Principal, dict[str, str]]:
+    """The narrowed child of §3.4 — G9's positive control.
+
+    Every dimension is narrowed to the *thing under test*: the action the scenario runs, the
+    resource it names, the environment it runs in. That keeps the control runnable, which is
+    the point of a control — a child narrowed to a literal nothing satisfies would be accepted
+    and then prove nothing.
+
+    The child's subject names an agent the parent's does not match, where it can. Containment
+    permits it (`v0.3 §5.4` leaves which concrete agent a child names unconstrained — that is
+    what delegation is for), and it is what lets the control assert that authority passed *via
+    the delegation* rather than via the parent that also covers the action.
+    """
+    agent = f"{reg.SYNTHETIC_PREFIX}-delegate"
+    user = _from_pattern(parent.subject.user)
+    subject = Subject(agent=agent, user=user)
+    child_principal = Principal(agent=agent, user=user)
+    action = Action(
+        name=selection.action,
+        arguments=dict(selection.arguments),
+        principal=child_principal,
+        resource=selection.resource,
+        environment=selection.environment,
+    )
+    constraints: dict[str, Condition] = dict(parent.constraints)
+    tightened: dict[str, str] = {}
+    for key, condition in parent.constraints.items():
+        candidate = _tightened(condition)
+        if candidate is None:
+            continue
+        trial = dict(constraints)
+        trial[key] = candidate
+        probe = replace(parent, id="", constraints=trial, delegable=False)
+        if probe.constraints_hold(action) and contained_dimension(parent, probe) is None:
+            constraints[key] = candidate
+            tightened[key] = f"{condition.operand} -> {candidate.operand}"
+    child = Grant(
+        id="",
+        subject=subject,
+        actions=(selection.action,),
+        resources=None if parent.resources is None else (str(selection.resource),),
+        constraints=constraints,
+        environments=None if parent.environments is None else (selection.environment,),
+        expires_at=None if parent.expires_at is None else parent.expires_at - _ONE_HOUR,
+        delegable=False,
+    )
+    offending = contained_dimension(parent, child)
+    if offending is not None:
+        raise VerifyInternalError(
+            f"G9: the narrowed child is not contained in {parent.id!r} on {offending!r}; "
+            "the control cannot be built (SPEC-v0.4 §3.4)"
+        )
+    return child, child_principal, tightened
+
+
+def _widen(parent: Grant, narrowed: Grant, dimension: str) -> Grant | None:
+    """The narrowed child, widened on exactly one dimension. `None` where there is nothing
+    to widen, which is how a dimension the parent does not constrain is reported unexercised
+    rather than silently counted as covered (§2.2 G9)."""
+    if dimension == "subject":
+        return replace(narrowed, subject=Subject(agent=WILDCARD, user=narrowed.subject.user))
+    if dimension == "actions":
+        return replace(narrowed, actions=(DEEP_WILDCARD,))
+    if dimension == "resources":
+        if parent.resources is None:
+            return None
+        return replace(narrowed, resources=(DEEP_WILDCARD,))
+    if dimension == "constraints":
+        if not parent.constraints:
+            return None
+        return replace(
+            narrowed,
+            constraints={key: _loosened(value) for key, value in parent.constraints.items()},
+        )
+    if dimension == "environments":
+        if parent.environments is None:
+            return None
+        return replace(
+            narrowed,
+            environments=(*parent.environments, f"{reg.SYNTHETIC_PREFIX}-env"),
+        )
+    if dimension == "expires_at":
+        if parent.expires_at is None:
+            return None
+        return replace(narrowed, expires_at=parent.expires_at + _ONE_HOUR)
+    raise VerifyInternalError(f"G9: unknown containment dimension {dimension!r}")
+
+
+def _omit(narrowed: Grant, parent: Grant, dimension: str) -> Grant | None:
+    """The narrowed child with one dimension **dropped**. May raise `InvalidArgument`.
+
+    `actions: []` and a subject with neither an agent nor a user are refused by the model at
+    construction, one layer below containment. That refusal is the guarantee too: omission
+    never means unlimited, whichever layer says so.
+    """
+    if dimension == "subject":
+        if parent.subject.user is None:
+            return None
+        return replace(narrowed, subject=Subject(agent=narrowed.subject.agent))
+    if dimension == "actions":
+        return replace(narrowed, actions=())
+    if dimension == "resources":
+        return None if parent.resources is None else replace(narrowed, resources=None)
+    if dimension == "constraints":
+        return None if not parent.constraints else replace(narrowed, constraints={})
+    if dimension == "environments":
+        return None if parent.environments is None else replace(narrowed, environments=None)
+    if dimension == "expires_at":
+        return None if parent.expires_at is None else replace(narrowed, expires_at=None)
+    raise VerifyInternalError(f"G9: unknown containment dimension {dimension!r}")

--- a/src/ctrlrun/verify/worker.py
+++ b/src/ctrlrun/verify/worker.py
@@ -1,0 +1,136 @@
+"""G4's process target. SPEC-v0.4 §2.2, §3.6.
+
+A module-level function taking one picklable argument — a JSON string — because a bound method
+over a `Control` is not picklable and `spawn` is the default start method on macOS and Windows.
+The child rebuilds the whole composition from paths and plain strings: the same policy
+document, the same authority document, a `SQLiteStateStore` on the same scratch file.
+
+It is reached as `python -m ctrlrun.verify.worker`, with the payload on stdin, rather than
+through `multiprocessing.Process`. `spawn` re-imports the parent's `__main__` module in every
+child, so a caller who ran `ctrlrun.verify.run()` from an unguarded script would fork-bomb
+itself — and "put your call under `if __name__ == '__main__'`" is not a requirement a
+verification tool gets to impose on the program it is verifying. These are the same eight OS
+processes either way, which is the whole of what the guarantee is about.
+
+The children run under the **real** clock. §2.2 says why: a callable is not picklable, and
+timing is not what G4 is about — atomicity across processes is. Every other scenario uses the
+injected clock of §3.6.
+
+Nothing here opens a socket, and nothing here imports the operator's code (§1.2, §3.7).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any
+
+#: What a child reports back, in the file it writes. The parent reads these rather than a
+#: return value, because a child that died before returning must still be visible as one.
+OUTCOME_COMMITTED = "committed"
+OUTCOME_REFUSED = "refused"
+OUTCOME_ERROR = "error"
+
+
+def _count(counter_dir: str) -> None:
+    """Record one executor call, in a way that survives a process boundary (§2.2).
+
+    `O_CREAT|O_EXCL` on a name no other attempt can produce: the file is the count, and a
+    count kept in process memory would be eight separate zeros.
+    """
+    name = os.path.join(counter_dir, f"{os.getpid()}-{time.monotonic_ns()}")
+    handle = os.open(name, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    os.close(handle)
+
+
+def attempt(payload: str) -> None:
+    """Execute one action against the scratch store, and write what happened.
+
+    `payload` is a JSON document rather than a tuple of positional arguments so the shape can
+    grow without a signature every caller has to match. Everything in it is picklable by
+    construction: it is a string.
+
+    Refusals are expected — seven of eight processes must meet one — so they are recorded and
+    never raised. An unexpected exception is recorded too, with its type, because a child that
+    vanished silently would look exactly like a child that lost the race.
+    """
+    request: dict[str, Any] = json.loads(payload)
+    result: dict[str, Any] = {"pid": os.getpid(), "index": request["index"]}
+    try:
+        from ..action import Action, Principal
+        from ..approval import LocalApprovalProvider
+        from ..authority import Authority
+        from ..control import Control
+        from ..errors import CTRLRunError
+        from ..policy import Policy
+        from ..state import SQLiteStateStore
+
+        policy = Policy.from_file(request["policy_path"])
+        authority = (
+            None
+            if request["authority_yaml"] is None
+            else Authority.from_yaml(
+                request["authority_yaml"],
+                source=request["authority_source"],
+                standalone=request["authority_standalone"],
+            )
+        )
+        store = SQLiteStateStore(request["store_path"])
+        control = Control(
+            policy,
+            store,
+            LocalApprovalProvider(store),
+            sinks=(),
+            authority=authority,
+            environment=request["environment"],
+        )
+        action = Action(
+            name=request["action"],
+            arguments=request["arguments"],
+            principal=Principal(agent=request["agent"], user=request["user"]),
+            resource=request["resource"],
+            environment=request["environment"],
+        )
+
+        def executor() -> str:
+            _count(request["counter_dir"])
+            return "ctrlrun-verify"
+
+        try:
+            if request["approval_id"] is not None:
+                from ..control import with_approval
+
+                with with_approval(request["approval_id"]):
+                    control.execute(action, executor, request["effect_key"])
+            else:
+                control.execute(action, executor, request["effect_key"])
+            result["outcome"] = OUTCOME_COMMITTED
+        except CTRLRunError as refused:
+            result["outcome"] = OUTCOME_REFUSED
+            result["refusal"] = type(refused).__name__
+            result["message"] = str(refused)
+        finally:
+            store.close()
+    except BaseException as exc:  # recorded, never re-raised: a child reports, it does not throw
+        result["outcome"] = OUTCOME_ERROR
+        result["refusal"] = type(exc).__name__
+        result["message"] = str(exc)
+    path = os.path.join(request["result_dir"], f"{request['index']}.json")
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(result, handle)
+
+
+def main() -> int:
+    """`python -m ctrlrun.verify.worker`, with one payload on stdin."""
+    import sys
+
+    attempt(sys.stdin.read())
+    return 0
+
+
+__all__ = ["OUTCOME_COMMITTED", "OUTCOME_ERROR", "OUTCOME_REFUSED", "attempt", "main"]
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised as a subprocess by G4
+    raise SystemExit(main())

--- a/tests/test_observe.py
+++ b/tests/test_observe.py
@@ -946,15 +946,34 @@ def test_T85_the_banner_keeps_json_stdout_parseable(cli):
     assert json.loads(result.stdout)["schema"] == STATS_SCHEMA
 
 
-@pytest.mark.parametrize("mode", [OBSERVE, ENFORCE])
-def test_T85_verify_exits_2_naming_v0_4(cli, mode):
-    _write_policy(cli, mode)
+def test_T85_verify_exits_2_under_observe_mode_naming_the_mode(cli):
+    """Amended by SPEC-v0.4 §9.4, item 2, in the commit that made `ctrlrun verify` real.
+
+    The frozen sentence was *"`ctrlrun verify` exits 2 in both modes with a message naming
+    v0.4"*, and its subject was explicitly temporary. It now exits 2 under `mode: observe`
+    only, with a message naming the mode: observe mode enforces nothing, so every refusal the
+    guarantees assert would be recorded rather than made, and there is nothing to verify
+    (SPEC-v0.4 §3.8). The banner assertions for every other command are untouched.
+    """
+    _write_policy(cli, OBSERVE)
 
     result = _run("verify")
 
     assert result.exit_code == 2
-    assert "0.4" in result.stderr
+    assert OBSERVE_BANNER in result.stderr
+    assert "observe" in result.stderr
     assert result.stdout == ""
+
+
+def test_T85_verify_runs_under_enforce_mode(cli):
+    """The other half of the same amendment: under `mode: enforce` it runs, and reports."""
+    _write_policy(cli, ENFORCE)
+
+    result = _run("verify")
+
+    assert result.exit_code == 0, result.output
+    assert OBSERVE_BANNER not in result.output
+    assert "declared guarantees pass" in result.stdout
 
 
 def test_T85_a_policy_that_cannot_be_loaded_exits_non_zero_without_a_banner(cli):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,0 +1,760 @@
+"""`ctrlrun verify` — the registry, the engine, G1-G6 and G10. SPEC-v0.4 §2, §3; T100-T107.
+
+T125 and T125b live here too, despite sitting at the end of the number range: they are the two
+guards on verify lying about itself (§8), and item 1 is where they belong.
+
+Every test that asserts a guarantee **passes** also has to show it can fail — a verify whose
+every guarantee is hard-coded to pass satisfies T100 perfectly — so T104 and T125 inject a
+broken kernel and a broken control and require the report to go red.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from ctrlrun.verify import Status, VerifyRefused, run
+from ctrlrun.verify import guarantees as reg
+from ctrlrun.verify.report import REPORT_SCHEMA
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AUTHORITY_PAYMENTS = REPO_ROOT / "examples" / "authority" / "payments.yaml"
+EXAMPLE_POLICY = REPO_ROOT / "ctrlrun.example.yaml"
+V1_PAYMENTS = REPO_ROOT / "examples" / "policies" / "payments.yaml"
+
+V1 = "schema: ctrlrun.policy/v1\n"
+V2 = "schema: ctrlrun.policy/v2\n"
+V3 = "schema: ctrlrun.policy/v3\n"
+
+#: A v2 document with effect templates, so the effect guarantees are applicable, and an
+#: approve band, so the approval guarantees are.
+WITH_EFFECTS = (
+    V2
+    + """
+actions:
+  acme.refund:
+    effect: "refund:{payment_id}"
+    resource: "payment:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 1000 }
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 100000 }
+        decision: approve
+      - decision: deny
+  acme.read:
+    decision: allow
+"""
+)
+
+#: The same, with no `approve` band anywhere: G1 and G2 cannot be exercised.
+NO_APPROVAL = (
+    V2
+    + """
+actions:
+  acme.refund:
+    effect: "refund:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 1000 }
+        decision: allow
+      - decision: deny
+  acme.read:
+    decision: allow
+"""
+)
+
+#: No effect template anywhere: G3, G4 and G5 cannot be exercised, and the rest still can.
+NO_EFFECTS = (
+    V1
+    + """
+actions:
+  acme.refund:
+    rules:
+      - when: { amount_gte: 0, amount_lte: 1000 }
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 100000 }
+        decision: approve
+      - decision: deny
+  acme.read:
+    decision: allow
+"""
+)
+
+#: Nothing at all: every guarantee is N/A, which §3.8 makes an exit of 2 and never a pass.
+EMPTY = V1 + "actions: {}\n"
+
+
+def _write(directory: Path, document: str, name: str = "ctrlrun.yaml") -> Path:
+    path = directory / name
+    path.write_text(document, encoding="utf-8")
+    return path
+
+
+def _by_id(report):
+    return {result.id: result for result in report.guarantees}
+
+
+# --- T100: verify against this repository's own configurations ---------------------------
+
+
+@pytest.mark.authority
+def test_T100_the_authority_example_passes_every_non_authority_guarantee():
+    """`examples/authority/payments.yaml`: a v3 document with effect templates and grants.
+
+    G7 lands with item 2 and is asserted there; G8 and G9 likewise. Everything else must be
+    applicable and pass, and the action each chose is asserted by name — a selection that
+    silently changed which action it ran fails here.
+    """
+    report = run(AUTHORITY_PAYMENTS)
+    results = _by_id(report)
+
+    for gid in ("G1", "G2", "G3", "G4", "G5", "G6", "G10"):
+        assert results[gid].status is Status.PASS, (gid, results[gid].reason)
+    for gid in ("G1", "G2", "G3", "G4", "G5", "G10"):
+        assert results[gid].action == "stripe.refund", gid
+    assert results["G3"].effect_key == "refund:ctrlrun-verify-payment_id"
+    assert report.exit_code == 0
+
+
+def test_T100_a_v1_document_with_no_templates_and_no_grants():
+    """`ctrlrun.example.yaml`: G1, G2, G6 and G10 applicable and passing, the rest N/A."""
+    report = run(EXAMPLE_POLICY)
+    results = _by_id(report)
+
+    for gid in ("G1", "G2", "G6", "G10"):
+        assert results[gid].status is Status.PASS, (gid, results[gid].reason)
+    assert results["G1"].action == "k8s.delete_namespace"
+    assert results["G10"].action == "customer.read"
+    for gid in ("G3", "G4", "G5"):
+        assert results[gid].status is Status.NOT_APPLICABLE
+    assert report.exit_code == 0
+
+
+# --- T101 / T101b: N/A is not a pass, and zero applicable is not a pass ------------------
+
+
+def test_T101_a_policy_with_no_approve_rule_makes_G1_and_G2_not_applicable(tmp_path):
+    path = _write(tmp_path, NO_APPROVAL)
+
+    report = run(path)
+    results = _by_id(report)
+
+    for gid in ("G1", "G2"):
+        assert results[gid].status is Status.NOT_APPLICABLE, gid
+        assert results[gid].reason == reg.NO_APPROVE_RULE
+        # The `else` branch: either one reported `pass` is the defect this test exists for.
+        assert results[gid].status is not Status.PASS
+    assert report.applicable == report.passed + report.failed
+    # Ten in the catalogue; G1 and G2 for the missing approve band, G8 and G9 for the
+    # missing authority section. Six applicable, and the count is over those six.
+    assert report.applicable == 6
+    assert report.not_applicable == 4
+    text = report.to_text()
+    assert "8/8" not in text
+    assert f"{report.passed}/{report.applicable} declared guarantees pass." in text
+    assert "4 not applicable: G1, G2, G8, G9." in text
+
+
+def test_T101b_zero_applicable_guarantees_is_not_a_pass(tmp_path):
+    """§3.8 — `0/0` reported as success is the same false green as `8/8` with five N/As."""
+    path = _write(tmp_path, EMPTY)
+
+    report = run(path)
+
+    assert report.applicable == 0
+    assert all(result.status is Status.NOT_APPLICABLE for result in report.guarantees)
+    assert report.exit_code == 2
+    assert report.badge is None
+    assert "0/0 declared guarantees pass." in report.to_text()
+
+
+def test_T101b_the_command_exits_2_and_says_nothing_was_checked(tmp_path, monkeypatch):
+    from click.testing import CliRunner
+
+    from ctrlrun.cli.main import main
+
+    _write(tmp_path, EMPTY)
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(main, ["verify"])
+
+    assert result.exit_code == 2
+    assert "nothing was checked" in result.stderr
+
+
+# --- T102: no effect templates ------------------------------------------------------------
+
+
+def test_T102_a_policy_with_no_effect_templates_makes_G3_G4_and_G5_not_applicable(tmp_path):
+    path = _write(tmp_path, NO_EFFECTS)
+
+    report = run(path)
+    results = _by_id(report)
+
+    for gid in ("G3", "G4", "G5"):
+        assert results[gid].status is Status.NOT_APPLICABLE, gid
+        assert results[gid].reason == reg.NO_EFFECT_TEMPLATE
+        assert results[gid].detail["note"] == reg.EFFECT_TEMPLATE_NOTE
+        assert "@protect" in results[gid].detail["note"]
+    # A blanket "nothing applies" cannot pass this test.
+    for gid in ("G1", "G2", "G6", "G7", "G10"):
+        assert results[gid].status is Status.PASS, (gid, results[gid].reason)
+
+
+# --- T103: verify does not touch the operator's store -------------------------------------
+
+
+def _tree(root: Path) -> dict[str, tuple[str, int]]:
+    found: dict[str, tuple[str, int]] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            data = path.read_bytes()
+            found[str(path.relative_to(root))] = (
+                hashlib.sha256(data).hexdigest(),
+                path.stat().st_mtime_ns,
+            )
+    return found
+
+
+def _seed_store(directory: Path) -> Path:
+    """A `.ctrlrun/` with a receipt, an effect record, a delegation and the JSONL files."""
+    from datetime import UTC, datetime
+
+    from ctrlrun import (
+        Action,
+        Control,
+        InMemoryStateStore,
+        JSONLEventSink,
+        Policy,
+        Principal,
+        SQLiteStateStore,
+    )
+
+    del InMemoryStateStore
+    state = directory / ".ctrlrun"
+    state.mkdir(parents=True, exist_ok=True)
+    store = SQLiteStateStore(state / "state.db")
+    policy = Policy.from_yaml(WITH_EFFECTS, source=str(directory / "ctrlrun.yaml"))
+    control = Control(policy, store, sinks=[JSONLEventSink(state)])
+    action = Action(
+        name="acme.refund",
+        arguments={"amount": 10, "payment_id": "REAL-1"},
+        principal=Principal(agent="a-real-agent"),
+        resource="payment:REAL-1",
+    )
+    control.execute(action, lambda: "done", "refund:REAL-1")
+    from ctrlrun.state import DelegationRecord
+
+    store.put_delegation(
+        DelegationRecord(
+            delegation_id="dlg_" + "0" * 32,
+            parent_id="root",
+            depth=1,
+            grant_json=json.dumps({"subject": {"agent": "x"}, "actions": ["acme.refund"]}),
+            created_by_agent="a-real-agent",
+            created_by_user=None,
+            created_via="api",
+            created_at=datetime.now(UTC),
+        )
+    )
+    store.close()
+    return state
+
+
+def test_T103_the_operators_store_is_byte_identical_before_and_after(tmp_path, monkeypatch):
+    path = _write(tmp_path, WITH_EFFECTS)
+    state = _seed_store(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    before = _tree(state)
+    assert before, "the seeded store must actually contain something"
+
+    report = run(path)
+
+    assert report.exit_code == 0
+    assert _tree(state) == before
+
+
+def test_T103_a_store_that_does_not_exist_is_not_created(tmp_path, monkeypatch):
+    path = _write(tmp_path, WITH_EFFECTS)
+    monkeypatch.chdir(tmp_path)
+    assert not (tmp_path / ".ctrlrun").exists()
+
+    run(path)
+
+    assert not (tmp_path / ".ctrlrun").exists()
+    assert not (tmp_path / ".ctrlrun" / "state.db").exists()
+
+
+def test_T103_CTRLRUN_STATE_is_not_read_and_not_created(tmp_path, monkeypatch):
+    """The path an operator actually deploys: the store somewhere `$CTRLRUN_STATE` names."""
+    path = _write(tmp_path, WITH_EFFECTS)
+    elsewhere = tmp_path / "elsewhere" / "state.db"
+    monkeypatch.setenv("CTRLRUN_STATE", str(elsewhere))
+    monkeypatch.chdir(tmp_path)
+
+    run(path)
+
+    assert not elsewhere.exists()
+    assert not elsewhere.parent.exists()
+
+
+# --- T104: a broken kernel FAILS, with a counterexample -----------------------------------
+
+#: A kernel with the duplicate guard deleted: `plan_reservation` hands back a reservation
+#: where SPEC-v0.1 §5.4 says refuse. Installed through `sitecustomize` as well as in process,
+#: because G4's attempts run in their own OS processes and a mutation the children cannot see
+#: would leave G4 green against a broken kernel — which is the exact shape T104 exists to catch.
+_MUTATION_SOURCE = '''\
+"""A kernel whose `reserve_effect` always succeeds: SPEC-v0.1 §5.4's retry table, deleted."""
+
+from datetime import timedelta
+
+from ctrlrun.effect import DEFAULT_LEASE, EffectState, Reservation
+from ctrlrun.state import _iso
+
+
+def _always_reserves(self, effect_key, action_id, lease=DEFAULT_LEASE):
+    now = self._clock()
+    connection = self._connection()
+    connection.execute("BEGIN IMMEDIATE")
+    try:
+        connection.execute("DELETE FROM effects WHERE effect_key=?", (effect_key,))
+        connection.execute(
+            "INSERT INTO effects(effect_key, state, action_id, attempt, lease_expires_at, "
+            "result_json, error, created_at, updated_at) VALUES(?,?,?,?,?,NULL,NULL,?,?)",
+            (
+                effect_key,
+                str(EffectState.RESERVED),
+                action_id,
+                1,
+                _iso(now + lease),
+                _iso(now),
+                _iso(now),
+            ),
+        )
+        connection.execute("COMMIT")
+    except BaseException:
+        connection.execute("ROLLBACK")
+        raise
+    return Reservation(
+        effect_key=effect_key, action_id=action_id, attempt=1, lease_expires_at=now + lease
+    )
+'''
+
+#: The same mutation, installed by `site` at startup in every child G4 starts. A mutation the
+#: children could not see would leave G4 green against a broken kernel, which is the exact
+#: shape T104 exists to catch.
+_DELETE_THE_DUPLICATE_GUARD = (
+    _MUTATION_SOURCE
+    + "\nfrom ctrlrun.state import SQLiteStateStore as _Store\n"
+    + "_Store.reserve_effect = _always_reserves\n"
+)
+
+
+def _broken_kernel(tmp_path, monkeypatch):
+    """Install the mutation in this process and in every child G4 starts."""
+    guard = tmp_path / "broken"
+    guard.mkdir()
+    (guard / "sitecustomize.py").write_text(_DELETE_THE_DUPLICATE_GUARD, encoding="utf-8")
+    monkeypatch.setenv(
+        "PYTHONPATH",
+        os.pathsep.join(part for part in (str(guard), os.environ.get("PYTHONPATH", "")) if part),
+    )
+    namespace: dict = {}
+    # The *definition* only: the install line at the end of `_DELETE_THE_DUPLICATE_GUARD`
+    # writes straight onto `ctrlrun.state`, which monkeypatch could not undo, and a mutation
+    # that outlived its test would silently break every test after it.
+    exec(compile(_MUTATION_SOURCE, "<mutation>", "exec"), namespace)
+    from ctrlrun.state import SQLiteStateStore
+
+    monkeypatch.setattr(SQLiteStateStore, "reserve_effect", namespace["_always_reserves"])
+
+
+def test_T104_a_kernel_with_the_duplicate_guard_deleted_fails_G3_and_G4(tmp_path, monkeypatch):
+    path = _write(tmp_path, WITH_EFFECTS)
+    _broken_kernel(tmp_path, monkeypatch)
+
+    report = run(path)
+    results = _by_id(report)
+
+    assert results["G3"].status is Status.FAIL, results["G3"].reason
+    assert results["G4"].status is Status.FAIL, results["G4"].reason
+    assert report.exit_code == 1
+    example = results["G3"].counterexample
+    assert example is not None
+    # One receipt cannot show a double execution.
+    assert len(example.receipts) >= 2
+    assert example.effects
+    assert "DuplicateEffect" in example.expected
+    assert example.observed
+    document = json.loads(report.to_json())
+    assert document["schema"] == REPORT_SCHEMA
+    for row in document["guarantees"]:
+        if row["status"] == "fail":
+            assert row["counterexample"] is not None
+        else:
+            assert row["counterexample"] is None
+    # The other guarantees in the same run are unaffected, which is what makes the two
+    # failures attributable.
+    assert results["G1"].status is Status.PASS, results["G1"].reason
+    assert results["G6"].status is Status.PASS, results["G6"].reason
+
+
+# --- T105: determinism ---------------------------------------------------------------------
+
+
+def _stable(document: dict) -> dict:
+    document = dict(document)
+    document.pop("started_at", None)
+    document.pop("finished_at", None)
+    return document
+
+
+def test_T105_two_runs_produce_identical_json(tmp_path):
+    """Several actions per guarantee to choose from: a single-candidate document is
+    deterministic by accident."""
+    path = _write(
+        tmp_path,
+        V2
+        + """
+actions:
+  zeta.refund:
+    effect: "refund:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 10 }
+        decision: allow
+      - decision: approve
+  alpha.refund:
+    effect: "alpha:{ticket}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 500 }
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 5000 }
+        decision: approve
+      - decision: deny
+  beta.refund:
+    effect: "beta:{ticket}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 20 }
+        decision: allow
+      - decision: approve
+  gamma.read:
+    decision: allow
+""",
+    )
+
+    first = _stable(json.loads(run(path).to_json()))
+    second = _stable(json.loads(run(path).to_json()))
+
+    assert first == second
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+    chosen = {row["id"]: (row["action"], row["arguments"]) for row in first["guarantees"]}
+    assert chosen["G3"][0] == "alpha.refund", "selection is sorted by codepoint"
+
+
+# --- T106: G4 uses real processes -----------------------------------------------------------
+
+
+def test_T106_G4_contends_in_real_processes(tmp_path):
+    """A threads-only implementation fails this test.
+
+    The executor count comes from `O_CREAT|O_EXCL` files rather than from process memory, and
+    the control half — 8 distinct keys, 8 commits — is asserted in the same run, so a run in
+    which no child started cannot pass.
+    """
+    path = _write(tmp_path, WITH_EFFECTS)
+
+    report = run(path, only=("G4",))
+    result = _by_id(report)["G4"]
+
+    assert result.status is Status.PASS, result.reason
+    assert result.detail["processes"] == reg.PROCESSES
+    assert result.detail["distinct_child_pids"] == reg.PROCESSES
+    assert result.detail["parent_pid_among_children"] is False
+
+
+# --- T107: verify reaches no network ---------------------------------------------------------
+
+_REFUSE_EVERY_SOCKET = '''\
+"""Imported by `site` at startup: nothing under verify may open a socket."""
+
+import socket
+
+_real = socket.socket
+
+
+class _Refusing(_real):
+    def connect(self, *args, **kwargs):
+        raise RuntimeError("verify tried to connect; verify runs with no network")
+
+    def connect_ex(self, *args, **kwargs):
+        raise RuntimeError("verify tried to connect; verify runs with no network")
+
+
+def _refuse(*args, **kwargs):
+    raise RuntimeError("verify tried to resolve a name; verify runs with no network")
+
+
+socket.socket = _Refusing
+socket.create_connection = _refuse
+socket.getaddrinfo = _refuse
+'''
+
+_ASSERT_THE_GUARD_IS_LIVE = """
+import socket, sys
+
+# A network guard that was not installed proves nothing (SPEC-v0.4 §1.3).
+try:
+    socket.getaddrinfo("example.invalid", 80)
+except RuntimeError:
+    pass
+else:
+    sys.exit("the no-network guard was not installed")
+
+import ctrlrun.verify as verify
+
+report = verify.run(sys.argv[1])
+sys.exit(report.exit_code)
+"""
+
+
+def test_T107_a_full_run_completes_with_no_network(tmp_path):
+    path = _write(tmp_path, WITH_EFFECTS)
+    guard = tmp_path / "guard"
+    guard.mkdir()
+    (guard / "sitecustomize.py").write_text(_REFUSE_EVERY_SOCKET, encoding="utf-8")
+    script = tmp_path / "check.py"
+    script.write_text(_ASSERT_THE_GUARD_IS_LIVE, encoding="utf-8")
+
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(guard), environment.get("PYTHONPATH", "")) if part
+    )
+    finished = subprocess.run(
+        [sys.executable, str(script), str(path)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        env=environment,
+        cwd=tmp_path,
+        check=False,
+    )
+
+    assert finished.returncode == 0, f"{finished.stdout}\n{finished.stderr}"
+
+
+# --- T125: a failed control is a FAIL, never a PASS -------------------------------------------
+
+
+#: The guarantees item 1 ships. G7-G9 are asserted in `test_verify_authority.py`.
+ITEM_ONE = ("G1", "G2", "G3", "G4", "G5", "G6", "G10")
+
+
+def _break_the_executor(monkeypatch):
+    """The executor is never reached: nothing this scenario ran can have committed."""
+    from ctrlrun.verify import scenarios
+
+    def silent(self):
+        return None
+
+    monkeypatch.setattr(scenarios._Executor, "__call__", silent)
+
+
+def _break_the_commit(monkeypatch):
+    """The first attempt never reaches COMMITTED, so G3's control cannot establish anything."""
+    from ctrlrun.state import SQLiteStateStore
+
+    monkeypatch.setattr(
+        SQLiteStateStore, "commit_effect", lambda self, effect_key, action_id, result: None
+    )
+
+
+def _break_the_children(monkeypatch):
+    """No child ever starts, which is the scenario G4's control exists to rule out."""
+    from ctrlrun.verify import scenarios
+
+    monkeypatch.setattr(scenarios, "run_attempts", lambda payloads: None)
+
+
+def _break_the_evaluation(monkeypatch):
+    """Every action evaluates to `unknown_action`, so G6's refusal is not attributable."""
+    from ctrlrun.policy import Decision, Evaluation, Policy
+
+    monkeypatch.setattr(
+        Policy, "evaluate", lambda self, action: Evaluation(Decision.DENY, "unknown_action")
+    )
+
+
+def _break_the_asymmetry(monkeypatch):
+    """A kernel that maps *everything* to AMBIGUOUS: G10's `NotExecuted` row is the control."""
+    from ctrlrun.errors import NotExecuted
+    from ctrlrun.verify import scenarios
+
+    original = scenarios._raises
+
+    def swapped(exception):
+        if isinstance(exception, NotExecuted):
+            exception = RuntimeError("ctrlrun-verify: everything is ambiguous")
+        return original(exception)
+
+    monkeypatch.setattr(scenarios, "_raises", swapped)
+
+
+#: One breakage per guarantee, because a control is a per-guarantee claim (§8, T125). Each
+#: leaves the guarantee's *refusal* half working, so what goes red is the control and nothing
+#: else — which is the whole distinction §1.3 draws.
+BROKEN_CONTROLS = {
+    "G1": _break_the_executor,
+    "G2": _break_the_executor,
+    "G3": _break_the_commit,
+    "G4": _break_the_children,
+    "G5": _break_the_executor,
+    "G6": _break_the_evaluation,
+    "G10": _break_the_asymmetry,
+}
+
+
+@pytest.mark.parametrize("gid", ITEM_ONE)
+def test_T125_a_broken_positive_control_is_a_failure(tmp_path, monkeypatch, gid):
+    """§1.3's guard. A refusal asserted against a scenario in which nothing ran passes on a
+    kernel with the guard deleted, so a control that does not behave as specified is FAIL with
+    `reason: "control failed"` — never PASS, and never N/A.
+
+    Asserted per guarantee and not once, because a control is a per-guarantee claim. The
+    `else` branch — the guarantee reported `pass` or `not_applicable` — fails the test with
+    the id that got it.
+    """
+    path = _write(tmp_path, WITH_EFFECTS)
+    BROKEN_CONTROLS[gid](monkeypatch)
+
+    report = run(path, only=(gid,))
+    result = _by_id(report)[gid]
+
+    if result.status is not Status.FAIL:
+        raise AssertionError(
+            f"{gid} reported {result.status} with a broken positive control "
+            f"(reason={result.reason!r})"
+        )
+    assert result.reason == reg.CONTROL_FAILED
+    assert result.counterexample is not None
+    assert report.exit_code == 1
+
+
+# --- T125b: `import ctrlrun` does not import `ctrlrun.verify` ----------------------------------
+
+
+def test_T125b_importing_ctrlrun_does_not_import_ctrlrun_verify():
+    """In a subprocess, as T30 does: in-process this would pass or fail on whatever pytest
+    happened to import first."""
+    finished = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import ctrlrun, sys;"
+            "print(sorted(n for n in sys.modules if n.startswith('ctrlrun.verify')))",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert finished.stdout.strip() == "[]"
+
+
+def test_T125b_importing_ctrlrun_verify_pulls_in_no_module_from_an_extra():
+    finished = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import ctrlrun.verify, sys;"
+            "print(sorted(n for n in sys.modules"
+            " if n.split('.')[0] in ('httpx', 'opentelemetry', 'jwt', 'xmlschema')"
+            " or n in ('ctrlrun.gateway', 'ctrlrun.otel', 'ctrlrun.acs',"
+            " 'ctrlrun.jwt_identity')))",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert finished.stdout.strip() == "[]"
+
+
+# --- the registry itself ------------------------------------------------------------------
+
+
+def test_the_catalogue_is_closed_and_ordered():
+    assert reg.CATALOGUE == "ctrlrun.guarantees/v1"
+    assert [guarantee.id for guarantee in reg.GUARANTEES] == [f"G{n}" for n in range(1, 11)]
+    for guarantee in reg.GUARANTEES:
+        assert guarantee.descends_from, f"{guarantee.id} names no acceptance test"
+
+
+def test_a_store_url_v0_4_does_not_have_is_refused(tmp_path):
+    path = _write(tmp_path, WITH_EFFECTS)
+
+    with pytest.raises(VerifyRefused) as refused:
+        run(path, store_url="postgres://localhost/ctrlrun")
+
+    assert "v0.6" in str(refused.value)
+
+
+def test_authority_declared_twice_is_refused(tmp_path):
+    policy = _write(
+        tmp_path,
+        V3
+        + """
+authority:
+  grants:
+    - id: only
+      subject: { agent: "bot" }
+      actions: ["acme.read"]
+actions:
+  acme.read:
+    decision: allow
+""",
+    )
+    standalone = _write(
+        tmp_path,
+        V3
+        + """
+authority:
+  grants:
+    - id: other
+      subject: { agent: "bot" }
+      actions: ["acme.read"]
+""",
+        name="authority.yaml",
+    )
+
+    with pytest.raises(VerifyRefused) as refused:
+        run(policy, authority=standalone)
+
+    assert str(policy) in str(refused.value)
+    assert str(standalone) in str(refused.value)
+
+
+def test_observe_mode_is_refused_before_any_scenario_runs(tmp_path):
+    path = _write(tmp_path, V3 + "mode: observe\nactions:\n  acme.read:\n    decision: allow\n")
+
+    with pytest.raises(VerifyRefused) as refused:
+        run(path)
+
+    assert "observe" in str(refused.value)
+
+
+def test_the_v1_payments_template_reports_five_over_five_with_five_not_applicable():
+    """The definition of done, dogfooded rather than described (SPEC-v0.4 §4.1)."""
+    report = run(V1_PAYMENTS)
+
+    assert report.exit_code == 0
+    assert (report.passed, report.applicable, report.not_applicable) == (5, 5, 5)
+    text = report.to_text()
+    assert "5/5 declared guarantees pass." in text
+    assert "5 not applicable: G3, G4, G5, G8, G9." in text
+    assert "10/10" not in text

--- a/tests/test_verify_authority.py
+++ b/tests/test_verify_authority.py
@@ -1,0 +1,367 @@
+"""The authority guarantees and config-derived selection. SPEC-v0.4 §2 (G7-G9), §3.4.
+
+T108-T112. The principal is derived from the **grant** under test and never from the policy
+(§3.4), so these tests assert which grant was used as well as what it refused: five refusals
+that all raise `AuthorityDenied` are five guards a check asserting only the type cannot tell
+apart (`v0.3 §10`'s rule, unchanged).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ctrlrun.authority import DIMENSIONS
+from ctrlrun.verify import Status, VerifyRefused, run
+from ctrlrun.verify import guarantees as reg
+from ctrlrun.verify.scenarios import EXPIRY_NOT_DECISIVE
+
+pytestmark = pytest.mark.authority
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AUTHORITY_PAYMENTS = REPO_ROOT / "examples" / "authority" / "payments.yaml"
+
+V2 = "schema: ctrlrun.policy/v2\n"
+V3 = "schema: ctrlrun.policy/v3\n"
+
+ACTIONS = """
+actions:
+  acme.refund:
+    effect: "refund:{payment_id}"
+    resource: "payment:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 1000 }
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 100000 }
+        decision: approve
+      - decision: deny
+  acme.read:
+    decision: allow
+"""
+
+#: One delegable grant carrying every dimension, so G9 has all six to exercise.
+FULL_AUTHORITY = """
+authority:
+  grants:
+    - id: head-of-support
+      subject: { agent: "head-of-support", user: "dana@example.com" }
+      actions: ["acme.refund", "acme.read"]
+      resources: ["payment:*"]
+      constraints: { amount_gte: 0, amount_lte: 500000 }
+      environments: ["production"]
+      delegable: true
+      expires_at: "2027-01-01T00:00:00Z"
+"""
+
+#: Grants that name actions the policy does not list: nothing is authorized, which is a
+#: fail-closed state and not a broken guarantee (T111).
+UNREACHABLE_AUTHORITY = """
+authority:
+  grants:
+    - id: elsewhere
+      subject: { agent: "some-agent" }
+      actions: ["other.system.thing"]
+      expires_at: "2027-01-01T00:00:00Z"
+      delegable: true
+"""
+
+
+def _write(directory: Path, document: str, name: str = "ctrlrun.yaml") -> Path:
+    path = directory / name
+    path.write_text(document, encoding="utf-8")
+    return path
+
+
+def _by_id(report):
+    return {result.id: result for result in report.guarantees}
+
+
+# --- T108: a configuration with grants exercises G7-G9 ------------------------------------
+
+
+def test_T108_the_authority_example_exercises_G7_G8_and_G9():
+    report = run(AUTHORITY_PAYMENTS)
+    results = _by_id(report)
+
+    for gid in ("G7", "G8", "G9"):
+        assert results[gid].status is Status.PASS, (gid, results[gid].reason)
+    assert results["G8"].grant_id == "head-of-support"
+    assert results["G9"].grant_id == "head-of-support"
+    assert results["G9"].detail["dimensions_exercised"] == list(DIMENSIONS)
+    assert results["G9"].detail["dimensions_unconstrained"] == []
+    assert report.exit_code == 0
+    assert report.passed == 10
+    assert report.applicable == 10
+
+
+def test_T108_G8_asserts_the_denial_by_reason_and_not_by_type(tmp_path, monkeypatch):
+    """A kernel that denied for any other cause fails: the reason is what is asserted.
+
+    `AUTHORITY_RESOLVED` before the expiry, `AuthorityDenied(reason="authority_expired")`
+    after it. Injecting a kernel that denies with a *different* reason must go red.
+    """
+    from ctrlrun.authority import AUTHORITY_CONSTRAINT, Authority, AuthorityResult
+
+    path = _write(tmp_path, V3 + FULL_AUTHORITY + ACTIONS)
+    original = Authority.evaluate
+
+    def wrong_reason(self, action, *, now, store):
+        result = original(self, action, now=now, store=store)
+        if not result.passed and result.reason == "authority_expired":
+            return AuthorityResult(False, AUTHORITY_CONSTRAINT, grant_id=result.grant_id)
+        return result
+
+    monkeypatch.setattr(Authority, "evaluate", wrong_reason)
+
+    result = _by_id(run(path, only=("G8",)))["G8"]
+
+    assert result.status is Status.FAIL
+    assert "authority_expired" in str(result.counterexample.expected)
+
+
+# --- T109: no `authority:` section --------------------------------------------------------
+
+
+def test_T109_no_authority_section_makes_G8_and_G9_not_applicable_and_leaves_G7_applicable(
+    tmp_path,
+):
+    """The pair is one test, because reporting all three N/A is the plausible wrong answer.
+
+    No principal is a `v0.1` rule and does not depend on the authority model.
+    """
+    path = _write(tmp_path, V2 + ACTIONS)
+
+    report = run(path)
+    results = _by_id(report)
+
+    for gid in ("G8", "G9"):
+        assert results[gid].status is Status.NOT_APPLICABLE, gid
+        assert results[gid].reason == reg.NO_AUTHORITY_SECTION
+    assert results["G7"].status is Status.PASS, results["G7"].reason
+    assert results["G7"].action is not None
+
+
+# --- T110: every dimension, including the omission case -----------------------------------
+
+
+@pytest.mark.parametrize("dimension", DIMENSIONS)
+def test_T110_G9_exercises_every_dimension_the_parent_constrains(tmp_path, dimension):
+    path = _write(tmp_path, V3 + FULL_AUTHORITY + ACTIONS)
+
+    result = _by_id(run(path, only=("G9",)))["G9"]
+
+    assert result.status is Status.PASS, result.reason
+    assert dimension in result.detail["dimensions_exercised"]
+    # The omission half is recorded per dimension, and it is never "not attempted": either
+    # containment refused the child, or the model refused to construct it at all.
+    assert result.detail["omissions"][dimension] in (
+        "refused by containment",
+        "refused at construction",
+    )
+
+
+def test_T110_a_kernel_where_omission_means_unlimited_makes_G9_fail(tmp_path, monkeypatch):
+    """The mutation half. `contained_dimension` is what makes omission a refusal; a kernel in
+    which a dropped dimension is treated as inherited must make G9 go red, and the
+    counterexample must carry the offending delegation."""
+    from ctrlrun import authority as authority_module
+
+    path = _write(tmp_path, V3 + FULL_AUTHORITY + ACTIONS)
+    original = authority_module.contained_dimension
+
+    def omission_is_inheritance(parent, child):
+        # Exactly the defect §5.4 forbids: a child that drops `environments` is treated as
+        # though it had inherited the parent's.
+        if parent.environments is not None and child.environments is None:
+            from dataclasses import replace
+
+            child = replace(child, environments=parent.environments)
+        return original(parent, child)
+
+    monkeypatch.setattr(authority_module, "contained_dimension", omission_is_inheritance)
+
+    result = _by_id(run(path, only=("G9",)))["G9"]
+
+    assert result.status is Status.FAIL, result.detail
+    assert "environments" in str(result.counterexample.expected)
+    created = [
+        event for event in result.counterexample.events if event["type"] == "DELEGATION_CREATED"
+    ]
+    # The offending delegation is in the evidence: the child that should have been refused
+    # was written, and the counterexample shows the row.
+    assert created
+
+
+def test_T110_a_dimension_the_parent_does_not_constrain_is_reported_unexercised(tmp_path):
+    """Reporting `G9 PASS` for a parent constraining one dimension as though it had covered
+    six is the N/A rule violated one level down (§2.2 G9)."""
+    path = _write(
+        tmp_path,
+        V3
+        + """
+authority:
+  grants:
+    - id: thin
+      subject: { agent: "thin-agent" }
+      actions: ["acme.refund"]
+      delegable: true
+      expires_at: "2027-01-01T00:00:00Z"
+"""
+        + ACTIONS,
+    )
+
+    result = _by_id(run(path, only=("G9",)))["G9"]
+
+    assert result.status is Status.PASS, result.reason
+    assert set(result.detail["dimensions_unconstrained"]) == {
+        "resources",
+        "constraints",
+        "environments",
+    }
+    assert set(result.detail["dimensions_exercised"]) == {"subject", "actions", "expires_at"}
+    assert "3 of 6 dimensions" in result.detail["summary"]
+
+
+# --- T111: grants that reach no action ----------------------------------------------------
+
+
+def test_T111_grants_that_match_no_action_are_not_applicable_and_never_fail(tmp_path):
+    """A configuration in which nothing is authorized is fail-closed, and reporting it as a
+    failed guarantee would train an operator to ignore red."""
+    path = _write(tmp_path, V3 + UNREACHABLE_AUTHORITY + ACTIONS)
+
+    report = run(path)
+    results = _by_id(report)
+
+    for gid in ("G8", "G9"):
+        assert results[gid].status is Status.NOT_APPLICABLE, (gid, results[gid].status)
+        assert results[gid].reason == reg.NO_GRANT_MATCHES
+        assert results[gid].status is not Status.FAIL
+    assert report.failed == 0
+    assert report.exit_code == 0
+
+
+def test_a_layered_expiry_is_not_applicable_rather_than_a_failure(tmp_path):
+    """Where a second grant covers the same action past the first one's expiry, the expired
+    grant refuses nothing observable. That is a property of the document, so N/A."""
+    path = _write(
+        tmp_path,
+        V3
+        + """
+authority:
+  grants:
+    - id: aaa-short
+      subject: { agent: "*" }
+      actions: ["acme.refund"]
+      expires_at: "2027-01-01T00:00:00Z"
+    - id: bbb-forever
+      subject: { agent: "*" }
+      actions: ["acme.refund"]
+"""
+        + ACTIONS,
+    )
+
+    result = _by_id(run(path, only=("G8",)))["G8"]
+
+    assert result.status is Status.NOT_APPLICABLE
+    assert result.reason == EXPIRY_NOT_DECISIVE
+
+
+# --- T112: `--only` runs what it names and nothing else -----------------------------------
+
+
+def test_T112_only_runs_the_named_guarantee_and_writes_no_badge(tmp_path, monkeypatch):
+    """ "It did not run" is proven by the scratch store's contents and not by the report
+    describing itself: every other guarantee's scenario would have written a receipt for its
+    own action, and none exists."""
+    from ctrlrun.verify import scenarios
+
+    path = _write(tmp_path, V3 + FULL_AUTHORITY + ACTIONS)
+    opened: list[str] = []
+    original = scenarios.Engine._control_for
+    plain = scenarios.Engine.control
+    receipts: list[str] = []
+
+    def recording(self, gid, selection, *, clock=None):
+        opened.append(gid)
+        built = original(self, gid, selection, clock=clock)
+        return built
+
+    def recording_plain(self, gid, *, clock=None, authority=True):
+        opened.append(gid)
+        return plain(self, gid, clock=clock, authority=authority)
+
+    monkeypatch.setattr(scenarios.Engine, "_control_for", recording)
+    monkeypatch.setattr(scenarios.Engine, "control", recording_plain)
+
+    original_close = scenarios.SQLiteStateStore.close
+
+    def closing(self):
+        receipts.extend(receipt.action for receipt in self.receipts())
+        original_close(self)
+
+    monkeypatch.setattr(scenarios.SQLiteStateStore, "close", closing)
+
+    report = run(path, only=("G9",))
+    results = _by_id(report)
+
+    assert results["G9"].status is Status.PASS, results["G9"].reason
+    for gid in reg.BY_ID:
+        if gid == "G9":
+            continue
+        assert results[gid].status is Status.SKIPPED, gid
+        assert results[gid].reason == reg.NOT_SELECTED
+    assert report.partial is True
+    assert report.badge is None
+    # Only G9's scratch store was ever created, so no other guarantee's scenario ran.
+    assert opened == ["G9"]
+    assert set(receipts) <= {"acme.refund"}
+    document = json.loads(report.to_json())
+    assert document["partial"] is True
+
+
+def test_T112_an_unknown_only_id_exits_2_naming_it(tmp_path):
+    path = _write(tmp_path, V3 + FULL_AUTHORITY + ACTIONS)
+
+    with pytest.raises(VerifyRefused) as refused:
+        run(path, only=("G99",))
+
+    assert "G99" in str(refused.value)
+    assert reg.CATALOGUE in str(refused.value)
+
+
+# --- §3.4: the principal comes from the grant, never from the policy -----------------------
+
+
+def test_the_principal_is_derived_from_the_grants_subject(tmp_path):
+    path = _write(
+        tmp_path,
+        V3
+        + """
+authority:
+  grants:
+    - id: wildcards
+      subject: { agent: "finance-*", user: "*" }
+      actions: ["acme.refund"]
+      expires_at: "2027-01-01T00:00:00Z"
+"""
+        + ACTIONS,
+    )
+
+    report = run(path, only=("G8",))
+    result = _by_id(report)["G8"]
+
+    assert result.status is Status.PASS, result.reason
+    receipt_agents = {
+        receipt["principal"]["agent"]
+        for row in report.guarantees
+        if row.counterexample
+        for receipt in row.counterexample.receipts
+    }
+    # No failure, so no counterexample: the derivation is asserted through the run succeeding
+    # against a grant whose subject is two wildcards — `finance-*` keeps its prefix and `*`
+    # becomes `ctrlrun-verify` (§3.4).
+    assert receipt_agents == set()
+    assert result.grant_id == "wildcards"


### PR DESCRIPTION
SPEC-v0.4 **items 1 and 2**. `ctrlrun.verify` reads the operator's policy document and the authority document beside it, derives concrete actions, principals and delegations the configuration actually admits, and runs the failure scenarios of `v0.1 §7`, `v0.2 §10` and `v0.3 §10` against them — in a scratch store, with in-process fake executors, reaching no network.

**Why the two items land together.** Splitting them would ship a closed registry with three unreachable entries. G7–G9 share the config-derived selection item 1 defines, and §3.4's rule — *the principal comes from the grant under test, never from the policy* — is what makes G1–G6 and G10 runnable at all under an `authority:` section. Item 3's reporting code is here too, because `Report.exit_code` is what T101b asserts; its acceptance tests (T113–T117) are the next PR.

## What it reports

Against `examples/authority/payments.yaml` — **10/10**:

```
G1   mutated approval refused         PASS  stripe.refund
G2   replayed approval refused        PASS  stripe.refund
G3   duplicate effect refused         PASS  stripe.refund
G4   one winner under concurrency     PASS  stripe.refund (8 processes)
G5   ambiguous blocks a blind retry   PASS  stripe.refund
G6   unknown action refused           PASS
G7   no principal refused             PASS  stripe.refund
G8   expired authority refused        PASS  head-of-support
G9   delegation cannot escalate       PASS  head-of-support (6 of 6 dimensions)
G10  unknown exception is ambiguous   PASS  stripe.refund

10/10 declared guarantees pass. 0 not applicable.
```

Against `examples/policies/payments.yaml` — **5/5, 5 not applicable**, which is the N/A rule dogfooded rather than described.

## The three rules, and where each is enforced

- **Not applicable is not a pass.** Every N/A reason in `guarantees.py` is a statement about the *document*. A scenario that could not be built for any other cause is exit 3 — never N/A, never a FAIL. Zero applicable is exit 2. (T101, T101b, T102, T111.)
- **Verify never touches the operator's store.** `state_path()` is never called and `Control.from_file()` is never used. T103 hashes `.ctrlrun/` before and after, asserts the file is not created where it did not exist, and repeats the whole thing with `$CTRLRUN_STATE` pointing elsewhere.
- **Every guarantee carries a positive control.** T125 breaks each guarantee's control in its own way and requires `fail` with `reason: "control failed"` every time.

And **no flag relaxes a check**: no argument and no environment variable makes verify's `Control` behave differently from the operator's.

## Three readings the spec left open

Each is argued in a `# SPEC:` comment where it lives, not only here.

| Question | Decision |
|---|---|
| G6's observable is `ActionDenied(reason="unknown_action")`, but `v0.3 §4.3` runs authority first, so under an `authority:` section an unlisted name is refused by the authority axis and the policy axis is never reached. | G6 drives a `Control` composed from the **policy alone**. It descends from `v0.1 §7` T6, which predates the authority model. The kernel code under test is unchanged; what is left out is a second refusal that G7 and G8 exercise directly. |
| §2.2 says G7 is *never* N/A; §1.3 requires a positive control, and G7's control is "the identical call inside `context()` runs". Both cannot hold for a policy in which nothing can run. | G7 is **N/A when no action can be driven to `allow` or `approve`**, with G10's reason. T101b requires an empty `actions:` to leave zero applicable guarantees, which settles it. |
| Where a *second* grant covers the same action past the first one's expiry, the expired grant refuses nothing observable. | A new N/A reason, `EXPIRY_NOT_DECISIVE`. The pre-check asks only **whether** authority still passes, never **why** it stopped — filtering on the reason would turn a kernel denying for the wrong cause into a false N/A, which is a false pass in the other costume. |

## One deviation from §2.2's mechanics

G9's control asserts the narrowed child is accepted, `DELEGATION_CREATED` reaches a sink, and an action within the child's limits passes authority **naming the delegation**. Naming it is only possible where the parent's subject does not also match the child's principal — containment leaves the child's concrete agent unconstrained (`v0.3 §5.4`), so the child names an agent the parent does not, and `AUTHORITY_RESOLVED` then carries the `delegation_id`. Where the parent's subject is a wildcard that matches it too, `v0.3 §4.6` picks the lowest grant id among those that passed, and asserting the delegation would be asserting something the model does not promise — so that case asserts authority passed and records `delegation_isolated: false`.

## G4 runs subprocesses, not `multiprocessing`

`spawn` re-imports the caller's `__main__` in every child, so a caller running `verify.run()` from an unguarded script would fork-bomb itself. Requiring `if __name__ == "__main__"` in the program under verification is not a trade a verification tool gets to make. `python -m ctrlrun.verify.worker`, payload on stdin — the same eight OS processes, which is the whole of what the guarantee is about. The executor count comes from `O_CREAT|O_EXCL` files so it survives the process boundary.

## Mutation evidence

Each row is a test that injects the break and requires the report to go red. These are in the suite, not a one-off table.

| Guard removed | Injected by | Result |
|---|---|---|
| `reserve_effect` refuses a committed key (`v0.1 §5.4`) | `sitecustomize` + in-process patch, so G4's children see it too | G3 **FAIL** with both receipts in the counterexample, G4 **FAIL**; G1 and G6 unaffected (T104) |
| `contained_dimension` treats a dropped `environments` as inherited | patched on `ctrlrun.authority` | G9 **FAIL**, counterexample carries the `DELEGATION_CREATED` that should not exist (T110) |
| authority denies an expired grant with the wrong `reason` | patched `Authority.evaluate` | G8 **FAIL**, not N/A (T108) |
| G1/G2/G5's control executor never runs | patched `_Executor.__call__` | `fail`, `reason: "control failed"` (T125) |
| G3's `commit_effect` is a no-op | patched `SQLiteStateStore` | `fail`, `reason: "control failed"` (T125) |
| G4's children never start | patched `run_attempts` | `fail`, `reason: "control failed"` (T125) |
| every action evaluates to `unknown_action` | patched `Policy.evaluate` | G6 `fail`, `reason: "control failed"` (T125) |
| `NotExecuted` maps to AMBIGUOUS like everything else | patched `_raises` | G10 `fail`, `reason: "control failed"` (T125) |

## Amendments to the earlier specs (SPEC-v0.4 §9.4)

1. **`v0.3 §10` T85** — `ctrlrun verify` exits 2 under `mode: observe` with a message naming the mode, and runs under `mode: enforce`. Its subject was explicitly temporary, so the test is amended rather than deleted, and the amendment is in this commit.
2. **`v0.3 §4.3.1`** gains an informational row for `ctrlrun.verify.run`. It is not a new entry point — it proposes no action of its own and drives the rows already there — but a reader will look for one.
3. **`ARCHITECTURE.md` §6**'s module map gains `verify/`, above `control.py` and beside `cli/`.

## Tests

T100, T101, T101b, T102, T103, T104, T105, T106, T107, T108, T109, T110, T111, T112, T125, T125b. `1919 passed`, `mypy --strict src/` clean, `ruff check` and `ruff format --check` clean.

## Not in this PR

Reporting's own acceptance tests (item 3), the GitHub Action and badge (item 4), the OWASP mapping (item 5), the research harness (item 6), the release pass (item 7).