### PR TITLE
verify: the GitHub Action, the badge and docs/verify.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,56 @@ jobs:
       - name: check
         run: ./scripts/check.sh
 
+  # SPEC-v0.4 §5, T118. The composite action, run against this repository's own
+  # configurations, with `install: .` so it dogfoods the checkout rather than the last
+  # release. Two runs, because the second is the one that matters: the N/A path has to be
+  # dogfooded and not merely described.
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # 10/10. Effect templates, three grants, a delegable parent — the only configuration in
+      # the repository that can exercise the whole catalogue.
+      - name: Verify examples/authority/payments.yaml
+        id: authority
+        uses: ./
+        with:
+          policy: examples/authority/payments.yaml
+          install: .
+          badge-path: verify-badge.json
+          artifact-name: ctrlrun-verify-authority
+
+      # 5/5, 5 not applicable. A `ctrlrun.policy/v1` document with no effect templates and no
+      # grants, and the assertion is on **that shape**: a change that made verify silently
+      # count N/As as passes is caught here rather than in a badge.
+      - name: Verify examples/policies/payments.yaml
+        id: templates
+        uses: ./
+        with:
+          policy: examples/policies/payments.yaml
+          install: .
+          badge-path: verify-badge-templates.json
+          artifact-name: ctrlrun-verify-templates
+
+      - name: The reported shapes are the ones the specification names
+        env:
+          AUTHORITY: ${{ steps.authority.outputs.badge-message }}
+          AUTHORITY_NA: ${{ steps.authority.outputs.not-applicable }}
+          TEMPLATES: ${{ steps.templates.outputs.badge-message }}
+          TEMPLATES_NA: ${{ steps.templates.outputs.not-applicable }}
+        run: |
+          set -eu
+          echo "authority: $AUTHORITY ($AUTHORITY_NA not applicable)"
+          echo "templates: $TEMPLATES ($TEMPLATES_NA not applicable)"
+          test "$AUTHORITY" = "verified 10/10"
+          test "$AUTHORITY_NA" = "0"
+          test "$TEMPLATES" = "verified 5/5"
+          test "$TEMPLATES_NA" = "5"
+          test -s verify-badge.json
+          test -s verify-report.json
+          test -s verify-report.xml
+
   # The definition of done says the demo runs with no network and the README quick start
   # works verbatim. Both were only ever checked by hand, which is how a README stops being
   # true. This job runs them against an installed wheel, the way a new user meets them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,37 @@ any change to one appears here.
   document structurally as well — a permissive schema is not a check. `xmlschema` joins the
   **dev** extra for that test and for nothing else.
 
+- **The GitHub Action, the badge and `docs/verify.md`** (SPEC-v0.4 §5). `action.yml` at the
+  repository root is a composite action: it installs `ctrlrun`, runs
+  `ctrlrun verify --json --junit`, renders the job summary and the badge **from that report**
+  rather than from a second run — so the badge, the summary and the uploaded artifact can never
+  disagree about what happened — and uploads the three files as one artifact.
+
+  It fails the job when a guarantee failed and when the configuration was refused, and succeeds
+  when guarantees are N/A. **There is no input that makes a failure not fail the job**: a
+  `continue-on-error`-shaped flag here would be a flag that makes a consequential thing
+  permissive by default, and a workflow that wants to tolerate a failure has
+  `continue-on-error` on the step already, where it is visible.
+
+  The badge is a Shields endpoint JSON the action **writes and never publishes**. Committing it
+  would need `contents: write` in every consumer's workflow, and asking for write access to a
+  repository as the price of a verification badge is a bad trade for a tool whose subject is
+  least privilege; `docs/verify.md` shows the one-job publishing pattern once, with its cost
+  visible. Rendered, it reads exactly `CTRLRun verified N/M`, where `M` is **applicable**
+  guarantees and never the catalogue size. A partial run and a run that exited 2 or 3 write no
+  badge at all.
+
+  The badge means **"declared guarantees pass"** — that phrase, on the badge's link target, and
+  no other. Not secure, not safe, not compliant, not certified, not audited.
+  `docs/verify.md#what-the-badge-means` says it in its first sentence and, on the same screen,
+  what verify cannot see: the operator's executors, their `reconcile` hooks, where they put the
+  decorator, their deployment, and whether the policy is the right policy.
+
+  This repository's CI runs the action against `examples/authority/payments.yaml` (10/10) and
+  against `examples/policies/payments.yaml` (5/5, 5 not applicable), asserting **both shapes** —
+  so a change that made verify silently count N/As as passes is caught in CI rather than in a
+  badge.
+
 ### Changed
 
 - **`docs/SPEC-v0.3.md` §10 T85 is amended**, as SPEC-v0.4 §9.4 item 2 requires and in the

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CTRLRun
 
+[![CTRLRun verified](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/CTRLRun/ctrlrun/badges/verify-badge.json)](https://github.com/CTRLRun/ctrlrun/blob/main/docs/verify.md#what-the-badge-means)
+
 **Transaction safety for AI-agent actions.**
 
 > Agents can retry. Your refund shouldn't.
@@ -149,6 +151,56 @@ executes, and effects land at remotes. It is a way to learn what enforcement wil
 `JWTIdentityProvider` that verifies a bearer token against a JWKS or a pinned key and maps the
 verified claims onto a principal. CTRLRun issues no credential and defines no identity format.
 
+## Does it hold in *your* setup?
+
+Everything above is proven by this repository's tests against this repository's configurations.
+That is the right place to start and the wrong place to stop, because what you deploy is *your*
+policy, *your* grants and *your* store.
+
+```console
+$ ctrlrun verify
+CTRLRun verify — ctrlrun 0.4.0, catalogue ctrlrun.guarantees/v1
+policy     examples/authority/payments.yaml (ctrlrun.policy/v3, mode: enforce)
+authority  same document, 3 grants
+store      sqlite, scratch (created and destroyed for this run)
+
+G1   mutated approval refused         PASS  stripe.refund
+G2   replayed approval refused        PASS  stripe.refund
+G3   duplicate effect refused         PASS  stripe.refund
+G4   one winner under concurrency     PASS  stripe.refund (8 processes)
+G5   ambiguous blocks a blind retry   PASS  stripe.refund
+G6   unknown action refused           PASS
+G7   no principal refused             PASS  stripe.refund
+G8   expired authority refused        PASS  head-of-support
+G9   delegation cannot escalate       PASS  head-of-support (6 of 6 dimensions)
+G10  unknown exception is ambiguous   PASS  stripe.refund
+
+10/10 declared guarantees pass. 0 not applicable.
+```
+
+It runs the kernel's own failure scenarios against the configuration in front of it, in a
+scratch store, with fake executors, and no network. Your `.ctrlrun/state.db` is byte-identical
+before and after.
+
+**Not applicable is not a pass.** A policy with no `approve` rule cannot exercise the
+approval-binding guarantees, so they are reported `N/A` with the reason, excluded from the
+denominator and listed separately — `5/5 (5 not applicable)`, never `10/10`. There is no flag
+that folds one into the count.
+
+The badge means the **declared guarantees pass** — every guarantee this configuration can
+exercise was exercised, and none of them failed. It does not mean secure, safe, compliant,
+certified or audited, and [`docs/verify.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/verify.md#what-the-badge-means)
+says on the same screen what verify cannot see: your executors, your `reconcile` hooks, where
+you put the decorator, your deployment, and whether your policy is the right policy.
+
+There is a [GitHub Action](https://github.com/CTRLRun/ctrlrun/blob/main/docs/verify.md#in-ci):
+
+```yaml
+      - uses: CTRLRun/ctrlrun@main
+        with:
+          policy: ctrlrun.yaml
+```
+
 ## Two more things
 
 **Resolving an unknown outcome without a human.** `@protect(..., reconcile=...)` takes a
@@ -229,6 +281,9 @@ CTRLRun cannot guarantee exactly-once execution against external systems it does
 | [`docs/SPEC-v0.1.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/SPEC-v0.1.md) | The v0.1 contract: models, invariants, acceptance tests |
 | [`docs/SPEC-v0.2.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/SPEC-v0.2.md) | The v0.2 delta: gateway, sinks, reconciliation, webhooks |
 | [`docs/SPEC-v0.3.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/SPEC-v0.3.md) | The v0.3 delta: identity, authority, delegation, observe mode |
+| [`docs/SPEC-v0.4.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/SPEC-v0.4.md) | The v0.4 delta: the guarantee catalogue, the scenario engine, the badge |
+| [`docs/verify.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/verify.md) | `ctrlrun verify`, the guarantees, the N/A rule, and what the badge means |
+| [`docs/OWASP-AGENTIC-TOP10.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/OWASP-AGENTIC-TOP10.md) | A reading of the OWASP Top 10 for Agentic Applications against the guarantees |
 | [`docs/authority.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/authority.md) | Grants, delegation and the omission rule, in plain language |
 | [`docs/ACS.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/ACS.md) | The OWASP Agent Control Standard: what maps, and where it is silent |
 | [`docs/ARCHITECTURE.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/ARCHITECTURE.md) | Kernel design and key decisions |

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,182 @@
+name: CTRLRun verify
+description: >-
+  Run CTRLRun's declared guarantees against your policy and grants, and report what passed,
+  what failed, and what could not be tested at all.
+author: CTRLRun
+
+branding:
+  icon: shield
+  color: blue
+
+# SPEC-v0.4 §5.1. Composite, so it is what it looks like: a few steps a reader can follow,
+# with no container to trust and nothing running that the workflow log does not show.
+#
+# **There is no input that makes a failure not fail the job.** A `continue-on-error`-shaped
+# flag here would be a flag that makes a consequential thing permissive by default, which
+# `v0.1 §3.4` refuses everywhere else. A workflow that wants to tolerate a failure has
+# `continue-on-error` on the step already, where it is visible in the workflow rather than
+# hidden in an action's defaults.
+
+inputs:
+  policy:
+    description: Path to the policy document.
+    required: false
+    default: ctrlrun.yaml
+  authority:
+    description: >-
+      Path to a standalone authority document, as `ctrlrun gateway --authority` takes. Leave
+      empty where the `authority:` section is in the policy document itself.
+    required: false
+    default: ""
+  only:
+    description: >-
+      Comma-separated guarantee ids, e.g. `G1,G3`. Empty runs the whole catalogue. A partial
+      run writes no badge (SPEC-v0.4 §4.6).
+    required: false
+    default: ""
+  python-version:
+    description: The Python to run verify on.
+    required: false
+    default: "3.11"
+  install:
+    description: >-
+      The pip requirement to install. Defaults to the published package; set it to `.` to
+      verify with the checkout rather than with the last release.
+    required: false
+    default: ctrlrun
+  badge-path:
+    description: >-
+      Where to write the Shields endpoint JSON. The action writes it and never publishes it:
+      publishing is your decision, in your own workflow, with whatever permissions you choose
+      (SPEC-v0.4 §5.2, `docs/verify.md`).
+    required: false
+    default: verify-badge.json
+  upload-artifact:
+    description: Upload the report, the JUnit file and the badge as one artifact.
+    required: false
+    default: "true"
+  artifact-name:
+    description: The artifact's name.
+    required: false
+    default: ctrlrun-verify
+
+outputs:
+  passed:
+    description: Guarantees that passed.
+    value: ${{ steps.verify.outputs.passed }}
+  failed:
+    description: Guarantees that failed.
+    value: ${{ steps.verify.outputs.failed }}
+  applicable:
+    description: Guarantees this configuration can exercise. The badge's denominator.
+    value: ${{ steps.verify.outputs.applicable }}
+  not-applicable:
+    description: Guarantees this configuration cannot exercise. Never counted as passes.
+    value: ${{ steps.verify.outputs.not-applicable }}
+  badge-message:
+    description: The badge's message, `verified N/M`, or empty where no badge was written.
+    value: ${{ steps.verify.outputs.badge-message }}
+  report-path:
+    description: The `ctrlrun.verify/v1` document.
+    value: ${{ steps.verify.outputs.report-path }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install CTRLRun
+      shell: bash
+      env:
+        CTRLRUN_INSTALL: ${{ inputs.install }}
+      run: |
+        python -m pip install --upgrade pip
+        pip install "$CTRLRUN_INSTALL"
+
+    # One run. The job summary and the badge are rendered from the JSON this step wrote, not
+    # from a second verify, so the badge and the artifact can never disagree about what
+    # happened (§5.1).
+    - name: Verify
+      id: verify
+      shell: bash
+      env:
+        # Inputs reach the shell through the environment and never through `${{ }}`
+        # interpolation into a script: a path is somebody else's string, and a policy path
+        # that closed a quote would be running whatever came after it.
+        CTRLRUN_CONFIG: ${{ inputs.policy }}
+        CTRLRUN_AUTHORITY: ${{ inputs.authority }}
+        CTRLRUN_ONLY: ${{ inputs.only }}
+        CTRLRUN_BADGE: ${{ inputs.badge-path }}
+      run: |
+        set -uo pipefail
+        arguments=(--json --junit verify-report.xml)
+        if [ -n "$CTRLRUN_AUTHORITY" ]; then arguments+=(--authority "$CTRLRUN_AUTHORITY"); fi
+        if [ -n "$CTRLRUN_ONLY" ]; then arguments+=(--only "$CTRLRUN_ONLY"); fi
+
+        status=0
+        ctrlrun verify "${arguments[@]}" > verify-report.json || status=$?
+        echo "ctrlrun verify exited $status"
+
+        echo "status=$status" >> "$GITHUB_OUTPUT"
+        echo "report-path=verify-report.json" >> "$GITHUB_OUTPUT"
+
+        if [ ! -s verify-report.json ]; then
+          # Exit 2 and exit 3 print to stderr and write no document. There is nothing to
+          # render, no badge to write, and the job fails below.
+          {
+            echo "### CTRLRun verify"
+            echo
+            echo "The configuration was refused, or verify failed internally"
+            echo "(exit \`$status\`). No report was produced and no badge was written."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        python -c 'import sys; from ctrlrun.verify.report import main; sys.exit(main())' \
+          --report verify-report.json \
+          --summary "$GITHUB_STEP_SUMMARY" \
+          --badge "$CTRLRUN_BADGE"
+
+        python - <<'PY' >> "$GITHUB_OUTPUT"
+        import json
+        import os
+        import pathlib
+
+        document = json.loads(pathlib.Path("verify-report.json").read_text(encoding="utf-8"))
+        summary = document["summary"]
+        badge = pathlib.Path(os.environ["CTRLRUN_BADGE"])
+        message = json.loads(badge.read_text(encoding="utf-8"))["message"] if badge.exists() else ""
+        print(f"passed={summary['passed']}")
+        print(f"failed={summary['failed']}")
+        print(f"applicable={summary['applicable']}")
+        print(f"not-applicable={summary['not_applicable']}")
+        print(f"badge-message={message}")
+        PY
+
+    - name: Upload the report
+      if: ${{ inputs.upload-artifact == 'true' && always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: |
+          verify-report.json
+          verify-report.xml
+          ${{ inputs.badge-path }}
+        if-no-files-found: warn
+
+    # Last, so the report is on the job summary and the artifact is uploaded even when the
+    # job is about to go red. A failure an operator cannot read is a failure they will learn
+    # to ignore.
+    - name: Fail the job on a failed guarantee or a refused configuration
+      shell: bash
+      env:
+        STATUS: ${{ steps.verify.outputs.status }}
+      run: |
+        case "$STATUS" in
+          0) echo "every applicable guarantee passed"; exit 0 ;;
+          1) echo "::error::a declared guarantee failed; see the job summary"; exit 1 ;;
+          2) echo "::error::the configuration was refused or is unusable"; exit 1 ;;
+          *) echo "::error::ctrlrun verify failed internally (exit $STATUS)"; exit 1 ;;
+        esac

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -1,0 +1,273 @@
+# `ctrlrun verify`
+
+Everything CTRLRun guarantees is proven by this repository's tests against this repository's
+configurations. That is the right place to start and the wrong place to stop, because the thing
+you deploy is *your* policy, *your* grants and *your* store — and a guarantee that has never
+been exercised against those is a guarantee nobody has checked.
+
+`ctrlrun verify` runs the kernel's own failure scenarios against the configuration in front of
+it and reports what passed, what failed, and — the part that makes the number mean anything —
+what could not be tested at all.
+
+```console
+$ ctrlrun verify
+CTRLRun verify — ctrlrun 0.4.0, catalogue ctrlrun.guarantees/v1
+policy     examples/authority/payments.yaml (ctrlrun.policy/v3, mode: enforce)
+authority  same document, 3 grants
+store      sqlite, scratch (created and destroyed for this run)
+
+G1   mutated approval refused         PASS  stripe.refund
+G2   replayed approval refused        PASS  stripe.refund
+G3   duplicate effect refused         PASS  stripe.refund
+G4   one winner under concurrency     PASS  stripe.refund (8 processes)
+G5   ambiguous blocks a blind retry   PASS  stripe.refund
+G6   unknown action refused           PASS
+G7   no principal refused             PASS  stripe.refund
+G8   expired authority refused        PASS  head-of-support
+G9   delegation cannot escalate       PASS  head-of-support (6 of 6 dimensions)
+G10  unknown exception is ambiguous   PASS  stripe.refund
+
+10/10 declared guarantees pass. 0 not applicable.
+```
+
+It reads the policy document — `$CTRLRUN_CONFIG`, else `./ctrlrun.yaml` — and the authority
+document beside it. It executes nothing real: every executor is an in-process fake, no scenario
+opens a socket, and it writes nothing outside a temporary directory.
+
+---
+
+## What the badge means
+
+> The badge means the **declared guarantees pass**: every guarantee in the catalogue that this
+> configuration can exercise was exercised, and none of them failed.
+
+That is the whole claim. It is not a statement that your system is secure, that your policy is
+a good policy, or that CTRLRun has audited anything. A configuration that permits everything
+and constrains nobody can pass all ten guarantees, because the guarantees are about **the
+kernel doing what it says under that configuration** — not about whether the configuration is
+wise.
+
+### What it does not mean
+
+Verify sees **the configuration, not the code**. It does not check:
+
+- **Your executors.** The function behind `@protect` is never called. An executor that raises
+  `NotExecuted` when the remote *did* act — `THREAT_MODEL.md` calls this an integration bug,
+  and it is the most dangerous one available — is invisible here, because verify supplies its
+  own executors and never imports your module.
+- **Your `reconcile` hooks**, for the same reason: a hook is a Python callable passed to
+  `@protect`, and it does not appear in any file verify reads.
+- **Where you put the decorator.** Code that calls the raw function bypasses CTRLRun entirely,
+  and no amount of configuration-reading finds that.
+- **Your deployment.** Whether the proxy in front of `HeaderIdentityProvider` overwrites the
+  header, whether `$CTRLRUN_STATE` points where you think, whether two gateways share a state
+  file — none of it is in the document.
+- **Whether your policy is the *right* policy.** Verify has no opinion on whether
+  `stripe.refund` should be autonomous to €500 or to €5. It is not a linter, it does not score,
+  and it will never tell you a configuration is too permissive. That judgment belongs to the
+  person who wrote it, and a tool that pretended otherwise would be handing out an
+  authoritative-looking opinion it has no basis for.
+
+The words **secure**, **safe**, **compliant**, **certified** and **audited** do not appear as
+claims about CTRLRun or about your system on the badge, in its JSON, in the job summary, or on
+this page.
+
+---
+
+## Not applicable is not a pass
+
+A configuration with no `approve` rule cannot exercise the approval-binding guarantees. Verify
+reports them `N/A` with the reason that made them inapplicable, **excludes them from the
+denominator**, and shows them separately:
+
+```
+G3   duplicate effect refused         N/A   no action declares an `effect:` template
+                                            (in a `ctrlrun.policy/v1` document the template
+                                            lives in the @protect decorator, which verify does
+                                            not read)
+G4   one winner under concurrency     N/A   no action declares an `effect:` template
+G5   ambiguous blocks a blind retry   N/A   no action declares an `effect:` template
+G8   expired authority refused        N/A   no authority section
+G9   delegation cannot escalate       N/A   no authority section
+
+5/5 declared guarantees pass. 5 not applicable: G3, G4, G5, G8, G9.
+```
+
+That run is `5/5`, never `10/10`. There is no flag that folds an N/A into the count, and there
+will not be one: a number that counts guarantees nobody exercised is a number that means
+nothing.
+
+An N/A is always a statement about your **document**, derived from it. A scenario verify could
+not build for any other reason is an internal error and exits 3 — never an N/A, and never a
+failure attributed to your kernel.
+
+---
+
+## The guarantees
+
+Ten, in `ctrlrun.guarantees/v1`. Every one is the deployed form of an acceptance test that
+already exists and passes in this repository; verify adds no guarantee of its own and weakens
+none.
+
+| id | invariant | N/A when |
+|---|---|---|
+| **G1** | An approval is bound to one `action_hash`; presenting it for any other action is refused, and the approval is not consumed. | No action reaches `approve` under any satisfiable argument vector. |
+| **G2** | An approval is single-use; the second presentation is refused and does not execute. | As G1. |
+| **G3** | A second attempt on an effect key whose record is `COMMITTED` is refused, and the remote is not called. | No action declares an `effect:` template. |
+| **G4** | Reservation is atomic **across processes**, not merely across threads. | As G3, or the store backend cannot span processes. |
+| **G5** | An executor that raises anything other than `NotExecuted` leaves the effect `AMBIGUOUS`, and the retry is refused rather than executed. | As G3. |
+| **G6** | Unknown action → DENY. There is no default-allow. | `actions:` is empty. |
+| **G7** | No principal, no action: an action proposed outside `context()` with no identity provider is refused, and no receipt and no events are written. | No action in the policy can run at all. |
+| **G8** | A grant is authority only until its `expires_at`; after that the action it covered is denied, by name. | No `authority:` section, no grant with an `expires_at`, or no grant matching any action the policy lists. |
+| **G9** | A delegated grant is valid only if it is provably a subset of its parent on every dimension — and a child that **drops** a dimension its parent constrains is rejected rather than treated as unconstrained. | No `authority:` section, or no grant is delegable. |
+| **G10** | `NotExecuted` is the only outcome that means "the remote did nothing". Everything else, timeouts included, is `AMBIGUOUS`. | Every action in the policy is denied. |
+
+G9 reports **which dimensions it exercised**. A parent that constrains one dimension does not
+score as though it had covered six, because that would be the N/A rule violated one level down.
+
+### Every guarantee carries a positive control
+
+A guarantee is a refusal, and "the second attempt was refused" is satisfied just as well by a
+scenario in which **nothing ever ran**. Such a scenario would report PASS, every time, against
+a kernel with the guard deleted.
+
+So every scenario runs a companion that establishes the observable would have been visible had
+the guard not fired: the unmutated action commits, the first attempt reaches `COMMITTED`, eight
+processes on eight distinct keys all commit, an executor raising `NotExecuted` **is** retried
+and does execute. If the control does not behave as specified, the guarantee is reported
+`FAIL` with `reason: "control failed"`. It is never a pass, and it is never an N/A: an N/A is a
+statement about the configuration, and a failed control is a statement about the run.
+
+---
+
+## Verify never touches your store
+
+Every scenario runs against a scratch store of the same backend type, created for the run and
+destroyed with it. Your `.ctrlrun/state.db` is byte-identical before and after, and it is never
+created where it did not exist. Verify does not call `state_path()`, does not read
+`$CTRLRUN_STATE`, and does not use `Control.from_file()`.
+
+It writes no evidence files either. Evidence of a scenario that never happened, filed beside
+evidence of actions that did, is a receipt trail nobody can read.
+
+---
+
+## Options
+
+```
+ctrlrun verify [--authority PATH] [--json] [--junit PATH] [--only G1,G3] [--store-url URL]
+```
+
+| | |
+|---|---|
+| `--authority PATH` | A standalone authority document, the one `ctrlrun gateway --authority` already accepts. Declaring authority in two places is refused, naming both. |
+| `--json` | One `ctrlrun.verify/v1` document on stdout, carrying the SHA-256 of both documents verify read, and on each failure a counterexample: the ordered events, receipts and effect records that show the violation. |
+| `--junit PATH` | A JUnit XML file for CI. An N/A is `<skipped>` and never a pass. |
+| `--only G1,G3` | Runs exactly those. Everything else is `skipped`, the report carries `"partial": true`, and **no badge is written** — a fraction computed over a subset somebody chose is a false green in a different costume. |
+| `--store-url URL` | Reserved. v0.4 accepts the SQLite backend; anything else exits 2 naming v0.6. |
+
+There is **no flag that relaxes a check**. No argument and no environment variable makes
+verify's `Control` behave differently from the one your deployment runs. The moment one exists,
+the thing being verified is not the thing that ships.
+
+### Exit codes
+
+| | |
+|---|---|
+| **0** | Every applicable guarantee passed, and at least one was applicable. |
+| **1** | At least one guarantee FAILED. |
+| **2** | The configuration was refused or is unusable — a missing or malformed policy, authority declared twice, `mode: observe`, an unknown `--only` id, an unsupported `--store-url`, or **zero applicable guarantees**. |
+| **3** | An internal error in verify itself. Never reported as a FAIL, and never as an N/A. |
+
+`mode: observe` is refused rather than run. Observe mode enforces nothing, so every refusal
+these guarantees assert would be recorded rather than made; running the scenarios and reporting
+ten failures would be true and useless, and running them in a synthetic enforce mode would
+report guarantees about a configuration nobody deployed.
+
+---
+
+## In CI
+
+```yaml
+name: CTRLRun verify
+
+on: [push, pull_request]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: CTRLRun/ctrlrun@main
+        with:
+          policy: ctrlrun.yaml
+```
+
+The action installs `ctrlrun`, runs `ctrlrun verify --json --junit`, renders the job summary
+and the badge JSON **from that report** — not from a second run, so they cannot disagree — and
+uploads the three files as one artifact.
+
+It fails the job when a guarantee failed and when the configuration was refused, and succeeds
+when guarantees are N/A. N/A is not a failure and it is not a pass; the job's green means
+"nothing that could be checked was wrong", which is exactly what the badge says.
+
+**There is no input that makes a failure not fail the job.** A workflow that wants to tolerate
+one puts `continue-on-error` on the step, where it is visible in the workflow rather than
+hidden in an action's defaults.
+
+### Inputs
+
+| | |
+|---|---|
+| `policy` | Path to the policy document. Default `ctrlrun.yaml`. |
+| `authority` | Path to a standalone authority document. Default: the policy document carries it. |
+| `only` | Comma-separated guarantee ids. A partial run writes no badge. |
+| `python-version` | Default `3.11`. |
+| `install` | The pip requirement to install. Default `ctrlrun`; set it to `.` to verify with the checkout. |
+| `badge-path` | Where to write the Shields endpoint JSON. Default `verify-badge.json`. |
+
+Outputs: `passed`, `failed`, `applicable`, `not-applicable`, `badge-message`, `report-path`.
+
+### Publishing the badge
+
+The action **writes** the endpoint JSON and never publishes it. Publishing it needs
+`contents: write`, and asking for write access to your repository as the price of a
+verification badge is a bad trade for a tool whose subject is least privilege. So the cost is
+here, visible, once — and it is your decision:
+
+```yaml
+      # Requires `permissions: contents: write` on the job.
+      - name: Publish the badge
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git fetch origin badges || git switch --orphan badges
+          git switch badges
+          cp verify-badge.json .
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add verify-badge.json
+          git commit -m "verify: $(python -c 'import json;print(json.load(open("verify-badge.json"))["message"])')" || exit 0
+          git push origin badges
+```
+
+Then the badge is:
+
+```markdown
+[![CTRLRun](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OWNER/REPO/badges/verify-badge.json)](docs/verify.md#what-the-badge-means)
+```
+
+It renders as **CTRLRun verified N/M**, where `N` is passes and `M` is **applicable**
+guarantees — never the catalogue size. It is `brightgreen` when nothing failed and `red`
+otherwise; there is no amber for N/A, because the badge's colour is about failures and the N/A
+count lives in the report the badge links to.
+
+A partial run (`--only`) and a run that exited 2 or 3 write **no badge at all**.
+
+---
+
+## Related
+
+- [`SPEC-v0.4.md`](SPEC-v0.4.md) — the contract this implements, guarantee by guarantee.
+- [`OWASP-AGENTIC-TOP10.md`](OWASP-AGENTIC-TOP10.md) — a reading of somebody else's taxonomy
+  against these guarantees, with the entries CTRLRun does not address listed by name.
+- [`THREAT_MODEL.md`](THREAT_MODEL.md) — what fail-closed means here, and what is out of scope.

--- a/src/ctrlrun/verify/report.py
+++ b/src/ctrlrun/verify/report.py
@@ -12,10 +12,11 @@ from __future__ import annotations
 
 import json
 import xml.etree.ElementTree as ElementTree
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
+from pathlib import Path
 from typing import Any, Final
 
 from .guarantees import CATALOGUE, EFFECT_TEMPLATE_NOTE, GUARANTEES
@@ -339,20 +340,90 @@ class Report:
         return ElementTree.tostring(suite, encoding="unicode", xml_declaration=True)
 
     def job_summary(self) -> str:
-        """§5.4 — a Markdown table, with the N/A rows in full."""
-        lines = [
-            f"### CTRLRun verify — {self.policy['path']}",
-            "",
-            "| id | guarantee | status | action | reason |",
-            "| --- | --- | --- | --- | --- |",
-        ]
-        for result in self.guarantees:
-            lines.append(
-                f"| {result.id} | {result.title} | `{result.status}` | "
-                f"{result.action or ''} | {result.reason or ''} |"
-            )
-        lines += ["", self.summary_line()]
-        return "\n".join(lines)
+        """§5.4 - a Markdown table, with the N/A rows in full.
+
+        Rendered from this report's own document, which is the same one the GitHub Action
+        reads (§5.1): the summary and the badge come from the report rather than from a second
+        run, so they can never disagree about what happened.
+        """
+        return summary_from_document(self.to_dict())
+
+
+# --- rendering from a `ctrlrun.verify/v1` document (§5.1, §5.2, §5.4) --------------------
+#
+# The Action reads the JSON `ctrlrun verify --json` wrote and renders the job summary and the
+# badge from it. It does not run verify a second time, so the badge and the uploaded artifact
+# cannot disagree; and it does not reimplement the rules, so "no badge for a partial run" is
+# written once and holds in both places.
+
+
+def badge_from_document(document: Mapping[str, Any]) -> dict[str, Any] | None:
+    """The Shields endpoint document, or `None` where §5.2 forbids one.
+
+    `N` is passes and `M` is **applicable**, never the catalogue size. `color` is
+    `brightgreen` when nothing failed and `red` otherwise; there is no amber for N/A, because
+    the badge's colour is about failures and the N/A count lives in the report the badge links
+    to.
+
+    `None` for a partial run and for a run that could not produce a usable answer at all. A
+    fraction computed over a subset somebody chose is the false green this release exists to
+    prevent, wearing a different costume.
+    """
+    if document.get("partial"):
+        return None
+    summary = document["summary"]
+    applicable = int(summary["applicable"])
+    failed = int(summary["failed"])
+    if applicable == 0:
+        # Zero applicable is an exit of 2 (§3.8), and an exit of 2 writes no badge.
+        return None
+    return {
+        "schemaVersion": 1,
+        "label": BADGE_LABEL,
+        "message": f"verified {int(summary['passed'])}/{applicable}",
+        "color": BADGE_PASS_COLOR if failed == 0 else BADGE_FAIL_COLOR,
+    }
+
+
+def summary_line_from_document(document: Mapping[str, Any]) -> str:
+    """§4.1's last line, from the document. Passes over applicable, N/A named separately."""
+    summary = document["summary"]
+    rows = document["guarantees"]
+    na = [row["id"] for row in rows if row["status"] == Status.NOT_APPLICABLE.value]
+    line = f"{summary['passed']}/{summary['applicable']} declared guarantees pass."
+    line += f" {len(na)} not applicable"
+    line += f": {', '.join(na)}." if na else "."
+    skipped = [row["id"] for row in rows if row["status"] == Status.SKIPPED.value]
+    if skipped:
+        line += f" {len(skipped)} not selected: {', '.join(skipped)}."
+    return line
+
+
+def summary_from_document(document: Mapping[str, Any]) -> str:
+    """§5.4 - the job summary: a Markdown table, id, title, status, action, reason.
+
+    It carries the N/A rows **in full**. A summary that listed only failures would make an
+    all-N/A run look like a clean one, which is the same false green in the one place an
+    operator is most likely to read it and nowhere else.
+    """
+    policy = document["policy"]
+    lines = [
+        f"### CTRLRun verify - `{policy['path']}`",
+        "",
+        f"{policy['schema']}, mode `{policy['mode']}`, {policy['actions']} actions, "
+        f"catalogue `{document['catalogue']}`, ctrlrun {document['ctrlrun_version']}",
+        "",
+        "| id | guarantee | status | subject | reason |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for row in document["guarantees"]:
+        subject = row["grant_id"] or row["action"] or ""
+        lines.append(
+            f"| {row['id']} | {row['title']} | `{row['status']}` | "
+            f"{subject} | {row['reason'] or ''} |"
+        )
+    lines += ["", summary_line_from_document(document)]
+    return "\n".join(lines)
 
 
 def _subject(result: GuaranteeResult) -> str:
@@ -420,3 +491,63 @@ __all__ = [
     "Status",
     "catalogue_ids",
 ]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """`python -m ctrlrun.verify.report`, the renderer the GitHub Action calls (§5.1).
+
+    Reads one `ctrlrun.verify/v1` document on stdin and writes the job summary and the badge
+    from **that document** — never from a second verify run, so the badge, the job summary and
+    the uploaded artifact cannot disagree about what happened.
+
+    `--badge PATH` writes the Shields endpoint JSON, and writes **nothing** where §5.2 forbids
+    a badge: a partial run, or a run with no applicable guarantee. It says which on stderr and
+    still exits 0, because "no badge was written" is the correct outcome there and not a
+    failure of the renderer.
+    """
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(prog="ctrlrun.verify.report", description=str(main.__doc__))
+    parser.add_argument("--badge", type=Path, default=None)
+    parser.add_argument("--summary", type=Path, default=None)
+    parser.add_argument("--report", type=Path, default=None)
+    arguments = parser.parse_args(argv)
+
+    raw = (
+        arguments.report.read_text(encoding="utf-8")
+        if arguments.report is not None
+        else sys.stdin.read()
+    )
+    document = json.loads(raw)
+    if document.get("schema") != REPORT_SCHEMA:
+        print(
+            f"not a {REPORT_SCHEMA} document: schema is {document.get('schema')!r}",
+            file=sys.stderr,
+        )
+        return 2
+
+    rendered = summary_from_document(document)
+    if arguments.summary is not None:
+        with arguments.summary.open("a", encoding="utf-8") as handle:
+            handle.write(rendered + "\n")
+    else:
+        print(rendered)
+
+    if arguments.badge is not None:
+        badge = badge_from_document(document)
+        if badge is None:
+            print(
+                "no badge written: a partial run and a run with no applicable guarantee do "
+                "not produce one (SPEC-v0.4 §5.2)",
+                file=sys.stderr,
+            )
+        else:
+            arguments.badge.write_text(
+                json.dumps(badge, ensure_ascii=False) + "\n", encoding="utf-8"
+            )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through the composite action
+    raise SystemExit(main())

--- a/tests/test_verify_action.py
+++ b/tests/test_verify_action.py
@@ -48,12 +48,27 @@ FORBIDDEN = ("secure", "safe", "compliant", "certified", "audited")
 BADGE_MESSAGE = re.compile(r"^verified \d+/\d+$")
 
 
+def _repository_file(path: Path) -> str:
+    """Read a file that belongs to the **repository** rather than to the package.
+
+    `action.yml` and `.github/workflows/ci.yml` are not in the sdist and must not be: a
+    downstream packager builds a library, not a GitHub Action, and `MANIFEST.in` prunes
+    `.github` on purpose. So these assertions skip where the file is absent, the way
+    `test_packaging.py` already skips without a checkout — and they run, with everything
+    asserted, in the working tree and in CI's `check` job, which is where a change to either
+    file is actually made.
+    """
+    if not path.exists():  # pragma: no cover - only outside a checkout
+        pytest.skip(f"{path.name} is not in the sdist; this asserts a repository file")
+    return path.read_text(encoding="utf-8")
+
+
 def _action() -> dict:
-    return yaml.safe_load(ACTION.read_text(encoding="utf-8"))
+    return yaml.safe_load(_repository_file(ACTION))
 
 
 def _workflow() -> dict:
-    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return yaml.safe_load(_repository_file(WORKFLOW))
 
 
 def _write(directory: Path, document: str) -> Path:
@@ -83,7 +98,6 @@ EMPTY = "schema: ctrlrun.policy/v1\nactions: {}\n"
 def test_T118_the_action_is_a_composite_action_at_the_repository_root():
     action = _action()
 
-    assert ACTION.exists()
     assert action["runs"]["using"] == "composite"
     assert set(action["inputs"]) >= {
         "policy",
@@ -207,7 +221,7 @@ def test_T119_the_colour_is_about_failures_and_has_no_amber_for_not_applicable(
 
 
 def test_T119_the_link_target_carries_the_exact_phrase():
-    page = VERIFY_DOC.read_text(encoding="utf-8")
+    page = _repository_file(VERIFY_DOC)
 
     assert "declared guarantees pass" in page
     # And it is the anchor the badge links to, not a phrase buried somewhere else.
@@ -231,7 +245,7 @@ def test_T119_no_claim_uses_the_forbidden_vocabulary(tmp_path, word):
     # On the page, each of these words appears only inside a sentence that refuses it. The
     # unit is the paragraph rather than the line, because the refusal and the word it refuses
     # are often on different lines of the same wrapped sentence.
-    page = VERIFY_DOC.read_text(encoding="utf-8")
+    page = _repository_file(VERIFY_DOC)
     offending = [
         paragraph
         for paragraph in page.split("\n\n")
@@ -242,7 +256,7 @@ def test_T119_no_claim_uses_the_forbidden_vocabulary(tmp_path, word):
 
 
 def test_T119_the_action_and_the_workflow_make_no_forbidden_claim():
-    text = (ACTION.read_text(encoding="utf-8") + WORKFLOW.read_text(encoding="utf-8")).lower()
+    text = (_repository_file(ACTION) + _repository_file(WORKFLOW)).lower()
 
     for word in FORBIDDEN:
         assert word not in text, word
@@ -350,7 +364,7 @@ def test_T120_the_renderer_writes_the_badge_where_one_is_allowed(tmp_path):
 
 
 def test_the_readme_carries_the_badge_and_links_it_to_what_it_means():
-    readme = README.read_text(encoding="utf-8")
+    readme = _repository_file(README)
 
     assert "img.shields.io/endpoint" in readme
     assert "verify-badge.json" in readme
@@ -358,7 +372,7 @@ def test_the_readme_carries_the_badge_and_links_it_to_what_it_means():
 
 
 def test_the_readme_documentation_table_links_the_verify_page():
-    readme = README.read_text(encoding="utf-8")
+    readme = _repository_file(README)
 
     assert "docs/verify.md" in readme
     assert "declared guarantees pass" in readme

--- a/tests/test_verify_action.py
+++ b/tests/test_verify_action.py
@@ -1,0 +1,376 @@
+"""The composite action, the badge and `docs/verify.md`. SPEC-v0.4 §5; T118-T120.
+
+The badge is the shortest sentence this project makes, and the one most likely to be read
+without the report behind it. So its text is asserted as a *concatenation* and against a
+regex rather than a word list — no adjective can be appended to it later — and the vocabulary
+it is not allowed to use is asserted against the badge, the job summary and `docs/verify.md`
+together.
+
+T118's substance runs in this repository's CI, where the action actually executes. What is
+asserted here is that the job exists, that it runs the action against both configurations, and
+that it checks the two shapes the specification names — because a CI job nothing asserts is a
+CI job somebody can delete.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ctrlrun.verify import guarantees as reg
+from ctrlrun.verify import run
+from ctrlrun.verify.report import (
+    BADGE_FAIL_COLOR,
+    BADGE_LABEL,
+    BADGE_PASS_COLOR,
+    badge_from_document,
+    summary_from_document,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ACTION = REPO_ROOT / "action.yml"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+VERIFY_DOC = REPO_ROOT / "docs" / "verify.md"
+README = REPO_ROOT / "README.md"
+AUTHORITY_PAYMENTS = REPO_ROOT / "examples" / "authority" / "payments.yaml"
+V1_PAYMENTS = REPO_ROOT / "examples" / "policies" / "payments.yaml"
+
+#: SPEC-v0.4 §5.3 and §6.1 — the vocabulary the badge, the summary and the page may not use as
+#: a claim about CTRLRun or about the operator's system. The same list `v0.2 §10` T31 holds the
+#: sector templates to.
+FORBIDDEN = ("secure", "safe", "compliant", "certified", "audited")
+
+#: §5.2 — a regex rather than a word list, so no adjective can be appended to it later.
+BADGE_MESSAGE = re.compile(r"^verified \d+/\d+$")
+
+
+def _action() -> dict:
+    return yaml.safe_load(ACTION.read_text(encoding="utf-8"))
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _write(directory: Path, document: str) -> Path:
+    path = directory / "ctrlrun.yaml"
+    path.write_text(document, encoding="utf-8")
+    return path
+
+
+ALL_APPLICABLE = """schema: ctrlrun.policy/v2
+actions:
+  acme.refund:
+    effect: "refund:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 1000 }
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 100000 }
+        decision: approve
+      - decision: deny
+"""
+
+EMPTY = "schema: ctrlrun.policy/v1\nactions: {}\n"
+
+
+# --- T118: the action runs in this repository's CI -----------------------------------------
+
+
+def test_T118_the_action_is_a_composite_action_at_the_repository_root():
+    action = _action()
+
+    assert ACTION.exists()
+    assert action["runs"]["using"] == "composite"
+    assert set(action["inputs"]) >= {
+        "policy",
+        "authority",
+        "only",
+        "python-version",
+        "install",
+        "badge-path",
+    }
+    assert set(action["outputs"]) >= {
+        "passed",
+        "failed",
+        "applicable",
+        "not-applicable",
+        "badge-message",
+        "report-path",
+    }
+
+
+def test_T118_ci_runs_the_action_against_both_configurations():
+    jobs = _workflow()["jobs"]
+
+    assert "verify" in jobs, "CI does not run the action at all"
+    steps = jobs["verify"]["steps"]
+    used = [step.get("with", {}).get("policy") for step in steps if step.get("uses") == "./"]
+
+    assert "examples/authority/payments.yaml" in used
+    assert "examples/policies/payments.yaml" in used
+    # `install: .` so the action dogfoods the checkout rather than the last release (§5.1).
+    for step in steps:
+        if step.get("uses") == "./":
+            assert step["with"]["install"] == "."
+
+
+def test_T118_ci_asserts_the_two_shapes_the_specification_names():
+    """The N/A dogfood. A change that made verify silently count N/As is caught in CI rather
+    than in a badge, and this test is what keeps the assertion in the job."""
+    steps = _workflow()["jobs"]["verify"]["steps"]
+    script = "\n".join(step.get("run", "") for step in steps)
+
+    assert 'test "$AUTHORITY" = "verified 10/10"' in script
+    assert 'test "$TEMPLATES" = "verified 5/5"' in script
+    assert 'test "$TEMPLATES_NA" = "5"' in script
+
+
+@pytest.mark.authority
+def test_T118_the_two_configurations_really_do_report_those_shapes():
+    """And the shapes CI asserts are the ones the code produces, checked here rather than only
+    on a runner: a CI assertion that has drifted from the code fails once, in the wrong place,
+    on somebody else's branch."""
+    authority = run(AUTHORITY_PAYMENTS)
+    templates = run(V1_PAYMENTS)
+
+    assert authority.badge is not None
+    assert authority.badge["message"] == "verified 10/10"
+    assert authority.not_applicable == 0
+    assert templates.badge is not None
+    assert templates.badge["message"] == "verified 5/5"
+    assert templates.not_applicable == 5
+
+
+def test_T118_the_action_uploads_the_report_and_writes_a_job_summary():
+    steps = _action()["runs"]["steps"]
+    uploads = [step for step in steps if str(step.get("uses", "")).startswith("actions/upload-")]
+    script = "\n".join(step.get("run", "") for step in steps)
+
+    assert uploads, "the action uploads nothing"
+    paths = uploads[0]["with"]["path"]
+    assert "verify-report.json" in paths
+    assert "verify-report.xml" in paths
+    assert "GITHUB_STEP_SUMMARY" in script
+    # Rendered from the report, never from a second run: `--report verify-report.json`.
+    assert "--report verify-report.json" in script
+    # One run. The summary and the badge come from the document it wrote, not from a second
+    # verify, so they can never disagree about what happened (§5.1).
+    assert script.count('ctrlrun verify "${arguments[@]}"') == 1
+
+
+# --- T119: the badge says what it is allowed to say ----------------------------------------
+
+
+def test_T119_the_rendered_badge_text_is_exactly_CTRLRun_verified_N_over_M(tmp_path):
+    report = run(_write(tmp_path, ALL_APPLICABLE))
+    badge = report.badge
+
+    assert badge is not None
+    rendered = f"{badge['label']} {badge['message']}"
+    assert rendered == f"CTRLRun verified {report.passed}/{report.applicable}"
+    assert re.fullmatch(r"CTRLRun verified \d+/\d+", rendered)
+    assert BADGE_MESSAGE.fullmatch(badge["message"])
+    assert badge["label"] == BADGE_LABEL == "CTRLRun"
+    assert badge["schemaVersion"] == 1
+
+
+def test_T119_the_denominator_is_applicable_and_never_the_catalogue_size():
+    report = run(V1_PAYMENTS)
+    badge = report.badge
+
+    assert badge is not None
+    assert badge["message"] == f"verified {report.passed}/{report.applicable}"
+    assert report.applicable == 5
+    assert len(reg.GUARANTEES) == 10
+    assert "/10" not in badge["message"]
+
+
+def test_T119_the_colour_is_about_failures_and_has_no_amber_for_not_applicable(
+    tmp_path, monkeypatch
+):
+    from ctrlrun.verify import scenarios
+
+    passing = run(V1_PAYMENTS)
+    assert passing.not_applicable == 5
+    assert passing.badge is not None
+    assert passing.badge["color"] == BADGE_PASS_COLOR
+
+    monkeypatch.setattr(scenarios, "run_attempts", lambda payloads: None)
+    failing = run(_write(tmp_path, ALL_APPLICABLE))
+    assert failing.failed == 1
+    assert failing.badge is not None
+    assert failing.badge["color"] == BADGE_FAIL_COLOR
+
+
+def test_T119_the_link_target_carries_the_exact_phrase():
+    page = VERIFY_DOC.read_text(encoding="utf-8")
+
+    assert "declared guarantees pass" in page
+    # And it is the anchor the badge links to, not a phrase buried somewhere else.
+    heading = page.index("## What the badge means")
+    assert "declared guarantees pass" in page[heading : heading + 600]
+
+
+@pytest.mark.parametrize("word", FORBIDDEN)
+def test_T119_no_claim_uses_the_forbidden_vocabulary(tmp_path, word):
+    """Asserted against the badge, its JSON, the job summary and `docs/verify.md` together.
+
+    `docs/verify.md` names the words in order to refuse them, and the sentence that does is the
+    only place any of them may appear on the page.
+    """
+    report = run(_write(tmp_path, ALL_APPLICABLE))
+    document = json.loads(report.to_json())
+
+    assert word not in json.dumps(badge_from_document(document)).lower()
+    assert word not in summary_from_document(document).lower()
+
+    # On the page, each of these words appears only inside a sentence that refuses it. The
+    # unit is the paragraph rather than the line, because the refusal and the word it refuses
+    # are often on different lines of the same wrapped sentence.
+    page = VERIFY_DOC.read_text(encoding="utf-8")
+    offending = [
+        paragraph
+        for paragraph in page.split("\n\n")
+        if word in paragraph.lower()
+        and not any(marker in paragraph.lower() for marker in ("not ", "never", "no "))
+    ]
+    assert not offending, f"{word!r} used as a claim: {offending}"
+
+
+def test_T119_the_action_and_the_workflow_make_no_forbidden_claim():
+    text = (ACTION.read_text(encoding="utf-8") + WORKFLOW.read_text(encoding="utf-8")).lower()
+
+    for word in FORBIDDEN:
+        assert word not in text, word
+
+
+# --- T120: the job fails on FAIL and succeeds on N/A ---------------------------------------
+
+
+def _fail_script() -> str:
+    steps = _action()["runs"]["steps"]
+    return "\n".join(step.get("run", "") for step in steps if "STATUS" in str(step.get("env", "")))
+
+
+def test_T120_the_job_fails_on_a_failed_guarantee_and_on_a_refused_configuration():
+    script = _fail_script()
+
+    assert "0) echo" in script and "exit 0" in script
+    assert "1) echo" in script and "::error::a declared guarantee failed" in script
+    assert "2) echo" in script and "the configuration was refused" in script
+    # Exit 2 fails the job. A configuration nothing could be checked against is not a pass.
+    assert script.count("exit 1") >= 3
+
+
+def test_T120_no_input_makes_a_failure_not_fail_the_job():
+    """Asserted against the parsed action, not its text: the text names `continue-on-error`
+    in order to refuse it, and a check that could not tell a comment from a key would have to
+    be deleted the first time somebody explained the rule."""
+    action = _action()
+
+    for name in action["inputs"]:
+        for suggestive in ("continue", "ignore", "soft", "fail", "tolerate", "warn"):
+            assert suggestive not in name, name
+    for step in action["runs"]["steps"]:
+        assert "continue-on-error" not in step, step.get("name")
+
+
+def test_T120_a_configuration_with_not_applicable_guarantees_still_writes_a_badge():
+    """N/A is not a failure and it is not a pass; the job's green means "nothing that could be
+    checked was wrong", which is exactly what the badge says."""
+    report = run(V1_PAYMENTS)
+
+    assert report.exit_code == 0
+    assert report.badge is not None
+    assert report.badge["message"] == "verified 5/5"
+
+
+def test_T120_a_failing_run_writes_a_red_badge_and_a_non_zero_exit(tmp_path, monkeypatch):
+    from ctrlrun.verify import scenarios
+
+    monkeypatch.setattr(scenarios, "run_attempts", lambda payloads: None)
+    report = run(_write(tmp_path, ALL_APPLICABLE))
+
+    assert report.exit_code == 1
+    assert report.badge is not None
+    assert report.badge["color"] == BADGE_FAIL_COLOR
+
+
+def test_T120_a_partial_run_writes_no_badge(tmp_path):
+    report = run(_write(tmp_path, ALL_APPLICABLE), only=("G6",))
+
+    assert report.partial is True
+    assert report.badge is None
+    assert badge_from_document(json.loads(report.to_json())) is None
+
+
+def test_T120_an_exit_2_configuration_writes_no_badge(tmp_path):
+    report = run(_write(tmp_path, EMPTY))
+
+    assert report.exit_code == 2
+    assert report.badge is None
+    assert badge_from_document(json.loads(report.to_json())) is None
+
+
+def test_T120_the_renderer_writes_no_badge_file_where_none_is_allowed(tmp_path):
+    """The action calls this, so "no badge for a partial run" has to hold at the file level and
+    not only in a property nothing writes out."""
+    from ctrlrun.verify.report import main
+
+    report = run(_write(tmp_path, ALL_APPLICABLE), only=("G6",))
+    document = tmp_path / "report.json"
+    document.write_text(report.to_json(), encoding="utf-8")
+    badge = tmp_path / "badge.json"
+    summary = tmp_path / "summary.md"
+
+    assert main(["--report", str(document), "--badge", str(badge), "--summary", str(summary)]) == 0
+    assert not badge.exists()
+    assert summary.read_text(encoding="utf-8").startswith("### CTRLRun verify")
+
+
+def test_T120_the_renderer_writes_the_badge_where_one_is_allowed(tmp_path):
+    from ctrlrun.verify.report import main
+
+    report = run(V1_PAYMENTS)
+    document = tmp_path / "report.json"
+    document.write_text(report.to_json(), encoding="utf-8")
+    badge = tmp_path / "badge.json"
+
+    assert main(["--report", str(document), "--badge", str(badge)]) == 0
+    written = json.loads(badge.read_text(encoding="utf-8"))
+    assert written == report.badge
+    assert BADGE_MESSAGE.fullmatch(written["message"])
+
+
+# --- the README badge and the documentation links ------------------------------------------
+
+
+def test_the_readme_carries_the_badge_and_links_it_to_what_it_means():
+    readme = README.read_text(encoding="utf-8")
+
+    assert "img.shields.io/endpoint" in readme
+    assert "verify-badge.json" in readme
+    assert "docs/verify.md#what-the-badge-means" in readme
+
+
+def test_the_readme_documentation_table_links_the_verify_page():
+    readme = README.read_text(encoding="utf-8")
+
+    assert "docs/verify.md" in readme
+    assert "declared guarantees pass" in readme
+
+
+def test_the_job_summary_carries_the_not_applicable_rows_in_full():
+    """A summary that listed only failures would make an all-N/A run look like a clean one."""
+    report = run(V1_PAYMENTS)
+    summary = report.job_summary()
+
+    for result in report.guarantees:
+        assert f"| {result.id} |" in summary
+        if result.reason:
+            assert result.reason in summary
+    assert report.summary_line() in summary


### PR DESCRIPTION
SPEC-v0.4 **item 4**, §5. Stacked on #35, which is stacked on #34.

## One run, two renderings

The action runs `ctrlrun verify --json --junit` **once** and renders the job summary and the badge from the JSON that run wrote. `Report.badge` and `Report.job_summary()` now route through the same document-shaped renderers (`badge_from_document`, `summary_from_document`), so the rule "a partial run writes no badge" is written once and holds whether it is asked of a `Report` in process or of a JSON document on a runner. The badge, the summary and the uploaded artifact cannot disagree about what happened.

## The badge

Rendered text is exactly **`CTRLRun verified N/M`** — label, a space, message. T119 asserts the concatenation *and* asserts `message` against `^verified \d+/\d+$`, a regex rather than a word list, so no adjective can be appended to it later.

- `M` is **applicable**, never the catalogue size. T119 checks `/10` does not appear in the badge for a configuration with five N/As.
- `brightgreen` when nothing failed, `red` otherwise. **No amber for N/A** — the colour is about failures, and the N/A count lives in the report the badge links to.
- **No badge at all** for a partial run (`--only`) or a run that exited 2 or 3. Asserted both as a property and at the file level, since the action is what actually writes the file.

The action **writes** the endpoint JSON and never publishes it. Committing it needs `contents: write` in every consumer's workflow, and asking for write access to a repository as the price of a verification badge is a bad trade for a tool whose subject is least privilege. `docs/verify.md` shows the one-job publishing pattern once, with the permission it costs stated beside it.

## What the badge means

> The badge means the **declared guarantees pass**: every guarantee in the catalogue that this configuration can exercise was exercised, and none of them failed.

That sentence opens `docs/verify.md#what-the-badge-means`, which is the badge's link target, and §1.2's list is on the same screen — verify does not check the operator's executors, their `reconcile` hooks, where they put the decorator, their deployment, or whether their policy is the right policy.

`secure`, `safe`, `compliant`, `certified` and `audited` appear on that page only inside the sentence that refuses them, and nowhere in the badge, its JSON, the job summary, `action.yml` or the workflow. T119 asserts that paragraph by paragraph.

## No input makes a failure not fail the job

The job fails on exit 1 (a guarantee failed) and on exit 2 (the configuration was refused), and succeeds when guarantees are N/A. The report reaches `$GITHUB_STEP_SUMMARY` and the artifact is uploaded **before** the job goes red, because a failure an operator cannot read is a failure they will learn to ignore.

T120 asserts this against the **parsed** action rather than its text: `action.yml` names `continue-on-error` in order to refuse it, and a check that could not tell a comment from a key would have to be deleted the first time somebody explained the rule.

Inputs reach the shell through `env:` and never through `${{ }}` interpolation into a script. A policy path is somebody else's string, and one that closed a quote would be running whatever came after it.

## Dogfooding, in CI

A new `verify` job runs the action twice with `install: .`, so it verifies the checkout rather than the last release:

| configuration | expected |
|---|---|
| `examples/authority/payments.yaml` | `verified 10/10`, 0 not applicable |
| `examples/policies/payments.yaml` | `verified 5/5`, **5 not applicable** |

The second is the one that matters. The N/A path is dogfooded rather than described, so a change that made verify silently count N/As as passes is caught in CI rather than in a badge. T118 asserts the job exists, that it names both configurations, that `install` is `.`, that the shape assertions are still in the job — and, separately, that those shapes are the ones the code actually produces, so a CI assertion that has drifted from the code does not first fail on somebody else's branch.

## Tests

T118, T119, T120 (26 tests). `1976 passed`, `mypy --strict src/` clean, `ruff check` and `ruff format --check` clean.

The `verify` CI job on this PR is the live half of T118 — it is the first run of the action against real configurations.