### PR TITLE
docs: the OWASP Agentic Top 10, read against the guarantees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,25 @@ any change to one appears here.
   so a change that made verify silently count N/As as passes is caught in CI rather than in a
   badge.
 
+- **`docs/OWASP-AGENTIC-TOP10.md`** (SPEC-v0.4 §6) — a reading of the OWASP Top 10 for Agentic
+  Applications (2026 edition, announced 2025-12-09) against the ten guarantees. Its first line,
+  before any table, says what it is not: not a compliance claim, not a conformance claim, not a
+  certification, and not a statement that CTRLRun covers the Top 10.
+
+  Two tables, and the second is what makes the first credible. `ASI04` supply chain, `ASI05`
+  code execution and `ASI06` memory and context poisoning are **not CTRLRun's subject** —
+  nothing here inspects a package, sandboxes an interpreter or reads a model's memory — and
+  `ASI07` inter-agent communication waits on v0.7. `ASI01` agent goal hijack and `ASI09`
+  human-agent trust exploitation appear in **both** tables, because CTRLRun constrains what a
+  hijacked agent can do without detecting the hijack, and binds an approval to one action
+  without authenticating the approver or noticing that they were misled.
+
+  The document records how its codes and titles were derived, because the published PDF sits
+  behind a download form and could not be retrieved: they come from the OWASP-owned
+  `OWASP/secure-agent-playbook` repository, corroborated against two independent summaries, and
+  the four places where a third summary disagreed are named. That correction is what SPEC-v0.4
+  §6.2 marked its own provisional list as needing.
+
 ### Changed
 
 - **`docs/SPEC-v0.3.md` §10 T85 is amended**, as SPEC-v0.4 §9.4 item 2 requires and in the

--- a/docs/OWASP-AGENTIC-TOP10.md
+++ b/docs/OWASP-AGENTIC-TOP10.md
@@ -1,0 +1,112 @@
+# The OWASP Top 10 for Agentic Applications, read against CTRLRun's guarantees
+
+This is a **reading** of somebody else's taxonomy against the guarantees CTRLRun tests. It is
+not a compliance claim, a conformance claim, a certification, or a statement that CTRLRun
+covers the OWASP Top 10 for Agentic Applications. Four of the ten entries are not addressed by
+CTRLRun at all, and they are listed by name below.
+
+Every row maps a guarantee to an entry, and every guarantee is backed by a passing acceptance
+test — so each row points at code and at a test. A row whose test disappears is a row that
+comes out.
+
+---
+
+## The edition this was written against
+
+| | |
+|---|---|
+| **Document** | OWASP Top 10 for Agentic Applications |
+| **Edition** | 2026 |
+| **Publisher** | OWASP GenAI Security Project, OWASP Foundation |
+| **Announced** | 2025-12-09 |
+| **Entry codes** | `ASI01:2026` – `ASI10:2026` |
+| **Landing page** | <https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/> |
+| **Read on** | 2026-09-04 |
+
+**How the codes and titles below were derived, stated plainly because it matters.** The
+published document itself is a PDF behind a download form on the landing page above and could
+not be retrieved. The ten codes and titles were taken from
+[`OWASP/secure-agent-playbook`](https://github.com/OWASP/secure-agent-playbook/blob/main/plugins/ai-security-skills/plays/agentic-ai-risk-assess.md),
+an OWASP-owned repository that enumerates them, and corroborated against two independent
+third-party summaries that agree with it in every entry. Where a third summary disagreed —
+`ASI02` as "Tool Misuse & Exploitation", `ASI04` as "…Compromise", `ASI08` as "Cascading Agent
+Failures" — the OWASP-owned repository's wording is the one used here.
+
+### The ten entries
+
+| Code | Title |
+|---|---|
+| `ASI01:2026` | Agent Goal Hijack |
+| `ASI02:2026` | Tool Misuse |
+| `ASI03:2026` | Identity & Privilege Abuse |
+| `ASI04:2026` | Agentic Supply Chain Vulnerabilities |
+| `ASI05:2026` | Unexpected Code Execution |
+| `ASI06:2026` | Memory & Context Poisoning |
+| `ASI07:2026` | Insecure Inter-Agent Communication |
+| `ASI08:2026` | Cascading Failures |
+| `ASI09:2026` | Human-Agent Trust Exploitation |
+| `ASI10:2026` | Rogue Agents |
+
+Anyone with the published PDF in front of them should check these ten strings against it. If
+one differs, this table is what is wrong, not the mapping.
+
+---
+
+## Guarantee → entries mitigated
+
+Each guarantee is one sentence about what the kernel **refuses**. The "how" column names the
+mechanism, not the entry.
+
+| Guarantee | Invariant | Entries | How |
+|---|---|---|---|
+| **G1** mutated approval refused | An approval is bound to one `action_hash`; presenting it for any other action is refused, and the approval is not consumed. | `ASI09:2026`, `ASI01:2026` (partly) | The approval a human granted is bound to the exact canonical form of the action they were shown, so an action that changed after the approval — by a hijacked goal or by anything else — has no approval to present. |
+| **G2** replayed approval refused | An approval is single-use; the second presentation is refused and does not execute. | `ASI09:2026` | The approval record is consumed in the same transaction that admits it, so one human decision authorizes exactly one execution and a loop cannot spend it twice. |
+| **G3** duplicate effect refused | A second attempt on an effect key whose record is `COMMITTED` is refused, and the remote is not called. | `ASI08:2026`, `ASI02:2026` | Effects are identified by a key derived from the action's own arguments, and a committed key is refused rather than retried — so a retry loop cannot turn one intended effect into several. |
+| **G4** one winner under concurrency | Reservation is atomic across processes, not merely across threads. | `ASI08:2026` | The reservation is taken inside a `BEGIN IMMEDIATE` against a unique constraint on the effect key, so two agents that picked up the same task produce one effect and one refusal. |
+| **G5** ambiguous blocks a blind retry | An executor that raises anything other than `NotExecuted` leaves the effect `AMBIGUOUS`, and the retry is refused rather than executed. | `ASI08:2026` | A lost response is recorded as an *unknown* outcome rather than a failure, and an unknown outcome is a state only a human or a reconciliation hook may leave — so the failure does not cascade into a second execution of something that may already have happened. |
+| **G6** unknown action refused | Unknown action → DENY. There is no default-allow. | `ASI02:2026`, `ASI01:2026` (partly) | The policy is the list of what an agent may do; anything not written in it is refused, so a tool an agent was talked into reaching for is refused whether or not the reasoning that reached for it was sound. |
+| **G7** no principal refused | An action proposed with no principal is refused, and no receipt and no events are written. | `ASI03:2026` | Every action carries a principal or it does not run, so there is no path on which an action executes with nobody attributable to it. |
+| **G8** expired authority refused | A grant is authority only until its `expires_at`; after that the action it covered is denied, by name. | `ASI03:2026`, `ASI10:2026` | Authority is evaluated on every action against the clock, not at the start of a session, so an agent still running after its grant lapsed is denied on its next proposal. |
+| **G9** delegation cannot escalate | A delegated grant is valid only if it is provably a subset of its parent on every dimension — and a child that **drops** a dimension its parent constrains is rejected rather than treated as unconstrained. | `ASI03:2026`, `ASI10:2026` | Containment is checked at creation and again on every evaluation by walking the chain to its root, and omission is never inheritance — so an agent handed authority cannot mint itself more of it, and a revocation anywhere in the chain cuts everything beneath it. |
+| **G10** unknown exception is ambiguous | `NotExecuted` is the only outcome that means "the remote did nothing". Everything else, timeouts included, is `AMBIGUOUS`. | `ASI08:2026` | The mapping from an executor's exception to an outcome is asymmetric on purpose: a timeout is not a failure, so a framework's retry-on-error cannot be the thing that decides whether money moved twice. |
+
+---
+
+## Not covered by CTRLRun
+
+The half that makes the table above credible. One honest sentence each; nothing aspirational.
+
+| Entry | Title | Why not |
+|---|---|---|
+| `ASI04:2026` | Agentic Supply Chain Vulnerabilities | Out of scope. CTRLRun never inspects a package, a model, a tool registry or an MCP server's provenance; it decides actions, and a poisoned dependency reaches it as an ordinary caller. |
+| `ASI05:2026` | Unexpected Code Execution | Out of scope. Nothing here sandboxes an interpreter or constrains what a process may run. CTRLRun sits between an agent and one remote effect, not between an agent and its own runtime. |
+| `ASI06:2026` | Memory & Context Poisoning | Out of scope, and deliberately so: CTRLRun never reads a model's memory, its context or its prompt. It sees a proposed action and its arguments, which is the point at which a poisoned context has already become a concrete request. |
+| `ASI07:2026` | Insecure Inter-Agent Communication | Not yet. Authority does not propagate across agent hops in this release — a grant is evaluated where the action is proposed, and there is no A2A model. `docs/ROADMAP.md` puts that in v0.7; until then, an agent handing work to another agent is outside what these guarantees say anything about. |
+
+And the two entries where the mapping above is **partial**, with the part that is not covered
+stated here rather than left implied:
+
+| Entry | Title | Covered | Not covered |
+|---|---|---|---|
+| `ASI01:2026` | Agent Goal Hijack | G1 and G6 constrain what a hijacked agent can *do*: it still meets the policy, and it still cannot present an approval granted for a different action. | CTRLRun does not detect or prevent the hijack. It never sees the prompt, the plan or the reasoning, so an agent whose goal was replaced proposes actions exactly as a healthy one would — and every action inside its policy and its grants will run. |
+| `ASI09:2026` | Human-Agent Trust Exploitation | G1 and G2 close the shape where an approval a human gave for one action is spent on another, or spent twice. | CTRLRun does not authenticate the *approver*, does not model separation of duties, and has no opinion on whether the human was misled into approving. A human persuaded to approve the right action for the wrong reason gets a valid approval, and the receipt records it as one. |
+
+---
+
+## Where the guarantees are actually checked
+
+The mapping is only worth what the tests behind it are worth. `ctrlrun verify` runs these ten
+against a configuration and reports which of them that configuration can exercise at all —
+**not applicable is not a pass**, so a mapping row whose guarantee your policy cannot exercise
+shows up as `N/A` with the reason rather than as a green tick. See
+[`docs/verify.md`](verify.md).
+
+Each guarantee also descends from an acceptance test in `docs/SPEC-v0.1.md §7`,
+`docs/SPEC-v0.2.md §10` or `docs/SPEC-v0.3.md §10`, named in the registry and carried into
+every report as `descends_from`.
+
+---
+
+This document is regenerated when the guarantee catalogue changes, and when OWASP publishes a
+new edition. It was written against `ctrlrun.guarantees/v1` and the **2026** edition of the
+OWASP Top 10 for Agentic Applications.

--- a/tests/test_owasp_mapping.py
+++ b/tests/test_owasp_mapping.py
@@ -1,0 +1,191 @@
+"""`docs/OWASP-AGENTIC-TOP10.md`. SPEC-v0.4 §6; T121.
+
+The mapping is complete in **both** directions, and the second direction is the one that makes
+the first credible: every entry with no guarantee is listed by name under "Not covered by
+CTRLRun", so a reader can see the size of what is left out without counting rows.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from ctrlrun.verify import guarantees as reg
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MAPPING = REPO_ROOT / "docs" / "OWASP-AGENTIC-TOP10.md"
+README = REPO_ROOT / "README.md"
+VERIFY_DOC = REPO_ROOT / "docs" / "verify.md"
+
+#: The edition this document is written against, as recorded in it. Derived from the
+#: OWASP-owned `OWASP/secure-agent-playbook` repository and corroborated against two
+#: independent third-party summaries; the published PDF is behind a download form, which the
+#: document says in as many words rather than implying a reading nobody made.
+EDITION = "2026"
+ENTRIES = {
+    "ASI01:2026": "Agent Goal Hijack",
+    "ASI02:2026": "Tool Misuse",
+    "ASI03:2026": "Identity & Privilege Abuse",
+    "ASI04:2026": "Agentic Supply Chain Vulnerabilities",
+    "ASI05:2026": "Unexpected Code Execution",
+    "ASI06:2026": "Memory & Context Poisoning",
+    "ASI07:2026": "Insecure Inter-Agent Communication",
+    "ASI08:2026": "Cascading Failures",
+    "ASI09:2026": "Human-Agent Trust Exploitation",
+    "ASI10:2026": "Rogue Agents",
+}
+
+#: §6.1 — every ASI code in the document has to look like one, so a typo is not silently a
+#: new entry.
+CODE = re.compile(r"ASI\d{2}:\d{4}")
+
+#: `v0.2 §10` T31's list, unchanged. A mapping table presented as coverage is a compliance
+#: claim wearing a table's clothes, so the same words are refused here.
+COMPLIANCE_WORDS = (
+    "compliant",
+    "compliance",
+    "certified",
+    "certification",
+    "accredited",
+    "attestation",
+    "conforms to",
+    "aligned with",
+)
+
+
+def _document() -> str:
+    return MAPPING.read_text(encoding="utf-8")
+
+
+def _flat() -> str:
+    """The document with its line wrapping removed, so a phrase can be asserted whole.
+
+    A sentence that reads correctly and wraps across two lines is still the sentence; a test
+    that could not see it would be a test that pushes prose into one long line to satisfy it.
+    """
+    return " ".join(_document().split())
+
+
+def _sections() -> tuple[str, str]:
+    """The mapping table and the `Not covered by CTRLRun` half, as text."""
+    text = _document()
+    split = text.index("## Not covered by CTRLRun")
+    return text[:split], text[split:]
+
+
+# --- T121: the mapping is complete in both directions --------------------------------------
+
+
+def test_T121_every_guarantee_in_the_registry_appears_in_the_mapping():
+    mapping, _ = _sections()
+
+    for guarantee in reg.GUARANTEES:
+        assert f"**{guarantee.id}**" in mapping, guarantee.id
+        assert guarantee.title in mapping, guarantee.id
+
+
+def test_T121_every_code_in_the_document_is_one_of_the_ten_in_the_cited_edition():
+    found = set(CODE.findall(_document()))
+
+    assert found, "the document names no entry at all"
+    assert found <= set(ENTRIES), sorted(found - set(ENTRIES))
+    for code in found:
+        assert CODE.fullmatch(code), code
+
+
+def test_T121_every_entry_in_the_cited_edition_appears_in_one_half_or_the_other():
+    """None appears in neither. An entry silently absent would read as covered."""
+    mapping, not_covered = _sections()
+
+    for code in ENTRIES:
+        assert code in mapping or code in not_covered, code
+
+
+def test_T121_the_four_uncovered_entries_are_listed_by_name():
+    """§6.1's disclaimer says four of the ten are not addressed at all, and this is the test
+    that keeps that sentence true rather than merely written."""
+    _, not_covered = _sections()
+
+    fully_uncovered = {"ASI04:2026", "ASI05:2026", "ASI06:2026", "ASI07:2026"}
+    for code in fully_uncovered:
+        assert code in not_covered, code
+        assert ENTRIES[code] in not_covered, code
+    assert "Four of the ten entries are not addressed by CTRLRun at all" in _flat()
+
+
+def test_T121_a_partly_addressed_entry_appears_in_both_halves():
+    """§6.2 item 4 — the honest place for a hedge is next to the thing it qualifies."""
+    mapping, not_covered = _sections()
+
+    for code in ("ASI01:2026", "ASI09:2026"):
+        assert code in mapping, code
+        assert code in not_covered, code
+    assert "Not covered" in not_covered
+
+
+def test_T121_every_entry_title_is_the_one_the_cited_edition_uses():
+    document = _document()
+
+    for code, title in ENTRIES.items():
+        if code not in document:
+            continue
+        # The title has to appear somewhere the code does, so a code cannot drift onto a
+        # different entry's sentence without the pair going out of step.
+        assert title in document, (code, title)
+
+
+def test_T121_the_document_makes_no_compliance_claim():
+    text = _document().lower()
+
+    for word in COMPLIANCE_WORDS:
+        if word not in text:
+            continue
+        # The disclaimer names the words in order to refuse them. Every occurrence has to sit
+        # in a paragraph that does.
+        offending = [
+            paragraph
+            for paragraph in _document().split("\n\n")
+            if word in paragraph.lower()
+            and not any(marker in paragraph.lower() for marker in ("not ", "never", "no "))
+        ]
+        assert not offending, f"{word!r} used as a claim: {offending}"
+
+
+def test_T121_the_first_line_before_any_table_is_the_disclaimer():
+    text = _document()
+    first_table = text.index("|")
+
+    disclaimer = " ".join(text[:first_table].split())
+    assert "is a **reading** of somebody else's taxonomy" in disclaimer
+    assert "not a compliance claim" in disclaimer
+
+
+def test_T121_the_edition_and_the_date_it_was_read_are_recorded():
+    text = _document()
+
+    assert EDITION in text
+    assert "2025-12-09" in text
+    assert "2026-09-04" in text
+    assert "genai.owasp.org" in text
+    # And how the codes were derived, because the published PDF could not be retrieved and
+    # saying so is the difference between a citation and a claim.
+    assert "could not be retrieved" in _flat()
+    assert "secure-agent-playbook" in text
+
+
+@pytest.mark.parametrize("guarantee", reg.GUARANTEES, ids=lambda g: g.id)
+def test_T121_every_guarantee_row_names_at_least_one_entry(guarantee):
+    mapping, _ = _sections()
+    row = next(line for line in mapping.split("\n") if line.startswith(f"| **{guarantee.id}**"))
+
+    assert CODE.search(row), guarantee.id
+
+
+# --- linked from where a reader will be -----------------------------------------------------
+
+
+def test_the_mapping_is_linked_from_the_readme_and_from_the_verify_page():
+    assert "OWASP-AGENTIC-TOP10.md" in README.read_text(encoding="utf-8")
+    assert "OWASP-AGENTIC-TOP10.md" in VERIFY_DOC.read_text(encoding="utf-8")


### PR DESCRIPTION
SPEC-v0.4 **item 5**, §6. Stacked on #36.

A reading of somebody else's taxonomy against what CTRLRun tests. Its first line, before any table, says what it is not: not a compliance claim, not a conformance claim, not a certification, and not a statement that CTRLRun covers the Top 10.

## Where the codes came from, and why that sentence is in the document

The published PDF sits behind a download form on the OWASP landing page and could not be retrieved. So the document says so, and names what was used instead: the OWASP-owned [`OWASP/secure-agent-playbook`](https://github.com/OWASP/secure-agent-playbook/blob/main/plugins/ai-security-skills/plays/agentic-ai-risk-assess.md) repository, corroborated against two independent third-party summaries that agree with it entry for entry. Where a third summary disagreed, the OWASP-owned wording won, and the three disagreements are named in the document rather than smoothed over.

A citation that cannot say where it came from is a claim. **Anyone with the PDF in front of them should check the ten strings** — the document says that too.

This corrects SPEC-v0.4 §6.2's provisional list in four places, which is what §6.2 said to expect:

| | §6.2 provisional | Used here |
|---|---|---|
| ASI02 | Tool Misuse & Exploitation | **Tool Misuse** |
| ASI03 | Agent Identity & Privilege Abuse | **Identity & Privilege Abuse** |
| ASI04 | Agentic Supply Chain Compromise | **Agentic Supply Chain Vulnerabilities** |
| ASI08 | Cascading Agent Failures | **Cascading Failures** |

## Two tables, and the second is the point

The first maps each guarantee to the entries it mitigates, with one sentence on the **mechanism** rather than a restatement of the entry.

The second, `Not covered by CTRLRun`, is what makes the first credible:

- **`ASI04:2026` Agentic Supply Chain Vulnerabilities** — out of scope. Nothing here inspects a package, a model or a tool registry.
- **`ASI05:2026` Unexpected Code Execution** — out of scope. Nothing sandboxes an interpreter.
- **`ASI06:2026` Memory & Context Poisoning** — out of scope, deliberately. CTRLRun never reads a model's memory, its context or its prompt.
- **`ASI07:2026` Insecure Inter-Agent Communication** — not yet. Authority does not propagate across agent hops in this release; ROADMAP puts that in v0.7.

And two entries appear in **both** tables, with the uncovered half stated next to the covered one:

- **`ASI01:2026` Agent Goal Hijack** — G1 and G6 constrain what a hijacked agent can *do*. CTRLRun does not detect the hijack: it never sees the prompt, so an agent whose goal was replaced proposes actions exactly as a healthy one would, and everything inside its policy and its grants runs.
- **`ASI09:2026` Human-Agent Trust Exploitation** — G1 and G2 close the shape where an approval given for one action is spent on another, or spent twice. CTRLRun does not authenticate the approver, does not model separation of duties, and has no opinion on whether the human was misled.

## T121

Complete in both directions, and the second direction is asserted separately:

- every `G` in the registry appears in the mapping, with its title;
- every ASI code in the document is one of the ten in the cited edition, and matches `^ASI\d{2}:\d{4}$`;
- every entry in the cited edition is in one half or the other, **none in neither** — an entry silently absent would read as covered;
- the four fully-uncovered entries are listed by name, and the disclaimer's "four of the ten" is true rather than merely written;
- the two partly-covered entries appear in both halves;
- every guarantee row names at least one entry;
- no compliance claim, against `v0.2 §10` T31's word list, unchanged.

Linked from the README's documentation table and from `docs/verify.md`.

`1996 passed`.