### PR TITLE
release: 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,28 @@ All notable changes to this project are documented here. The format follows
 Public API names are frozen in `docs/SPEC-v0.1.md` §8. Before 1.0 they may still change, and
 any change to one appears here.
 
-## [Unreleased]
+## [0.4.0] - 2026-09-04
+
+**Does it hold in *your* setup?** Everything CTRLRun guarantees was proven, until now, by this
+repository's tests against this repository's configurations. That is the right place to start
+and the wrong place to stop: what an operator deploys is *their* policy, *their* grants and
+*their* store, and a guarantee that has never been exercised against those is a guarantee
+nobody has checked.
+
+`ctrlrun verify` runs the failure scenarios of v0.1 §7, v0.2 §10 and v0.3 §10 against the
+configuration in front of it and reports what passed, what failed, and — the part that makes
+the number mean anything — what could not be tested at all.
+
+Three rules govern it, and each has a test that would go red if it stopped holding. **Not
+applicable is not a pass.** **Verify never touches the operator's store.** **The badge means
+"declared guarantees pass"**, and nothing else. A fourth keeps verify honest about itself:
+**every guarantee carries a positive control**, because a refusal asserted against a scenario
+in which nothing ran passes on a kernel with the guard deleted.
+
+No schema changes: `ctrlrun.policy/v3`, `ctrlrun.receipt/v2`, `ctrlrun.action/v1` and
+`ctrlrun.inspection/v2` are untouched, and **no store gains a table or a column** — verify
+writes only to a scratch store it created. Three new schema strings belong to documents rather
+than to storage: `ctrlrun.verify/v1`, `ctrlrun.guarantees/v1` and `ctrlrun.framework-probe/v1`.
 
 ### Added
 
@@ -774,5 +795,6 @@ until it gets one, which is the point.
 - Policy conditions address an action's arguments only. Scoping a rule by environment,
   resource or principal arrives with the authority model in v0.3.
 
-[Unreleased]: https://github.com/CTRLRun/ctrlrun/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/CTRLRun/ctrlrun/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/CTRLRun/ctrlrun/releases/tag/v0.4.0
 [0.1.0]: https://github.com/CTRLRun/ctrlrun/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,17 @@ than to storage: `ctrlrun.verify/v1`, `ctrlrun.guarantees/v1` and `ctrlrun.frame
   maintainer; a commit carrying findings about other projects that nobody had reviewed is not
   one this repository makes.
 
+- **`docs/SPEC-v0.4.md` gains a §12**, recording the four readings the implementation had to
+  take where the specification could not be satisfied as written. A specification that
+  disagrees with the code it describes is worse than one that admits a gap: G6 drives a
+  `Control` composed from the policy alone, because authority is evaluated first and its
+  observable would otherwise be unreachable in every configuration with grants; G7 is `N/A`
+  where no action in the policy can run, because §2.2 said "never" and §1.3 requires a control
+  that such a policy cannot supply; G8 gains a fourth N/A reason for a layered document; G9's
+  control names the delegation only where the parent's subject does not also match it; and
+  G4's children are subprocesses rather than `multiprocessing`, which would re-import the
+  caller's `__main__` in every child.
+
 ### Changed
 
 - **`docs/SPEC-v0.3.md` §10 T85 is amended**, as SPEC-v0.4 §9.4 item 2 requires and in the

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -8,7 +8,7 @@ removed from the README in the same commit — the README is not allowed to desc
 that no longer ships. If you find a row here that does not hold against the version you
 installed, that is a bug: please open an issue.
 
-Regenerated for: **v0.3.0**. Line numbers refer to that tag.
+Regenerated for: **v0.4.0**. Line numbers refer to that tag.
 
 ## The opening paragraph
 
@@ -21,16 +21,16 @@ Regenerated for: **v0.3.0**. Line numbers refer to that tag.
 
 | Claim | Code | Proof |
 |---|---|---|
-| "Transaction safety for AI-agent actions" | `Control.execute` — `control.py:188` drives reserve → execute → commit/fail/ambiguous over `EffectState` (`effect.py:56`) | `test_T1_a_lost_response_leaves_the_effect_ambiguous` |
-| "Agents can retry. Your refund shouldn't." | A retry against an `AMBIGUOUS` key is refused — `state.py:187` | `test_T1_a_blind_retry_is_refused_and_never_reaches_the_remote` |
+| "Transaction safety for AI-agent actions" | `Control.execute` — `control.py:520` drives reserve → execute → commit/fail/ambiguous over `EffectState` (`effect.py:67`) | `test_T1_a_lost_response_leaves_the_effect_ambiguous` |
+| "Agents can retry. Your refund shouldn't." | A retry against an `AMBIGUOUS` key is refused — `effect.py:179`, the one place `plan_reservation` decides it for both stores | `test_T1_a_blind_retry_is_refused_and_never_reaches_the_remote` |
 | "open-source" | Apache-2.0 `LICENSE`; `license = "Apache-2.0"` in `pyproject.toml` | n/a — licence file |
-| "controlling consequential AI-agent actions" | `@protect` — `control.py:688`; `context()` — `control.py:86` | `test_T6_unknown_action_raises_ActionDenied_with_reason_unknown_action` |
-| "what an agent can do autonomously, what requires human approval, and what is blocked" | `Decision.ALLOW / APPROVE / DENY` — `policy.py:55`. Exactly three members. | `test_T6_unknown_action_is_denied_with_reason_unknown_action` |
+| "controlling consequential AI-agent actions" | `@protect` — `control.py:1781`; `context()` — `control.py:132` | `test_T6_unknown_action_raises_ActionDenied_with_reason_unknown_action` |
+| "what an agent can do autonomously, what requires human approval, and what is blocked" | `Decision.ALLOW / APPROVE / DENY` — `policy.py:119`. Exactly three members. | `test_T6_unknown_action_is_denied_with_reason_unknown_action` |
 | "binds approvals to the exact action" | `ApprovalRequest.action_hash` — `approval.py:81`; `consume_approval(approval_id, action_hash)` — `approval.py:278` | `test_T2_a_mutated_action_presenting_the_approval_raises_ApprovalMismatch`, `test_T2_any_material_change_invalidates_the_approval` |
-| "blocks duplicate execution attempts for the same logical effect" | `reserve_effect` — `state.py:292`, decided inside the `BEGIN IMMEDIATE` of `_authorize_and_reserve` (`state.py:888`) against `effect_key TEXT PRIMARY KEY` (`state.py:69`) | `test_T3_exactly_one_agent_reserves_and_seven_are_blocked` (8 OS processes), `test_T3_the_fake_remote_is_called_exactly_once` |
-| "stops blind retries when an execution outcome is uncertain" | Only `NotExecuted` maps to `FAILED` — `control.py:250`. Every other exception, timeouts included, yields `AMBIGUOUS`. | `test_T1_a_blind_retry_writes_a_blocked_receipt`, `test_T1_the_ambiguous_record_survives_the_blocked_retry` |
-| "records what actually happened" | `ReceiptResult` — `receipt.py:44`; `Event` and JSONL `append_event` — `receipt.py:222` | `test_T11_every_demo_receipt_carries_every_field_in_the_spec`, `test_T11_every_demo_receipt_parses_back_into_a_Receipt` |
-| "Autonomy belongs to the action, not the agent." | `Policy.evaluate(action)` — `policy.py:233` — passes only the action's **name and arguments** to `_ActionPolicy.evaluate` (`policy.py:164`), whose signature has no principal in it. A rule cannot read who is acting even by accident. `agent_eq` and `user_eq` are refused at load (`policy.py:50`) rather than silently matching nothing. | `test_T6_an_action_name_is_matched_exactly`, `test_a_condition_naming_an_action_field_is_refused_at_load` |
+| "blocks duplicate execution attempts for the same logical effect" | `reserve_effect` — `state.py:380`, decided inside the `BEGIN IMMEDIATE` of `_authorize_and_reserve` (`state.py:1322`) against `effect_key TEXT PRIMARY KEY` (`state.py:71`) | `test_T3_exactly_one_agent_reserves_and_seven_are_blocked` (8 OS processes), `test_T3_the_fake_remote_is_called_exactly_once` |
+| "stops blind retries when an execution outcome is uncertain" | Only `NotExecuted` maps to `FAILED` — `control.py:951`. Every other exception, timeouts included, yields `AMBIGUOUS`. | `test_T1_a_blind_retry_writes_a_blocked_receipt`, `test_T1_the_ambiguous_record_survives_the_blocked_retry` |
+| "records what actually happened" | `ReceiptResult` — `receipt.py:85`; `Event` — `receipt.py:144`; JSONL `append_event` — `state.py:583` | `test_T11_every_demo_receipt_carries_every_field_in_the_spec`, `test_T11_every_demo_receipt_parses_back_into_a_Receipt` |
+| "Autonomy belongs to the action, not the agent." | `Policy.evaluate(action)` — `policy.py:368` — passes only the action's **name and arguments** to `_ActionPolicy.evaluate` (`policy.py:254`), whose signature has no principal in it. A rule cannot read who is acting even by accident. `agent_eq` and `user_eq` are refused at load (`policy.py:104`) rather than silently matching nothing. | `test_T6_an_action_name_is_matched_exactly`, `test_a_condition_naming_an_action_field_is_refused_at_load` |
 
 
 ## What v0.2 adds to the README
@@ -39,14 +39,14 @@ Every sentence the README gained in this release, mapped the same way.
 
 | Claim | Code | Proof |
 |---|---|---|
-| "Point the client at the gateway instead of at the tool server" | `Gateway.handle` — `gateway/server.py:135`; `serve` — `gateway/server.py:892` | `test_T19_the_upstream_receives_the_canonical_arguments` |
+| "Point the client at the gateway instead of at the tool server" | `Gateway.handle` — `gateway/server.py:421`; `serve` — `gateway/__init__.py:40` | `test_T19_the_upstream_receives_the_canonical_arguments` |
 | "No agent changes" | `tools/call` is intercepted and every other method relayed unchanged — `gateway/mcp.py:84` | `test_a_non_intercepted_method_is_relayed_with_no_ctrlrun_outcome` |
-| "The gateway prints … every action in your policy that has no `effect:` template" | `_announce` — `gateway/__init__.py` (it moved out of `cli/main.py` with SPEC-v0.3 §8.4, which added the environment, the identity provider and the authority section to the same block) | `test_the_startup_block_names_the_environment_identity_and_authority`, `test_the_startup_block_says_so_when_there_is_no_authority_section` |
-| "Tools become actions named `mcp.<alias>.<tool>`" | `Gateway._intercept` — `gateway/server.py` | `test_T19_the_action_is_named_for_the_alias_and_the_tool` |
-| "Declare their effect and resource templates there" | `Policy.effect_template` / `resource_template` — `policy.py:281`; `McpOptions` — `policy.py:187` | `test_T16_a_v2_document_loads_and_exposes_its_templates`, `test_T16_a_decorator_and_a_policy_template_produce_the_same_action_hash` |
+| "The gateway prints … every action in your policy that has no `effect:` template" | `_announce` — `gateway/__init__.py:145` (it moved out of `cli/main.py` with SPEC-v0.3 §8.4, which added the environment, the identity provider and the authority section to the same block) | `test_the_startup_block_names_the_environment_identity_and_authority`, `test_the_startup_block_says_so_when_there_is_no_authority_section` |
+| "Tools become actions named `mcp.<alias>.<tool>`" | `Gateway._intercept` — `gateway/server.py:459` | `test_T19_the_action_is_named_for_the_alias_and_the_tool` |
+| "Declare their effect and resource templates there" | `Policy.effect_template` / `resource_template` — `policy.py:349`; `McpOptions` — `policy.py:231` | `test_T16_a_v2_document_loads_and_exposes_its_templates`, `test_T16_a_decorator_and_a_policy_template_produce_the_same_action_hash` |
 | "Everything but `tools/call` is relayed untouched" | `parse_request(...).intercept` — `gateway/mcp.py:84` | `test_every_other_method_is_relayed_not_intercepted` |
 | "A lost response over the wire blocks the retry exactly as it does in-process" | `classify` — `gateway/outcome.py:144`, translated into v0.1 §5.5's own vocabulary by the gateway's executor | `test_T23_the_identical_call_sent_again_is_refused_and_the_upstream_called_once` |
-| "the only thing besides a human permitted to move a record out of `AMBIGUOUS`" | `Control._reconciled` — `control.py:713`; `RECONCILED_STATES` — `effect.py` | `test_T13_a_hook_answering_not_executed_moves_the_record_to_failed`, `test_T14_a_hook_answering_committed_refuses_the_retry_as_a_duplicate` |
+| "the only thing besides a human permitted to move a record out of `AMBIGUOUS`" | `Control._reconciled` — `control.py:1298`; `RECONCILED_STATES` — `effect.py` | `test_T13_a_hook_answering_not_executed_moves_the_record_to_failed`, `test_T14_a_hook_answering_committed_refuses_the_retry_as_a_duplicate` |
 | "and only in the direction its answer points" | `"unknown"` is absent from `RECONCILED_STATES` — `effect.py` | `test_T15_a_hook_that_cannot_answer_leaves_the_record_ambiguous` |
 | "one OpenTelemetry span per action, one span event per step" | `OTelEventSink` — `otel.py:45` | `test_T29_one_action_produces_one_span_named_for_the_action`, `test_T29_every_event_becomes_a_span_event_named_by_its_type` |
 | "Argument values stay out of it unless you ask for them" | `OTelEventSink(arguments=...)` — `otel.py:45` | `test_T29_argument_values_are_not_attributes_by_default` |
@@ -65,7 +65,7 @@ way — and the four the README deliberately *does not* say are below.
 | "A grant carries no `decision:`" | `_GRANT_KEYS` — `authority.py` — is a closed set that does not contain `decision` | `test_T73b_grant_refuses_what_the_loader_refuses` |
 | "the two axes … combine as the stricter of the two" | `Control.evaluate` returns the combined result — `control.py`; a denial on either axis is a denial | `test_T70_the_stricter_of_the_two_wins` |
 | "authority first" | `Control.execute` evaluates authority before policy and a denial appends `AUTHORITY_DENIED` and never `POLICY_EVALUATED` — `control.py:425` | `test_T74_a_denial_leaves_no_pending_approval_request` |
-| "narrow it at runtime with `ctrlrun delegate`" | `Control.delegate` — `control.py:1460`; `Authority.plan_delegation` — `authority.py:878`; `ctrlrun delegate` — `cli/main.py:675` | `test_t75_the_delegation_authorizes_an_action_within_its_limits` |
+| "narrow it at runtime with `ctrlrun delegate`" | `Control.delegate` — `control.py:1460`; `Authority.plan_delegation` — `authority.py:878`; `ctrlrun delegate` — `cli/main.py:660` | `test_t75_the_delegation_authorizes_an_action_within_its_limits` |
 | "provably a subset of its parent on every dimension, at creation and again at every evaluation" | `contained_dimension` — `authority.py:604` — runs from `plan_delegation` (`authority.py:878`) **and** from the chain walk in `Authority.evaluate` (`authority.py:807`) | `test_t76_each_dimension_violated_alone`, `test_t77b_a_narrowed_parent_narrows_its_children` |
 | "Omitting a dimension the parent constrains is rejected, not inherited" | `contained_dimension` treats an absent child dimension as unconstrained and therefore wider — `authority.py:604`; the subject half is `_subject_contained` (`authority.py:635`) | `test_t81_omission_is_not_unlimited`, `test_T73b_a_subject_addressed_to_every_principal_is_refused`, `test_t76_each_dimension_violated_alone` |
 | "`ctrlrun revoke` cuts a chain of any depth with one write" | `Control.revoke` — `control.py:1476` — writes one row (`state.py:529`) and visits no children; every evaluation walks to the root | `test_t78_a_revoked_parent_denies_its_grandchild`, `test_put_delegation_is_never_an_upsert` |
@@ -102,6 +102,32 @@ way — and the four the README deliberately *does not* say are below.
   CTRLRun guarantees it will not *knowingly* execute the same logical effect twice, and that
   it will never treat an unknown outcome as a failure.
 
+## What v0.4 adds to the README
+
+The `ctrlrun verify` section, the badge, and the sentence about what the badge does not mean.
+
+| Claim | Code | Proof |
+|---|---|---|
+| "It runs the kernel's own failure scenarios against the configuration in front of it" | `ctrlrun.verify.run` — `verify/__init__.py:84`; the ten guarantees — `verify/guarantees.py:36`; the scenarios — `verify/scenarios.py` | `test_T100_the_authority_example_passes_every_non_authority_guarantee` (10/10), `test_T100_a_v1_document_with_no_templates_and_no_grants` |
+| "in a scratch store, with fake executors, and no network" | One scratch store per guarantee under a temporary directory — `verify/scenarios.py`, `Engine.control`; `state_path()` is never called and `Control.from_file()` is never used | `test_T103_the_operators_store_is_byte_identical_before_and_after`, `test_T103_a_store_that_does_not_exist_is_not_created`, `test_T107_a_full_run_completes_with_no_network` |
+| "Your `.ctrlrun/state.db` is byte-identical before and after" | The scratch path is a `tempfile.mkdtemp` removed in a `finally` — `verify/__init__.py` | `test_T103_the_operators_store_is_byte_identical_before_and_after` (SHA-256 and `st_mtime_ns`), `test_T103_CTRLRUN_STATE_is_not_read_and_not_created` |
+| "Not applicable is not a pass" | `Report.applicable` is passes plus failures — `verify/report.py`; every N/A reason is a statement about the document — `verify/guarantees.py` | `test_T101_a_policy_with_no_approve_rule_makes_G1_and_G2_not_applicable`, `test_T102_a_policy_with_no_effect_templates_makes_G3_G4_and_G5_not_applicable` |
+| "`5/5 (5 not applicable)`, never `10/10`" | `Report.summary_line` — the N/A ids are a separate sentence, never a parenthesis inside the fraction | `test_T113_the_summary_is_the_last_line_and_names_the_not_applicable_ids` (asserts `10/10` appears nowhere) |
+| "There is no flag that folds one into the count" | There is no such parameter on `run()` (§9.1 freezes the signature) and no such option on the CLI | `test_T101b_zero_applicable_guarantees_is_not_a_pass` — `0/0` exits **2** |
+| "The badge means the **declared guarantees pass**" | `badge_from_document` — `verify/report.py`; the phrase is the first sentence under `docs/verify.md#what-the-badge-means` | `test_T119_the_rendered_badge_text_is_exactly_CTRLRun_verified_N_over_M`, `test_T119_the_link_target_carries_the_exact_phrase` |
+| "It does not mean secure, safe, compliant, certified or audited" | Those words appear in `docs/verify.md` only inside the sentence that refuses them, and nowhere in the badge, the summary, `action.yml` or the workflow | `test_T119_no_claim_uses_the_forbidden_vocabulary`, `test_T119_the_action_and_the_workflow_make_no_forbidden_claim` |
+| "There is a GitHub Action" | `action.yml` at the repository root — composite, one verify run, summary and badge rendered from its JSON | `test_T118_the_action_is_a_composite_action_at_the_repository_root`, and CI's own `verify` job against both example configurations |
+
+And the four things this section deliberately does **not** claim, each with the test that keeps
+it honest:
+
+| Not claimed | Why | Where the limit is asserted |
+|---|---|---|
+| That verify checks the operator's executors | It never calls the function behind `@protect` and never imports the module it lives in | `docs/verify.md`, "What it does not mean"; `THREAT_MODEL.md`, "Known v0.4 limitations" |
+| That a green badge means the configuration is a good one | The guarantees are about the kernel doing what it says *under* that configuration | `test_T119_no_claim_uses_the_forbidden_vocabulary` |
+| That a guarantee reported N/A was checked | It was not, and the reason is on the line | `test_T113_every_not_applicable_line_carries_its_reason` |
+| That a partial run means anything about the whole | `--only` writes no badge at all | `test_T120_a_partial_run_writes_no_badge` |
+
 ## Two claims stated as limits
 
 The README also makes two negative claims. They matter as much as the positive ones.
@@ -109,7 +135,7 @@ The README also makes two negative claims. They matter as much as the positive o
 | Claim | Where it holds |
 |---|---|
 | "CTRLRun cannot guarantee exactly-once execution against external systems it doesn't control." | Stated, not implemented — see `THREAT_MODEL.md`, "Out of scope". CTRLRun never asserts what a remote did; only `NotExecuted`, raised by the executor, claims that. |
-| "It will not *knowingly* execute the same logical effect twice, and will never treat an unknown outcome as a failure." | `state.py:187` (refuse retry on `AMBIGUOUS`) and `control.py:250` (only `NotExecuted` → `FAILED`) |
+| "It will not *knowingly* execute the same logical effect twice, and will never treat an unknown outcome as a failure." | `effect.py:179` (refuse retry on `AMBIGUOUS`) and `control.py:951` (only `NotExecuted` → `FAILED`) |
 
 ## Demo output
 
@@ -121,10 +147,16 @@ demo's output that nobody carried across fails there rather than shipping a READ
 ## How these line numbers are kept honest
 
 They are not, automatically — a citation is prose, and prose drifts. Every row above was
-re-derived against the tree at the tag named at the top of this file, and the two that had
-drifted since the previous pass are called out here rather than quietly corrected: the
-`BEGIN IMMEDIATE` citation pointed at `grant_approval`'s transaction rather than the
-reservation path's, and the "no principal" claim pointed at the private
-`_ActionPolicy.evaluate` while the sentence described the public `Policy.evaluate`. Both now
-point where the sentence says they do. If you are regenerating this file, re-derive every
-row; do not carry one forward on trust.
+re-derived against the tree at the tag named at the top of this file by reading the line each
+one names.
+
+This pass moved **fifteen** of them, and none for an interesting reason: the v0.1 and v0.2
+rows were written against v0.3.0 and the files have grown since. The two that had drifted
+*semantically* were fixed in the previous pass and still point where their sentences say —
+the `BEGIN IMMEDIATE` citation at the reservation path rather than `grant_approval`'s, and the
+"no principal" claim at the public `Policy.evaluate` rather than the private
+`_ActionPolicy.evaluate`. One row moved between files: "blocks duplicate execution attempts"
+cited `state.py` for the `AMBIGUOUS` refusal, which now lives in `effect.py`'s
+`plan_reservation`, decided once for both stores.
+
+If you are regenerating this file, re-derive every row. Do not carry one forward on trust.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,7 +8,7 @@ Sector rule: every pack cites its sources and ships its `REVIEW.md`. No complian
 
 Track rule: kernel versions ship correctness; the tracks that ship beside it (packs, templates, mappings, adapters) ship on their own cadence and never block or share a version with the kernel.
 
-## v0.1 — Kernel (current)
+## v0.1 — Kernel ✅ shipped
 
 Action · Policy (ALLOW/APPROVE/DENY) · `@protect` · exact-action approval (hash, single-use, expiry) · effect key · SQLite atomic reservation · COMMITTED/FAILED/AMBIGUOUS · receipts + events (JSONL) · CLI · `ctrlrun demo` with four scenarios.
 
@@ -16,7 +16,7 @@ Exit: all acceptance tests in `SPEC-v0.1.md §7` pass; demo < 60 s; README liter
 
 Standards: none. `THREAT_MODEL.md` is the only compliance-adjacent claim.
 
-## v0.2 — Zero-friction deployment (shipped)
+## v0.2 — Zero-friction deployment ✅ shipped
 
 - MCP adapter and `ctrlrun gateway --upstream <mcp server>` so an existing MCP tool server gets CTRLRun semantics with no agent changes.
 - OpenTelemetry export of events (align with ACS observability; don't invent a tracing format).
@@ -76,15 +76,20 @@ with RFC 8725's algorithm and explicit-typing rules applied, and it claims no co
 any of them. `--principal-from-client-info` is removed, and `AcsControlHook` gained the same
 requirement for the same reason: a self-reported name cannot be an authorization input.
 
-## v0.4 — Verification
+## v0.4 — Verification ✅ shipped
 
-- `ctrlrun verify`: runs deterministic failure scenarios against a user's config and reports pass/fail per guarantee (mutated approval, replayed approval, duplicate reservation, concurrent reservation, ambiguous retry, unknown action fail-close, expired authority, delegation escalation).
-- Counterexample output on failure.
-- GitHub Action + badge ("CTRLRun Verified n/n"). The badge means *declared guarantees pass*, never "this agent is secure."
+- `ctrlrun verify`: runs the kernel's own failure scenarios against the operator's config and reports pass, fail or **not applicable** per guarantee. Ten of them, `ctrlrun.guarantees/v1`: mutated approval · replayed approval · duplicate effect · concurrent reservation across real OS processes · ambiguous blocks a blind retry · unknown action fail-close · no principal · expired authority · delegation escalation on every dimension including omission · unknown exception is ambiguous, never failed.
+- **Not applicable is not a pass.** A guarantee this configuration cannot exercise is reported `N/A` with the reason, excluded from the denominator and listed separately. There is no flag that folds one into the count.
+- **Every guarantee carries a positive control.** A refusal asserted against a scenario in which nothing ran passes on a kernel with the guard deleted, so a control that misbehaves is `fail` with `reason: "control failed"` — never a pass, and never an N/A.
+- Counterexample output on failure: the ordered events, receipts and effect records that show the violation.
+- GitHub Action + badge, "CTRLRun verified N/M", where M is **applicable** guarantees. The badge means *declared guarantees pass*, never "this agent is secure."
+- `research/framework-probe/`, outside `src/` and never packaged: what an agent stack does with a lost response when nothing guards the effect. Behaviour, not quality.
 
-Standards: first mapping doc — each `ctrlrun verify` guarantee mapped to the OWASP Agentic Top 10 entries it mitigates. Entries not covered are listed as not covered.
+Exit: every acceptance test in `SPEC-v0.4.md §8` passes, and every one in v0.1, v0.2 and v0.3 still does. `ctrlrun verify` against `examples/authority/payments.yaml` reports 10/10; against `examples/policies/payments.yaml`, 5/5 with five not applicable — the N/A rule dogfooded rather than described.
 
-## v0.5 — Adapter contract
+Standards: first mapping doc — `docs/OWASP-AGENTIC-TOP10.md`, each guarantee mapped to the OWASP Top 10 for Agentic Applications entries it mitigates, and the four entries CTRLRun does not address listed by name. A reading of somebody else's taxonomy, and it says so on its first line.
+
+## v0.5 — Adapter contract (Current)
 
 - The adapter contract, documented. It is one of the six contracts v1.0 freezes, so it is written to be lived with.
 - Two reference adapters, to prove the contract is real rather than aspirational: OpenAI Agents SDK and LangGraph. Each reuses the framework's own HITL primitives — LangGraph's `interrupt()` and checkpointers, the Agents SDK's tool-approval interruption — mapped onto `Suspended` / `Control.resume`, which v0.2 already ships for exactly this shape. Never a second approval path beside the framework's own. They ship on the adapters track under their own versions like every other adapter; what v0.5 owns is the requirement that two exist and that the contract survived writing them.

--- a/docs/SPEC-v0.4.md
+++ b/docs/SPEC-v0.4.md
@@ -1514,3 +1514,91 @@ specifically:
   `docs/OWASP-AGENTIC-TOP10.md`, `docs/verify.md`, the README, docstrings, CLI output or the
   badge (§1.4, §6.1).
 - Anything in `VISION.md`.
+
+---
+
+## 12. What building v0.4 settled
+
+Three readings the implementation had to take, recorded here because a specification that
+disagrees with the code it describes is worse than one that admits a gap. Each is argued in a
+`# SPEC:` comment where it lives; this section is the index, in the form `§9.4` takes for the
+earlier contracts.
+
+### 12.1 G6 drives a `Control` composed from the policy alone
+
+§2.2 fixes G6's observable as `ActionDenied` with `reason == "unknown_action"`. But `v0.3 §4.3`
+evaluates **authority before policy**, so under an `authority:` section an action name no grant
+covers is refused by the authority axis and the policy axis is never reached: the observable
+would be `AuthorityDenied(reason="no_authority")`, every time, for every configuration with
+grants in it. The two sentences cannot both hold.
+
+G6 descends from `v0.1 §7` T6, which is about the policy axis and predates the authority model,
+so its scenario builds its `Control` from the policy and no `Authority`. The kernel code under
+test is unchanged and the observable is the one §2.2 fixes; what is left out is a second,
+independent refusal — and that refusal is not left unexercised, because G7 and G8 drive it
+directly. The report carries `detail.axis = "policy"` so a reader is not left to infer it.
+
+An alternative was considered and rejected: deriving an absent action name that some grant's
+wildcard *does* cover. It works only for configurations whose grants carry wildcards, so G6
+would exercise a different thing in different deployments, which is worse than exercising one
+thing everywhere and saying which.
+
+### 12.2 G7 is N/A where no action in the policy can run
+
+§2.2's `N/A when` row for G7 reads **Never**, and §1.3 requires every guarantee to carry a
+positive control. G7's control is *"the identical call inside `context()` runs"*. For a policy
+in which nothing can be driven to `allow` or `approve` there is no such call, so the two
+requirements cannot both hold.
+
+T101b settles it: it requires a configuration with an empty `actions:` to leave **zero**
+applicable guarantees, and G7 reported applicable would leave one. So G7 is `not_applicable`
+when no action can be driven to `allow` or `approve`, with G10's reason — `every action in the
+policy is denied`. It remains applicable to every configuration in which anything can run,
+including every configuration with no `authority:` section, which is what §2.2's row was
+protecting and what T109 asserts.
+
+### 12.3 G8 gains one N/A reason
+
+§2.2 lists three conditions under which G8 is N/A. A fourth exists and §2.2 does not name it,
+because it does not arise in a single-grant configuration: where a **second** grant covers the
+same action past the first one's expiry, the expired grant refuses nothing observable, and G8
+would report a failure that is really a property of a layered document.
+
+The reason is `no grant's expiry is the last authority for an action it covers; another grant
+still permits the action after it lapses`. The engine tries every grant carrying an
+`expires_at`, in id order, and reports this only when none of them is decisive.
+
+The pre-check asks only **whether** authority still passes one microsecond after the expiry —
+never **why** it stopped. Filtering on the reason would turn a kernel that denied for the wrong
+cause into an N/A, and a false N/A is a false pass wearing the other costume (§9.2). A kernel
+whose expiry denial reports the wrong reason therefore FAILs, which is what `v0.3 §10` T71 is
+for and what T108 asserts by injection.
+
+### 12.4 G9's control names the delegation only where it can
+
+§2.2's control for G9 requires *"an action within the child's limits passes authority naming
+the delegation"*. A child is contained in its parent on every dimension, so the parent matches
+every action the child does — and `v0.3 §4.6` picks the lowest grant id among those that
+passed, which is not the delegation's.
+
+`v0.3 §5.4` leaves the concrete agent a child names unconstrained: that is what delegation is
+for. So the narrowed child's subject names an agent the parent's subject does **not** match,
+and the delegation becomes the only authority for the action — `AUTHORITY_RESOLVED` then
+carries the `delegation_id` and the control asserts it. Where the parent's subject is a
+wildcard that matches the child's agent too, the delegation cannot be isolated; the control
+asserts that authority passed and the report records `detail.delegation_isolated = false`,
+because asserting a grant id the model does not promise would be asserting nothing.
+
+### 12.5 G4's children are subprocesses, not `multiprocessing`
+
+§2.2 requires `_PROCESSES` OS processes and says why they cannot share the injected clock. It
+does not say how they are started, and `multiprocessing` with the `spawn` method — the default
+on macOS and Windows — **re-imports the caller's `__main__` module in every child**. A caller
+who ran `ctrlrun.verify.run()` from an unguarded script would fork-bomb itself, and requiring
+an `if __name__ == "__main__"` guard in the program under verification is not a trade a
+verification tool gets to make.
+
+The worker is reached as `python -m ctrlrun.verify.worker` with its payload on stdin. It is
+still a module-level function taking one picklable argument, still eight OS processes, and the
+executor count still comes from `O_CREAT|O_EXCL` files so it survives the process boundary —
+which is the whole of what the guarantee is about.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -64,7 +64,7 @@ they entitled to?* Everything above still holds; these are the threats the secon
 - A root attacker or a malicious administrator with write access to the policy file or SQLite database.
 - A compromised external service (Stripe lying about outcomes).
 - A compromised approver, or social engineering of the approver. CTRLRun proves *what* was approved, not that the human was right.
-- Executors that raise `NotExecuted` incorrectly (asserting no side effect when one occurred). This is an integration bug; v0.4 `verify` will include a check for it where reconciliation exists.
+- Executors that raise `NotExecuted` incorrectly (asserting no side effect when one occurred). This is an integration bug, and it is the most dangerous one available: `NotExecuted` is the one exception that makes an effect retryable, so an executor that raises it after the remote acted turns the one guarantee CTRLRun is built around into a licence to act twice. **`ctrlrun verify` does not and cannot check for it.** Verify reads the operator's configuration and supplies its own executors; it never calls the one behind `@protect` and never imports the module it lives in (SPEC-v0.4 §1.2). An earlier version of this line said v0.4 verify would include such a check. It does not, and the sentence was wrong when it was written.
 - Data exfiltration through *read* actions the policy allows. CTRLRun is not DLP.
 - Denial of service by flooding approval requests.
 - Bypassing the decorator entirely (calling the raw function). v0.2 gateway mode narrows this; process-level enforcement is out of scope.
@@ -74,6 +74,34 @@ they entitled to?* Everything above still holds; these are the threats the secon
 - **A tenant-templated issuer.** `issuer` is matched as an exact string, so a multi-tenant endpoint cannot be configured correctly here. Pointing it at one without pinning the tenant makes every tenant on that platform a valid issuer — stated because the fail-open is inviting.
 - **Authority across an agent-to-agent hop.** A grant covers the principal CTRLRun resolved for *this* call. Propagating attenuated authority across hops is v0.7.
 - **Approving an authority change.** `ctrlrun delegate --as` is an assertion typed at a shell, not an authentication; the record keeps `created_via` so a reader can tell an act from an assertion. Authenticating the *approver* remains out of scope, as in v0.1.
+
+## Known v0.4 limitations — what `ctrlrun verify` does not see
+
+`ctrlrun verify` runs the kernel's own failure scenarios against an operator's configuration
+and reports what passed, what failed, and what could not be tested at all. The list of what it
+cannot see matters more than the feature does, so it is here as well as in
+[`docs/verify.md`](verify.md) — verify sees **the configuration, not the code**.
+
+- **Not the operator's executors.** The function behind `@protect` is never called. The
+  `NotExecuted` integration bug above is invisible here, because verify supplies its own
+  executors and never imports the operator's module.
+- **Not the operator's `reconcile` hooks**, for the same reason: a hook is a Python callable
+  passed to `@protect`, and it does not appear in any file verify reads.
+- **Not where the decorator was placed.** Code that calls the raw function bypasses CTRLRun
+  entirely — the "bypassing the decorator" line above — and no amount of configuration-reading
+  finds that.
+- **Not the deployment.** Whether the proxy in front of `HeaderIdentityProvider` overwrites the
+  header, whether `$CTRLRUN_STATE` points where the operator thinks, whether two gateways share
+  a state file: none of it is in the document.
+- **Not whether the policy is the *right* policy.** Verify has no opinion on whether
+  `stripe.refund` should be autonomous to €500 or to €5. It is not a linter, it does not score,
+  and it never says a configuration is too permissive. A configuration that permits everything
+  and constrains nobody can pass all ten guarantees, because the guarantees are about the
+  kernel doing what it says under that configuration.
+
+And the corollary, stated because a badge invites the opposite reading: **the badge means
+"declared guarantees pass"** and nothing else. Not secure, not safe, not compliant, not
+certified, not audited.
 
 ## Fail-closed rules (v0.1, not configurable)
 

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -125,6 +125,16 @@ none.
 G9 reports **which dimensions it exercised**. A parent that constrains one dimension does not
 score as though it had covered six, because that would be the N/A rule violated one level down.
 
+Two of these are worth a sentence on how they are exercised, because the answer is not the
+obvious one and `SPEC-v0.4.md` §12 argues both at length. **G6 runs against the policy axis
+alone.** Authority is evaluated before policy, so under an `authority:` section an unlisted
+action is refused by the authority axis and the policy's unknown-action refusal is never
+reached — the guarantee G6 makes. The report carries `detail.axis = "policy"` so this is
+visible rather than inferred, and the refusal G6 skips is exercised directly by G7 and G8.
+**G7 is `N/A` for a policy in which nothing can run at all**, because its control is "the same
+call inside `context()` runs" and there is no such call; it is applicable to every
+configuration in which anything can run, with or without grants.
+
 ### Every guarantee carries a positive control
 
 A guarantee is a refusal, and "the second attempt was refused" is satisfied just as well by a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ctrlrun"
-version = "0.4.0.dev0"
+version = "0.4.0"
 description = "Make consequential AI-agent actions safe to execute."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -405,6 +405,40 @@ def test_T104_a_kernel_with_the_duplicate_guard_deleted_fails_G3_and_G4(tmp_path
     assert results["G6"].status is Status.PASS, results["G6"].reason
 
 
+def test_a_synthesized_vector_landing_in_the_wrong_rule_is_an_internal_error(tmp_path, monkeypatch):
+    """SPEC-v0.4 §3.3 - "the vector is checked before it is used".
+
+    Having built one, the engine evaluates the action it just constructed and asserts the
+    decision is the one it was aiming for. A scenario built on a vector that landed in a
+    different rule is the "window not actually reproduced" failure in its purest form: it
+    would run, refuse something, and report a guarantee that was never exercised. So it is an
+    **internal error** - exit 3 - and never a FAIL and never an N/A.
+
+    Written because the mutation table found the guard load-bearing on nothing: T116 reaches
+    exit 3 by replacing `_checked` outright, so removing the raise *inside* it left the suite
+    green. A check nothing exercises is not a check.
+    """
+    from ctrlrun.policy import Evaluation, Policy
+    from ctrlrun.verify.scenarios import VerifyInternalError
+
+    path = _write(tmp_path, WITH_EFFECTS)
+    original = Policy.evaluate
+
+    def lands_elsewhere(self, action):
+        evaluation = original(self, action)
+        # Same decision, different rule: the vector satisfies a rule the engine was not
+        # aiming at, which is exactly the case §3.3 refuses to build a scenario on.
+        return Evaluation(evaluation.decision, "rule[99]")
+
+    monkeypatch.setattr(Policy, "evaluate", lands_elsewhere)
+
+    with pytest.raises(VerifyInternalError) as raised:
+        run(path)
+
+    assert "rule[99]" in str(raised.value)
+    assert "§3.3" in str(raised.value)
+
+
 # --- T105: determinism ---------------------------------------------------------------------
 
 

--- a/tests/test_verify_action.py
+++ b/tests/test_verify_action.py
@@ -388,3 +388,72 @@ def test_the_job_summary_carries_the_not_applicable_rows_in_full():
         if result.reason:
             assert result.reason in summary
     assert report.summary_line() in summary
+
+
+# --- the README quotes the real output (SPEC-v0.4 §4.1; the CLAIMS.md standard) -------------
+
+
+def _readme_verify_section() -> str:
+    readme = _repository_file(README)
+    section = readme.split("## Does it hold in *your* setup?")[1]
+    return section.split("\n## ")[0]
+
+
+def _quoted_report() -> list[str]:
+    block = _readme_verify_section().split("```console")[1].split("```")[0]
+    return [line for line in block.splitlines() if line.strip() and not line.startswith("$")]
+
+
+@pytest.mark.authority
+def test_the_readme_quotes_the_real_verify_output():
+    """The demo section has had this guard since v0.1; the verify section gets the same one.
+
+    Every line the README quotes has to be a line `ctrlrun verify` actually prints, so a
+    change to the report that nobody carried across fails here rather than shipping a README
+    that lies. The version line is normalised: it moves at every release, and the README is
+    not the place that number is kept honest — `pyproject.toml` is.
+    """
+    import re
+
+    report = run(AUTHORITY_PAYMENTS)
+    printed = {
+        re.sub(r"ctrlrun \S+,", "ctrlrun <version>,", line)
+        for line in report.to_text().splitlines()
+    }
+    # The README quotes a path relative to the repository root; the report prints the path it
+    # was given. Compare on the same footing rather than on how the test invoked it.
+    printed = {
+        line.replace(str(AUTHORITY_PAYMENTS), "examples/authority/payments.yaml")
+        for line in printed
+    }
+
+    missing = [
+        line
+        for line in _quoted_report()
+        if re.sub(r"ctrlrun \S+,", "ctrlrun <version>,", line) not in printed
+    ]
+
+    assert not missing, f"the README quotes lines verify does not print: {missing}"
+
+
+def test_the_readme_and_the_verify_page_quote_the_same_report():
+    """Two copies of one output is two things that can drift. They are asserted equal here so
+    the drift is a test failure rather than a reader's discovery."""
+    page = _repository_file(VERIFY_DOC)
+    quoted = page.split("```console")[1].split("```")[0]
+
+    from_page = [line for line in quoted.splitlines() if line.strip() and not line.startswith("$")]
+
+    assert from_page == _quoted_report()
+
+
+def test_the_readme_says_what_not_applicable_means():
+    """One sentence on N/A semantics, on the same screen as the badge. Asserted with the line
+    wrapping removed: a sentence that reads correctly and wraps across two lines is still the
+    sentence, and a test that could not see it would push prose onto one long line."""
+    section = " ".join(_readme_verify_section().split())
+
+    assert "Not applicable is not a pass" in section
+    assert "never `10/10`" in section
+    assert "There is no flag that folds one into the count" in section
+    assert "declared guarantees pass" in section


### PR DESCRIPTION
SPEC-v0.4 **item 7**. Version `0.4.0`, changelog closed, claims regenerated, threat model corrected, roadmap reconciled. **Not tagged and not published.**

## The correction this release owes

**`docs/THREAT_MODEL.md` promised a check v0.4 cannot deliver**, and SPEC-v0.4 §9.4 item 4 requires this commit to fix it. Its out-of-scope bullet read:

> Executors that raise `NotExecuted` incorrectly … This is an integration bug; **v0.4 `verify` will include a check for it** where reconciliation exists.

It does not, and it cannot. Verify reads the operator's configuration and supplies its own executors: it never calls the function behind `@protect` and never imports the module it lives in (§1.2). The bullet now says so, says why it is the most dangerous integration bug available — `NotExecuted` is the one exception that makes an effect retryable — and says **the sentence was wrong when it was written**. A guard documented as existing and not implemented at all is the false-green problem with a longer fuse.

A **Known v0.4 limitations** section carries §1.2's list in full, in the document a security reviewer reads rather than only in the one an operator does.

## `docs/CLAIMS.md`, regenerated rather than carried forward

The file's own last section says: *re-derive every row; do not carry one forward on trust.* Every citation was checked by reading the line it names. **Fifteen moved.** None for an interesting reason — the v0.1 and v0.2 rows were written against `v0.3.0` and the files have grown — but one moved between files: the `AMBIGUOUS` refusal cited `state.py` and now lives in `effect.py`'s `plan_reservation`, decided once for both stores.

A new **What v0.4 adds to the README** section maps every sentence the README gained to its code and its test, and a second table lists the four things that section deliberately does **not** claim, each with the test that keeps it honest:

| Not claimed | Where the limit is asserted |
|---|---|
| That verify checks the operator's executors | `docs/verify.md`; `THREAT_MODEL.md`, "Known v0.4 limitations" |
| That a green badge means the configuration is a good one | `test_T119_no_claim_uses_the_forbidden_vocabulary` |
| That a guarantee reported N/A was checked | `test_T113_every_not_applicable_line_carries_its_reason` |
| That a partial run means anything about the whole | `test_T120_a_partial_run_writes_no_badge` |

## The README's verify block gets the guard the demo block has

Since v0.1, a test has run `ctrlrun demo` and asserted every line it prints appears in the README. The verify block now has the same one: it runs `ctrlrun verify` against `examples/authority/payments.yaml` and asserts every line the README quotes is a line verify actually prints. A second test asserts the README and `docs/verify.md` quote the **same** report — two copies of one output are two things that can drift, so the drift is a test failure rather than a reader's discovery.

## Definition of done, verified from a fresh clone

Not from the working tree. A green build from the working tree is not evidence that a file is tracked — `MANIFEST.in` resolves against the working tree and not the index, which is how v0.2 shipped four `.gitignore`d policy files.

```console
$ git clone <repo> fresh-clone -b release-0.4.0 && cd fresh-clone
$ pip install -e ".[dev,gateway,otel,identity]"
$ ./scripts/check.sh
2035 passed in 110.52s
all checks passed
```

| Criterion | Result |
|---|---|
| Every acceptance test in SPEC-v0.4 §8, and every one in v0.1/v0.2/v0.3 | `2035 passed` |
| `ctrlrun verify` against `examples/policies/payments.yaml` | **5/5, 5 not applicable**, exit 0 |
| `ctrlrun verify` against `examples/authority/payments.yaml` | **10/10**, exit 0 |
| `ctrlrun demo` under 60 s with no network | 0.09 s |
| `import ctrlrun` pulls in no extra **and not `ctrlrun.verify`** | both lists empty |
| `mypy --strict src/`, `ruff check`, `ruff format --check` | clean |
| Every file the tests read is tracked | `action.yml`, `tests/data/junit-10.xsd`, `docs/verify.md`, `docs/OWASP-AGENTIC-TOP10.md`, `research/framework-probe/` all present in the clone |

`ctrlrun --version` reports `0.4.0`.

## Roadmap

v0.4 marked shipped with what it actually delivered — the N/A rule, the positive controls, the badge's denominator, the framework probe — and its exit criteria stated as the two configurations that dogfood them. v0.5 is current.

---

This is the last of the seven build-list items: #34 (engine + authority guarantees), #38 (reporting + the Action, re-opened from #35 and #36), #39 (the OWASP mapping, re-opened from #37), #40 (the framework probe), and this one.