### PR TITLE
verify: the human report, --json, --junit and the exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,21 @@ any change to one appears here.
   applicable, 1 a guarantee failed, 2 the configuration was refused or is unusable, 3 an
   internal error in verify itself.
 
+- **Reporting** (SPEC-v0.4 §4). The human report is one line per guarantee in catalogue order,
+  every N/A carrying the reason that made it one, with the summary as the last line so a
+  `tail -1` is meaningful. `--json` emits one `ctrlrun.verify/v1` document carrying the SHA-256
+  of both documents verify read — a report and a policy that do not hash the same are a report
+  about something else — and a `counterexample` **only** on a `fail`, because a counterexample
+  on a pass would be evidence of a failure that did not happen. `--junit PATH` writes a JUnit
+  XML file in which an N/A is `<skipped>` and never a pass, which is the same rule as
+  everywhere else expressed in the vocabulary a CI dashboard already has.
+
+  JUnit XML has no normative schema, and the report says so rather than implying one: T115
+  validates against `tests/data/junit-10.xsd`, a checked-in copy of the de-facto Windy Road
+  schema with its provenance and Apache-2.0 licence recorded beside it, and asserts the
+  document structurally as well — a permissive schema is not a check. `xmlschema` joins the
+  **dev** extra for that test and for nothing else.
+
 ### Changed
 
 - **`docs/SPEC-v0.3.md` §10 T85 is amended**, as SPEC-v0.4 §9.4 item 2 requires and in the

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,6 +13,11 @@ include SECURITY.md
 include VISION.md
 recursive-include docs *.md
 recursive-include tests *.py
+# SPEC-v0.4 §4.3 — T115 validates `--junit` against a checked-in schema, and reads the README
+# beside it for the schema's provenance and licence. A test that ships without its data is a
+# test the sdist cannot run.
+recursive-include tests *.xsd
+recursive-include tests *.md
 
 # `examples/` travels because T31 runs every script and loads every sector template out of
 # the source tree (SPEC-v0.2 §1.1). Without these the sdist would ship a test suite that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ dev = [
     "pytest>=8",
     "mypy>=2.3",
     "ruff>=0.16",
+    # SPEC-v0.4 §4.3 - T115 validates `ctrlrun verify --junit` against the checked-in
+    # `tests/data/junit-10.xsd`. JUnit XML has no normative schema, so the schema is a
+    # de-facto one and the test asserts structurally as well; `xmlschema` is used by that
+    # test and by nothing else, and `ctrlrun` never imports it.
+    "xmlschema>=3",
 ]
 # SPEC-v0.2 §1: `pip install ctrlrun` must not grow. Anything needing an HTTP server or a
 # third-party SDK lands here, lazily imported, with `MissingDependency` when it is absent.

--- a/src/ctrlrun/verify/report.py
+++ b/src/ctrlrun/verify/report.py
@@ -14,7 +14,7 @@ import json
 import xml.etree.ElementTree as ElementTree
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any, Final
 
@@ -272,20 +272,49 @@ class Report:
         return summary
 
     def to_junit(self) -> str:
-        """§4.3. N/A is `<skipped>` — reported as skipped and never as a pass."""
+        """§4.3. One `<testsuite>`, one `<testcase>` per guarantee.
+
+        **N/A is `<skipped>`** — reported as skipped and never as a pass, which is the same
+        rule as everywhere else expressed in the vocabulary a CI dashboard already has. A
+        dashboard that showed five N/As as five green ticks would be the false green this
+        release exists to prevent, wearing somebody else's colours.
+
+        JUnit XML has **no normative schema** (§1.4). The element order and the required
+        attributes below follow the de-facto `junit-10.xsd` checked in beside T115 — hence
+        `properties` first and `system-out`/`system-err` last, and hence `timestamp` carrying
+        no offset, which is what that schema's `ISO8601_DATETIME_PATTERN` permits.
+
+        `hostname` is the literal `localhost`, which the schema names as the value to use
+        where the host cannot be determined. Reading the real one would put the operator's
+        machine name in a file they may attach to a ticket, and would make two runs of the
+        same configuration differ (§3.6).
+        """
         duration = (self.finished_at - self.started_at).total_seconds()
         suite = ElementTree.Element(
             "testsuite",
             {
                 "name": SUITE_NAME,
+                "hostname": "localhost",
+                "timestamp": self.started_at.astimezone(UTC)
+                .replace(tzinfo=None, microsecond=0)
+                .isoformat(),
                 "tests": str(len(self.guarantees)),
                 "failures": str(self.failed),
                 "errors": "0",
                 "skipped": str(self.not_applicable + self.skipped),
                 "time": f"{duration:.3f}",
-                "timestamp": self.started_at.replace(tzinfo=None).isoformat(),
             },
         )
+        properties = ElementTree.SubElement(suite, "properties")
+        for name, value in (
+            ("catalogue", CATALOGUE),
+            ("ctrlrun_version", self.ctrlrun_version),
+            ("policy", str(self.policy["path"])),
+            ("policy_sha256", str(self.policy["sha256"])),
+            ("applicable", str(self.applicable)),
+            ("not_applicable", str(self.not_applicable)),
+        ):
+            ElementTree.SubElement(properties, "property", {"name": name, "value": value})
         for result in self.guarantees:
             case = ElementTree.SubElement(
                 suite,
@@ -305,18 +334,9 @@ class Report:
                 ElementTree.SubElement(
                     case, "skipped", {"message": result.reason or str(result.status)}
                 )
-        suites = ElementTree.Element(
-            "testsuites",
-            {
-                "name": SUITE_NAME,
-                "tests": str(len(self.guarantees)),
-                "failures": str(self.failed),
-                "errors": "0",
-                "time": f"{duration:.3f}",
-            },
-        )
-        suites.append(suite)
-        return ElementTree.tostring(suites, encoding="unicode", xml_declaration=True)
+        ElementTree.SubElement(suite, "system-out").text = ""
+        ElementTree.SubElement(suite, "system-err").text = ""
+        return ElementTree.tostring(suite, encoding="unicode", xml_declaration=True)
 
     def job_summary(self) -> str:
         """§5.4 — a Markdown table, with the N/A rows in full."""

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -1,0 +1,26 @@
+# `tests/data/`
+
+## `junit-10.xsd`
+
+**JUnit XML has no normative schema** (SPEC-v0.4 §1.4). There is no OASIS or IEEE document
+behind it; every CI parser reads a dialect of what Ant emitted. This file is the widely-used
+de-facto schema, checked in so T115 has something to validate against, and the real
+requirement — *the file is accepted by the parsers people actually run* — is asserted
+structurally in the same test rather than dressed up as conformance to a standard that does
+not exist.
+
+| | |
+|---|---|
+| **Source** | <https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd> |
+| **Upstream name** | `JUnit.xsd` — "JUnit test result schema for the Apache Ant JUnit and JUnitReport tasks" |
+| **Copyright** | © 2011, Windy Road Technology Pty. Limited |
+| **Licence** | Apache License 2.0, as the schema's own `xs:documentation` states |
+| **Retrieved** | 2026-09-04 |
+| **Modified** | No. Byte-for-byte as retrieved. |
+
+It is renamed `junit-10.xsd` here because that is the name the file circulates under; the
+content is unchanged, and the copyright and licence notice inside it is intact.
+
+Used by `tests/test_verify_report.py` (T115) and by nothing else. `xmlschema` is in the `dev`
+extra for that test and for nothing else; `ctrlrun` does not import it, and it is not a
+runtime dependency.

--- a/tests/data/junit-10.xsd
+++ b/tests/data/junit-10.xsd
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	 elementFormDefault="qualified"
+	 attributeFormDefault="unqualified">
+	<xs:annotation>
+		<xs:documentation xml:lang="en">JUnit test result schema for the Apache Ant JUnit and JUnitReport tasks
+Copyright © 2011, Windy Road Technology Pty. Limited
+The Apache Ant JUnit XML Schema is distributed under the terms of the Apache License Version 2.0 http://www.apache.org/licenses/
+Permission to waive conditions of this license may be requested from Windy Road Support (http://windyroad.org/support).</xs:documentation>
+	</xs:annotation>
+	<xs:element name="testsuite" type="testsuite"/>
+	<xs:simpleType name="ISO8601_DATETIME_PATTERN">
+		<xs:restriction base="xs:dateTime">
+			<xs:pattern value="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:element name="testsuites">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Contains an aggregation of testsuite results</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="testsuite" minOccurs="0" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:complexContent>
+							<xs:extension base="testsuite">
+								<xs:attribute name="package" type="xs:token" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">Derived from testsuite/@name in the non-aggregated documents</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="id" type="xs:int" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">Starts at '0' for the first testsuite and is incremented by 1 for each following testsuite</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+							</xs:extension>
+						</xs:complexContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="testsuite">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Contains the results of executing a testsuite</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="properties">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Properties (e.g., environment settings) set during test execution</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:attribute name="name" use="required">
+									<xs:simpleType>
+										<xs:restriction base="xs:token">
+											<xs:minLength value="1"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+								<xs:attribute name="value" type="xs:string" use="required"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="testcase" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:choice minOccurs="0">
+						<xs:element name="skipped" minOccurs="0" maxOccurs="1">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">Indicates that the test was skipped.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="pre-string">
+										<xs:attribute name="message" type="xs:string">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The message specifying why the test case was skipped</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="error" minOccurs="0" maxOccurs="1">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">Indicates that the test errored.  An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test. Contains as a text node relevant data for the error, e.g., a stack trace</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="pre-string">
+										<xs:attribute name="message" type="xs:string">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The error message. e.g., if a java exception is thrown, the return value of getMessage()</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="type" type="xs:string" use="required">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The type of error that occured. e.g., if a java execption is thrown the full class name of the exception.</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="failure">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">Indicates that the test failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals. Contains as a text node relevant data for the failure, e.g., a stack trace</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="pre-string">
+										<xs:attribute name="message" type="xs:string">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The message specified in the assert</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="type" type="xs:string" use="required">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The type of the assert.</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+					</xs:choice>
+					<xs:attribute name="name" type="xs:token" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Name of the test method</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="classname" type="xs:token" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Full class name for the class the test method is in.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="time" type="xs:decimal" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Time taken (in seconds) to execute the test</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="system-out">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Data that was written to standard out while the test was executed</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="pre-string">
+						<xs:whiteSpace value="preserve"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="system-err">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Data that was written to standard error while the test was executed</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="pre-string">
+						<xs:whiteSpace value="preserve"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="name" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Full class name of the test for non-aggregated testsuite documents. Class name without the package for aggregated testsuites documents</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:token">
+					<xs:minLength value="1"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="timestamp" type="ISO8601_DATETIME_PATTERN" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">when the test was executed. Timezone may not be specified.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="hostname" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Host on which the tests were executed. 'localhost' should be used if the hostname cannot be determined.</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:token">
+					<xs:minLength value="1"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="tests" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="failures" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite that failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="errors" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite that errored. An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="skipped" type="xs:int" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of ignored or skipped tests in the suite.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="time" type="xs:decimal" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Time taken (in seconds) to execute the tests in the suite</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:simpleType name="pre-string">
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -369,7 +369,7 @@ def _manifest_patterns() -> tuple[list[tuple[str, str]], set[str]]:
 
 
 def test_the_sdist_carries_everything_the_tests_read():
-    """Every tracked file under `examples/` and `docs/` matches a `MANIFEST.in` include.
+    """Every tracked non-Python file under `examples/`, `docs/` and `tests/` is shipped.
 
     `MANIFEST.in` has claimed for two releases that a test named this one keeps it honest,
     and there was no such test — so the first file it forgot was found by the CI job that
@@ -379,11 +379,15 @@ def test_the_sdist_carries_everything_the_tests_read():
 
     Checked against **git**, not the filesystem, for the same reason: an untracked file is not
     in a fresh clone whatever this file says about it.
+
+    `tests/` joined the list when `tests/data/junit-10.xsd` did, and it joined it the same way
+    the first two did: the sdist job found the missing file one push after this test could
+    have. `recursive-include tests *.py` had shipped every test and none of its data.
     """
     import fnmatch
 
     tracked = subprocess.run(
-        ["git", "ls-files", "examples", "docs"],
+        ["git", "ls-files", "examples", "docs", "tests"],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,

--- a/tests/test_verify_report.py
+++ b/tests/test_verify_report.py
@@ -1,0 +1,495 @@
+"""Reporting: the human report, `--json`, `--junit`, the exit codes. SPEC-v0.4 §4; T113-T117.
+
+The report is where the three rules become visible or stop being true. A count that summed the
+N/As, a counterexample on a pass, an N/A rendered as a green tick in a CI dashboard - each is
+the same false green in a different costume, and each has a test here.
+"""
+
+from __future__ import annotations
+
+import json
+import xml.etree.ElementTree as ElementTree
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from ctrlrun.cli.main import OBSERVE_BANNER, main
+from ctrlrun.verify import Status, run
+from ctrlrun.verify import guarantees as reg
+from ctrlrun.verify.report import CLASS_NAME, REPORT_SCHEMA, SUITE_NAME
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+JUNIT_XSD = REPO_ROOT / "tests" / "data" / "junit-10.xsd"
+
+V1 = "schema: ctrlrun.policy/v1\n"
+V2 = "schema: ctrlrun.policy/v2\n"
+V3 = "schema: ctrlrun.policy/v3\n"
+
+ALL_APPLICABLE = (
+    V2
+    + """
+actions:
+  acme.refund:
+    effect: "refund:{payment_id}"
+    resource: "payment:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 1000 }
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 100000 }
+        decision: approve
+      - decision: deny
+"""
+)
+
+#: A v1 document: five applicable, five N/A. The shape the badge and the job summary carry.
+WITH_NOT_APPLICABLE = (
+    V1
+    + """
+actions:
+  acme.refund:
+    rules:
+      - when: { amount_gte: 0, amount_lte: 1000 }
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 100000 }
+        decision: approve
+      - decision: deny
+"""
+)
+
+EMPTY = V1 + "actions: {}\n"
+OBSERVING = V3 + "mode: observe\nactions:\n  acme.read:\n    decision: allow\n"
+MALFORMED = "schema: not-a-schema\nactions: {}\n"
+
+
+def _write(directory: Path, document: str, name: str = "ctrlrun.yaml") -> Path:
+    path = directory / name
+    path.write_text(document, encoding="utf-8")
+    return path
+
+
+def _by_id(report):
+    return {result.id: result for result in report.guarantees}
+
+
+# --- T113: the human report ---------------------------------------------------------------
+
+
+def test_T113_one_line_per_guarantee_in_catalogue_order(tmp_path):
+    report = run(_write(tmp_path, ALL_APPLICABLE))
+
+    lines = report.to_text().split("\n")
+    ordered = [line.split()[0] for line in lines if line[:1] == "G" and line[1:2].isdigit()]
+
+    assert ordered == [guarantee.id for guarantee in reg.GUARANTEES]
+
+
+def test_T113_every_not_applicable_line_carries_its_reason(tmp_path):
+    """An N/A without a reason is indistinguishable from a guarantee somebody switched off."""
+    report = run(_write(tmp_path, WITH_NOT_APPLICABLE))
+
+    text = report.to_text()
+    for result in report.guarantees:
+        if result.status is Status.NOT_APPLICABLE:
+            assert result.reason
+            line = next(line for line in text.split("\n") if line.startswith(f"{result.id} "))
+            assert result.reason in line, line
+
+
+def test_T113_the_summary_is_the_last_line_and_names_the_not_applicable_ids(tmp_path):
+    """`tail -1` is meaningful, and the N/A count is a separate sentence - never a parenthesis
+    inside the fraction, and never summed into it."""
+    report = run(_write(tmp_path, WITH_NOT_APPLICABLE))
+
+    text = report.to_text()
+    last = text.split("\n")[-1]
+
+    assert last == report.summary_line()
+    assert last.startswith(f"{report.passed}/{report.applicable} declared guarantees pass.")
+    assert "5 not applicable: G3, G4, G5, G8, G9." in last
+    # The fraction is passes over applicable. A report with five N/As does not say 10/10.
+    assert "10/10" not in text
+
+
+def test_T113_a_failing_report_names_the_subject_and_prints_the_counterexample(
+    tmp_path, monkeypatch
+):
+    from ctrlrun.verify import scenarios
+
+    monkeypatch.setattr(scenarios, "run_attempts", lambda payloads: None)
+
+    report = run(_write(tmp_path, ALL_APPLICABLE), only=("G4",))
+    text = report.to_text()
+
+    assert _by_id(report)["G4"].status is Status.FAIL
+    assert "FAIL" in text
+    assert "acme.refund" in text
+    assert "expected:" in text
+    assert "observed:" in text
+
+
+@pytest.mark.parametrize(
+    ("document", "expected"),
+    [
+        (ALL_APPLICABLE, "8/8 declared guarantees pass. 2 not applicable"),
+        (WITH_NOT_APPLICABLE, "5/5 declared guarantees pass. 5 not applicable"),
+        (EMPTY, "0/0 declared guarantees pass. 10 not applicable"),
+    ],
+    ids=["passing", "some-na", "all-na"],
+)
+def test_T113_the_summary_over_three_shapes_of_configuration(tmp_path, document, expected):
+    report = run(_write(tmp_path, document))
+
+    assert report.to_text().split("\n")[-1].startswith(expected)
+
+
+# --- T114: `--json` validates, and the counterexample is conditional -----------------------
+
+#: SPEC-v0.4 §4.2, field for field.
+TOP_LEVEL = {
+    "schema",
+    "catalogue",
+    "ctrlrun_version",
+    "started_at",
+    "finished_at",
+    "policy",
+    "authority",
+    "store",
+    "partial",
+    "summary",
+    "guarantees",
+}
+GUARANTEE_FIELDS = {
+    "id",
+    "title",
+    "status",
+    "reason",
+    "action",
+    "arguments",
+    "effect_key",
+    "grant_id",
+    "descends_from",
+    "detail",
+    "counterexample",
+}
+SUMMARY_FIELDS = {"passed", "failed", "applicable", "not_applicable", "skipped", "badge"}
+
+
+def test_T114_the_document_matches_the_schema_field_for_field(tmp_path):
+    import hashlib
+
+    path = _write(tmp_path, WITH_NOT_APPLICABLE)
+    document = json.loads(run(path).to_json())
+
+    assert set(document) == TOP_LEVEL
+    assert document["schema"] == REPORT_SCHEMA == "ctrlrun.verify/v1"
+    assert document["catalogue"] == reg.CATALOGUE == "ctrlrun.guarantees/v1"
+    assert set(document["policy"]) == {"path", "sha256", "schema", "mode", "actions"}
+    assert document["authority"] is None
+    assert document["store"] == {"backend": "sqlite", "scratch": True}
+    assert document["partial"] is False
+    assert set(document["summary"]) == SUMMARY_FIELDS
+    passed = document["summary"]["passed"]
+    applicable = document["summary"]["applicable"]
+    assert document["summary"]["badge"] == f"{passed}/{applicable}"
+    for row in document["guarantees"]:
+        assert set(row) == GUARANTEE_FIELDS
+    # The digest is computed independently here: a report and a policy that do not hash the
+    # same are a report about something else.
+    expected = hashlib.sha256(path.read_bytes()).hexdigest()
+    assert document["policy"]["sha256"] == expected
+
+
+@pytest.mark.authority
+def test_T114_the_authority_block_carries_its_own_digest(tmp_path):
+    import hashlib
+
+    policy = _write(
+        tmp_path,
+        V3
+        + """
+authority:
+  grants:
+    - id: only
+      subject: { agent: "bot" }
+      actions: ["acme.refund"]
+      expires_at: "2027-01-01T00:00:00Z"
+"""
+        + ALL_APPLICABLE[len(V2) :],
+    )
+    document = json.loads(run(policy).to_json())
+
+    assert set(document["authority"]) == {"path", "sha256", "grants", "max_delegation_depth"}
+    assert document["authority"]["sha256"] == hashlib.sha256(policy.read_bytes()).hexdigest()
+    assert document["authority"]["grants"] == 1
+
+
+def test_T114_a_counterexample_is_present_exactly_on_the_fail_rows(tmp_path, monkeypatch):
+    """Asserted in both directions, on a run containing a pass, a fail and an N/A."""
+    from ctrlrun.verify import scenarios
+
+    monkeypatch.setattr(scenarios, "run_attempts", lambda payloads: None)
+
+    # A silenced control executor fails G1, G2, G7 and G10; G6 still passes; the effect and
+    # authority guarantees are N/A in this document. One run, all three statuses.
+    monkeypatch.setattr(scenarios._Executor, "__call__", lambda self: None)
+    failing = json.loads(run(_write(tmp_path, WITH_NOT_APPLICABLE)).to_json())
+    statuses = {row["status"] for row in failing["guarantees"]}
+
+    assert statuses == {"pass", "fail", "not_applicable"}
+
+    for row in failing["guarantees"]:
+        if row["status"] == "fail":
+            assert row["counterexample"] is not None, row["id"]
+            assert set(row["counterexample"]) == {
+                "expected",
+                "observed",
+                "receipts",
+                "events",
+                "effects",
+            }
+            assert row["reason"] is not None
+        else:
+            # A counterexample on a pass would be evidence of a failure that did not happen.
+            assert row["counterexample"] is None, row["id"]
+        if row["status"] == "pass":
+            assert row["reason"] is None
+        else:
+            assert row["reason"] is not None
+
+
+# --- T115: `--junit` produces a file CI parsers accept ------------------------------------
+
+
+def _schema():
+    xmlschema = pytest.importorskip("xmlschema")
+    return xmlschema.XMLSchema(str(JUNIT_XSD))
+
+
+def test_T115_the_checked_in_schema_records_its_provenance():
+    """JUnit XML has no normative schema (§1.4), so the one it is validated against says
+    where it came from and under what licence."""
+    readme = (JUNIT_XSD.parent / "README.md").read_text(encoding="utf-8")
+
+    assert "windyroad" in readme
+    assert "Apache License 2.0" in readme
+    assert "no normative schema" in readme
+    assert "Windy Road Technology" in JUNIT_XSD.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("document", [ALL_APPLICABLE, WITH_NOT_APPLICABLE, EMPTY])
+def test_T115_the_junit_file_validates(tmp_path, document):
+    report = run(_write(tmp_path, document))
+
+    _schema().validate(report.to_junit())
+
+
+def test_T115_not_applicable_is_skipped_and_never_absent_and_never_a_pass(tmp_path):
+    """The same rule as everywhere else, in the vocabulary a CI dashboard already has."""
+    report = run(_write(tmp_path, WITH_NOT_APPLICABLE))
+    suite = ElementTree.fromstring(report.to_junit())
+
+    assert suite.tag == "testsuite"
+    assert suite.get("name") == SUITE_NAME
+    cases = suite.findall("testcase")
+    assert len(cases) == len(reg.GUARANTEES)
+    by_name = {case.get("name", ""): case for case in cases}
+    for result in report.guarantees:
+        case = by_name[f"{result.id} {result.title}"]
+        assert case.get("classname") == CLASS_NAME
+        if result.status is Status.NOT_APPLICABLE:
+            skipped = case.find("skipped")
+            assert skipped is not None, result.id
+            assert skipped.get("message") == result.reason
+            assert case.find("failure") is None
+        elif result.status is Status.PASS:
+            assert list(case) == [], result.id
+
+
+def test_T115_the_counts_are_correct_and_the_failure_carries_the_counterexample(
+    tmp_path, monkeypatch
+):
+    from ctrlrun.verify import scenarios
+
+    monkeypatch.setattr(scenarios, "run_attempts", lambda payloads: None)
+    report = run(_write(tmp_path, ALL_APPLICABLE))
+    xml = report.to_junit()
+    _schema().validate(xml)
+    suite = ElementTree.fromstring(xml)
+
+    assert int(suite.get("tests", "")) == len(reg.GUARANTEES)
+    assert int(suite.get("failures", "")) == report.failed == 1
+    assert int(suite.get("skipped", "")) == report.not_applicable + report.skipped
+    failure = suite.find("./testcase/failure")
+    assert failure is not None
+    assert failure.get("type") == "G4"
+    assert failure.get("message") == reg.CONTROL_FAILED
+    assert failure.text is not None and "expected:" in failure.text
+
+
+def test_T115_a_skipped_row_under_only_says_not_selected(tmp_path):
+    report = run(_write(tmp_path, ALL_APPLICABLE), only=("G6",))
+    suite = ElementTree.fromstring(report.to_junit())
+    _schema().validate(report.to_junit())
+
+    messages = {
+        case.get("name", "").split()[0]: (case.find("skipped").get("message"))
+        for case in suite.findall("testcase")
+        if case.find("skipped") is not None
+    }
+
+    assert messages["G1"] == reg.NOT_SELECTED
+    assert "G6" not in messages
+
+
+# --- T116: every exit code is reachable ---------------------------------------------------
+
+
+def _cli(tmp_path, document, *arguments, monkeypatch=None):
+    _write(tmp_path, document)
+    runner = CliRunner()
+    return runner.invoke(main, ["verify", *arguments])
+
+
+def test_T116_exit_0_when_every_applicable_guarantee_passes(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    result = _cli(tmp_path, WITH_NOT_APPLICABLE)
+
+    assert result.exit_code == 0, result.output
+    assert "declared guarantees pass" in result.stdout
+
+
+def test_T116_exit_1_when_a_guarantee_fails(tmp_path, monkeypatch):
+    from ctrlrun.verify import scenarios
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(scenarios, "run_attempts", lambda payloads: None)
+
+    result = _cli(tmp_path, ALL_APPLICABLE)
+
+    assert result.exit_code == 1, result.output
+
+
+@pytest.mark.parametrize(
+    ("document", "arguments", "expected_in_stderr"),
+    [
+        (MALFORMED, (), "unknown policy schema"),
+        (EMPTY, (), "nothing was checked"),
+        (ALL_APPLICABLE, ("--only", "G99"), "G99"),
+        (ALL_APPLICABLE, ("--store-url", "postgres://x/y"), "v0.6"),
+    ],
+    ids=["malformed", "zero-applicable", "unknown-only", "unsupported-store"],
+)
+def test_T116_exit_2_for_a_configuration_that_is_refused(
+    tmp_path, monkeypatch, document, arguments, expected_in_stderr
+):
+    monkeypatch.chdir(tmp_path)
+
+    result = _cli(tmp_path, document, *arguments)
+
+    assert result.exit_code == 2, result.output
+    assert expected_in_stderr in result.stderr
+
+
+def test_T116_observe_mode_exits_2_with_the_banner_and_runs_nothing(tmp_path, monkeypatch):
+    """The banner on stderr, stdout empty, and **no scenario ran** - the scratch directory was
+    never created."""
+    import ctrlrun.verify as verify_module
+
+    monkeypatch.chdir(tmp_path)
+    made: list[str] = []
+    original = verify_module.tempfile.mkdtemp
+
+    def recording(*args, **kwargs):
+        made.append("scratch")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(verify_module.tempfile, "mkdtemp", recording)
+
+    result = _cli(tmp_path, OBSERVING)
+
+    assert result.exit_code == 2
+    assert OBSERVE_BANNER in result.stderr
+    assert "observe" in result.stderr
+    assert result.stdout == ""
+    assert made == []
+
+
+def test_T116_exit_3_for_an_internal_error(tmp_path, monkeypatch):
+    """A defect in verify must not read as a defect in the kernel, and it must not read as a
+    property of the configuration either."""
+    from ctrlrun.verify import scenarios
+
+    monkeypatch.chdir(tmp_path)
+
+    def broken(self, name, vector, decision, expected_reason):
+        raise scenarios.VerifyInternalError("injected: the synthesizer is wrong")
+
+    monkeypatch.setattr(scenarios.Engine, "_checked", broken)
+
+    result = _cli(tmp_path, ALL_APPLICABLE)
+
+    assert result.exit_code == 3, result.output
+    assert "internal error" in result.stderr
+
+
+def test_T116_a_run_with_five_not_applicable_still_exits_0(tmp_path, monkeypatch):
+    """N/A never changes the exit code by itself."""
+    monkeypatch.chdir(tmp_path)
+
+    result = _cli(tmp_path, WITH_NOT_APPLICABLE)
+
+    assert result.exit_code == 0
+    assert "5 not applicable" in result.stdout
+
+
+def test_T116_json_and_junit_can_be_combined(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "verify.xml"
+
+    result = _cli(tmp_path, WITH_NOT_APPLICABLE, "--json", "--junit", str(target))
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["schema"] == REPORT_SCHEMA
+    _schema().validate(target.read_text(encoding="utf-8"))
+
+
+# --- T117: enums render by value ----------------------------------------------------------
+
+
+ENUM_REPRS = (
+    "Status.",
+    "Decision.",
+    "EffectState.",
+    "ReceiptResult.",
+    "ApprovalStatus.",
+    "EventType.",
+)
+
+
+@pytest.mark.parametrize("document", [ALL_APPLICABLE, WITH_NOT_APPLICABLE, EMPTY])
+def test_T117_no_output_format_renders_an_enum_by_its_member_name(tmp_path, monkeypatch, document):
+    """The existing guard, applied to `ctrlrun.verify/v1`. A run that fails is included so the
+    counterexample - which carries receipts, events and effect records - is covered too."""
+    from ctrlrun.verify import scenarios
+
+    monkeypatch.setattr(scenarios, "run_attempts", lambda payloads: None)
+    report = run(_write(tmp_path, document))
+
+    printed = report.to_json() + report.to_text() + report.to_junit() + report.job_summary()
+
+    for name in ENUM_REPRS:
+        assert name not in printed, name
+
+
+def test_T117_every_status_in_the_json_is_one_of_the_four_values(tmp_path, monkeypatch):
+    from ctrlrun.verify import scenarios
+
+    monkeypatch.setattr(scenarios, "run_attempts", lambda payloads: None)
+    document = json.loads(run(_write(tmp_path, ALL_APPLICABLE), only=("G4", "G6")).to_json())
+
+    values = {row["status"] for row in document["guarantees"]}
+
+    assert values <= {"pass", "fail", "not_applicable", "skipped"}
+    assert isinstance(document["guarantees"][0]["status"], str)


### PR DESCRIPTION
SPEC-v0.4 **item 3**, §4. Stacked on #34 — review that one first; this PR's diff is the reporting change and its acceptance tests.

## What changed in `src/`

Only `to_junit()`. It now emits the shape the de-facto schema actually accepts — one `<testsuite>` root, `properties` first and `system-out`/`system-err` last, a `timestamp` with no offset — so T115 can validate rather than assert against a schema nothing conforms to.

`hostname` is the literal `localhost`, which the schema names as the value to use where the host cannot be determined. Reading the real one would put the operator's machine name in a file they may attach to a ticket, and would make two runs of one configuration differ (§3.6).

## The checked-in schema

`tests/data/junit-10.xsd` is a byte-for-byte copy of the Windy Road JUnit schema. `tests/data/README.md` records the source URL, the copyright, the Apache-2.0 licence the schema's own `xs:documentation` states, the retrieval date, and the fact that it is unmodified. Its first paragraph says JUnit XML has no normative schema — because it does not, and T115 asserts structurally as well, since a permissive schema is not a check.

`xmlschema` joins the **dev** extra for that test and for nothing else. `ctrlrun` never imports it, and T125b already asserts it is absent from `sys.modules` after `import ctrlrun.verify`.

## Tests

| | |
|---|---|
| **T113** | One line per guarantee in catalogue order; every N/A carries its reason on its own line; the summary is the last line and names the N/A ids separately. Parametrized over a passing, a failing and an all-N/A configuration. A report with five N/As does not contain `10/10`. |
| **T114** | The document matches §4.2 field for field, `schema` and `catalogue` are exact, both `sha256` values are recomputed independently in the test, and `counterexample` is non-null **exactly** on the `fail` rows — asserted in both directions, on one run containing a pass, a fail and an N/A. |
| **T115** | Validated against the checked-in XSD over three configurations, plus a structural pass: N/A rows are `<skipped>` and never absent and never empty testcases, `tests`/`failures`/`skipped` are counted correctly, and the failure text contains the rendered counterexample. |
| **T116** | Every exit code reachable: 0, 1, 2 (malformed policy · zero applicable · unknown `--only` id · unsupported `--store-url`) and 3 (an injected internal error). Observe mode additionally asserts the `v0.3 §6.5` banner on stderr, empty stdout, and that `tempfile.mkdtemp` was never called — no scratch directory, so no scenario ran. |
| **T117** | The existing enum guard applied to `ctrlrun.verify/v1`: no `Status.`, `Decision.`, `EffectState.`, `ReceiptResult.`, `ApprovalStatus.` or `EventType.` repr appears in the JSON, the text, the JUnit or the job summary — including on a run that fails, so the counterexample's receipts, events and effect records are covered too. |

`1950 passed`, `mypy --strict src/` clean, `ruff check` and `ruff format --check` clean.