### PR TITLE
verify: G6 asserts the behaviour, and this repository publishes its own badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+# Read-only by default, so the single `contents: write` below is visibly an exception rather
+# than something the whole workflow happens to have.
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -80,6 +85,49 @@ jobs:
           test -s verify-badge.json
           test -s verify-report.json
           test -s verify-report.xml
+
+  # SPEC-v0.4 §5.2 — the action *writes* the badge and never publishes it, because publishing
+  # needs `contents: write` and asking every consumer for that is a bad trade for a tool whose
+  # subject is least privilege. Publishing is this project's own decision, and this job is it.
+  #
+  # Three constraints, and each is load-bearing:
+  #
+  #   - `contents: write` is **job-level**. The workflow is read-only; nothing else here can
+  #     write to the repository.
+  #   - It runs on a **push to `main`** and on nothing else. A pull request never reaches it —
+  #     a PR from a fork must not be able to write the badge, and relying on the fork token
+  #     being read-only would be relying on a default rather than refusing.
+  #   - It publishes the badge the `verify` job already produced, downloaded as an artifact
+  #     rather than regenerated. §5.1's rule holds across the job boundary: the badge, the job
+  #     summary and the uploaded report all come from one verify run.
+  badge:
+    needs: verify
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ctrlrun-verify-authority
+          path: badge
+
+      - name: Publish to the badges branch
+        run: |
+          set -eu
+          test -s badge/verify-badge.json
+          message=$(python -c 'import json;print(json.load(open("badge/verify-badge.json"))["message"])')
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin badges 2>/dev/null && git switch badges || git switch --orphan badges
+          # An orphan branch carries the working tree across; the badge branch holds one file.
+          git rm -rq --cached . 2>/dev/null || true
+          cp badge/verify-badge.json verify-badge.json
+          git add -f verify-badge.json
+          git commit -m "verify: $message" || { echo "badge unchanged"; exit 0; }
+          git push origin badges
 
   # The definition of done says the demo runs with no network and the README quick start
   # works verbatim. Both were only ever checked by hand, which is how a README stops being

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,19 @@ jobs:
           message=$(python -c 'import json;print(json.load(open("badge/verify-badge.json"))["message"])')
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin badges 2>/dev/null && git switch badges || git switch --orphan badges
-          # An orphan branch carries the working tree across; the badge branch holds one file.
-          git rm -rq --cached . 2>/dev/null || true
+          # `actions/checkout` configures a single-branch refspec, so a plain
+          # `git fetch origin badges` writes FETCH_HEAD and *not* `refs/remotes/origin/badges`
+          # - and `git switch badges` would then fail, fall through to a fresh orphan, and be
+          # rejected as a non-fast-forward. That failure appears on the **second** publish and
+          # not the first, so the destination ref is named explicitly.
+          if git fetch origin badges:refs/remotes/origin/badges 2>/dev/null; then
+            git switch -c badges refs/remotes/origin/badges
+          else
+            git switch --orphan badges
+          fi
+          # Nothing to clear: `git switch` replaces the working tree with the target's, and
+          # `--orphan` starts from an empty one. The downloaded artifact is untracked, so it
+          # survives either path - which is the only file that must.
           cp badge/verify-badge.json verify-badge.json
           git add -f verify-badge.json
           git commit -m "verify: $message" || { echo "badge unchanged"; exit 0; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,11 +150,22 @@ than to storage: `ctrlrun.verify/v1`, `ctrlrun.guarantees/v1` and `ctrlrun.frame
   maintainer; a commit carrying findings about other projects that nobody had reviewed is not
   one this repository makes.
 
-- **`docs/SPEC-v0.4.md` gains a §12**, recording the four readings the implementation had to
-  take where the specification could not be satisfied as written. A specification that
+- **The badge this repository shows is published**, by a `badge` job scoped as narrowly as the
+  thing it does: `contents: write` at **job level** (the workflow is `contents: read`, so
+  nothing else in it can write), running on a push to `main` and on nothing else — a pull
+  request from a fork must not be able to write the badge, and a read-only fork token is a
+  default rather than a refusal — and publishing the badge the `verify` job already produced,
+  downloaded as an artifact rather than regenerated, so §5.1's one-run rule holds across the
+  job boundary. `docs/verify.md` shows the job and names the permission it costs.
+
+- **`docs/SPEC-v0.4.md` gains a §12**, recording the readings the implementation had to take
+  where the specification could not be satisfied as written. A specification that
   disagrees with the code it describes is worse than one that admits a gap: G6 drives a
-  `Control` composed from the policy alone, because authority is evaluated first and its
-  observable would otherwise be unreachable in every configuration with grants; G7 is `N/A`
+  a guarantee's invariant is the **behaviour** and not one reason string — G6 asserts that an
+  unlisted action never executes, against the `Control` the operator's configuration actually
+  composes, accepting any reason that configuration can produce and reporting which one fired,
+  because under an `authority:` section the refusal correctly arrives from the authority axis
+  before policy is reached; G7 is `N/A`
   where no action in the policy can run, because §2.2 said "never" and §1.3 requires a control
   that such a policy cannot supply; G8 gains a fourth N/A reason for a layered document; G9's
   control names the delegation only where the parent's subject does not also match it; and

--- a/docs/SPEC-v0.4.md
+++ b/docs/SPEC-v0.4.md
@@ -1524,24 +1524,34 @@ disagrees with the code it describes is worse than one that admits a gap. Each i
 `# SPEC:` comment where it lives; this section is the index, in the form `§9.4` takes for the
 earlier contracts.
 
-### 12.1 G6 drives a `Control` composed from the policy alone
+### 12.1 A guarantee's invariant is the behaviour, not the reason string
 
 §2.2 fixes G6's observable as `ActionDenied` with `reason == "unknown_action"`. But `v0.3 §4.3`
 evaluates **authority before policy**, so under an `authority:` section an action name no grant
-covers is refused by the authority axis and the policy axis is never reached: the observable
-would be `AuthorityDenied(reason="no_authority")`, every time, for every configuration with
-grants in it. The two sentences cannot both hold.
+covers is refused by the authority axis and the policy axis is never reached: the refusal
+arrives as `AuthorityDenied(reason="no_authority")`, which is an `ActionDenied` with a different
+reason.
 
-G6 descends from `v0.1 §7` T6, which is about the policy axis and predates the authority model,
-so its scenario builds its `Control` from the policy and no `Authority`. The kernel code under
-test is unchanged and the observable is the one §2.2 fixes; what is left out is a second,
-independent refusal — and that refusal is not left unexercised, because G7 and G8 drive it
-directly. The report carries `detail.axis = "policy"` so a reader is not left to infer it.
+That is still the guarantee holding. G6's invariant is the **behaviour** — an action the policy
+does not list never executes — and not one particular string. So the scenario runs against the
+`Control` the operator's configuration actually composes, authority included, and asserts:
 
-An alternative was considered and rejected: deriving an absent action name that some grant's
-wildcard *does* cover. It works only for configurations whose grants carry wildcards, so G6
-would exercise a different thing in different deployments, which is worse than exercising one
-thing everywhere and saying which.
+- the call raises `ActionDenied`;
+- its `reason` is one **this configuration can produce** — `unknown_action`, plus `v0.3 §4.3`'s
+  closed set of authority denials where an `authority:` section exists;
+- the executor's call count is 0;
+- a `denied` receipt was written.
+
+The counterexample is any execution, or any receipt other than `denied`. The reason that
+actually fired is reported as `detail.refused_by`, and the set it was checked against as
+`detail.reachable_reasons`, so a reader can see **which axis refused** rather than infer it.
+That is more informative than the single string §2.2 named, not less.
+
+**This generalizes, and §2.2's other rows are read the same way.** Where a guarantee names one
+observable and a fail-closed kernel produces an equivalent one earlier in the same ordered
+sequence of checks, the guarantee holds and the report says which. What it may never do is
+accept a reason the configuration cannot produce: a check that took any refusal at all would
+pass against a kernel that refused everything, which is the failure §1.3 exists to prevent.
 
 ### 12.2 G7 is N/A where no action in the policy can run
 

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -126,14 +126,18 @@ G9 reports **which dimensions it exercised**. A parent that constrains one dimen
 score as though it had covered six, because that would be the N/A rule violated one level down.
 
 Two of these are worth a sentence on how they are exercised, because the answer is not the
-obvious one and `SPEC-v0.4.md` §12 argues both at length. **G6 runs against the policy axis
-alone.** Authority is evaluated before policy, so under an `authority:` section an unlisted
-action is refused by the authority axis and the policy's unknown-action refusal is never
-reached — the guarantee G6 makes. The report carries `detail.axis = "policy"` so this is
-visible rather than inferred, and the refusal G6 skips is exercised directly by G7 and G8.
+obvious one; `SPEC-v0.4.md` §12 argues both at length.
+
+**G6 asserts the behaviour, not one reason string.** An action your policy does not list never
+executes — but *which* check refuses it depends on your configuration. With an `authority:`
+section, no grant covers it and authority refuses first, before policy is reached; without one,
+policy refuses it as `unknown_action`. Both are the guarantee holding, so the report names the
+reason that fired in `detail.refused_by` and the set it was checked against in
+`detail.reachable_reasons`. A reason your configuration cannot produce is a failure.
+
 **G7 is `N/A` for a policy in which nothing can run at all**, because its control is "the same
-call inside `context()` runs" and there is no such call; it is applicable to every
-configuration in which anything can run, with or without grants.
+call inside `context()` runs" and there is no such call. It is applicable to every configuration
+in which anything can run, with or without grants.
 
 ### Every guarantee carries a positive control
 
@@ -243,20 +247,50 @@ Outputs: `passed`, `failed`, `applicable`, `not-applicable`, `badge-message`, `r
 The action **writes** the endpoint JSON and never publishes it. Publishing it needs
 `contents: write`, and asking for write access to your repository as the price of a
 verification badge is a bad trade for a tool whose subject is least privilege. So the cost is
-here, visible, once — and it is your decision:
+here, visible, once — and it is your decision.
+
+This repository publishes its own badge, and this is the job it uses. Three things about it are
+load-bearing:
+
+- **`contents: write` is job-level.** The workflow itself is `contents: read`, so nothing else
+  in it can write to the repository. A workflow-level grant would hand every job write access
+  to buy one file.
+- **It runs on a push to `main` and nothing else.** A pull request never reaches it. A PR from
+  a fork gets a read-only token anyway, but relying on that is relying on a default rather than
+  refusing.
+- **It publishes the badge the verify job already produced**, downloaded as an artifact rather
+  than regenerated — so the badge, the job summary and the uploaded report all come from one
+  verify run and cannot disagree.
 
 ```yaml
-      # Requires `permissions: contents: write` on the job.
-      - name: Publish the badge
-        if: github.ref == 'refs/heads/main'
+permissions:
+  contents: read          # every job, unless it says otherwise
+
+jobs:
+  badge:
+    needs: verify
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write     # the one exception, and only here
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: ctrlrun-verify
+          path: badge
+      - name: Publish to the badges branch
         run: |
-          git fetch origin badges || git switch --orphan badges
-          git switch badges
-          cp verify-badge.json .
+          set -eu
+          test -s badge/verify-badge.json
+          message=$(python -c 'import json;print(json.load(open("badge/verify-badge.json"))["message"])')
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add verify-badge.json
-          git commit -m "verify: $(python -c 'import json;print(json.load(open("verify-badge.json"))["message"])')" || exit 0
+          git fetch origin badges 2>/dev/null && git switch badges || git switch --orphan badges
+          git rm -rq --cached . 2>/dev/null || true
+          cp badge/verify-badge.json verify-badge.json
+          git add -f verify-badge.json
+          git commit -m "verify: $message" || { echo "badge unchanged"; exit 0; }
           git push origin badges
 ```
 

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -286,8 +286,18 @@ jobs:
           message=$(python -c 'import json;print(json.load(open("badge/verify-badge.json"))["message"])')
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin badges 2>/dev/null && git switch badges || git switch --orphan badges
-          git rm -rq --cached . 2>/dev/null || true
+          # Explicit destination ref: `actions/checkout` sets a single-branch refspec, so a
+          # plain `git fetch origin badges` leaves `refs/remotes/origin/badges` unset and the
+          # switch below would create a fresh orphan and be rejected on push — on the second
+          # publish, not the first.
+          if git fetch origin badges:refs/remotes/origin/badges 2>/dev/null; then
+            git switch -c badges refs/remotes/origin/badges
+          else
+            git switch --orphan badges
+          fi
+          # Nothing to clear: `git switch` replaces the working tree with the target's,
+          # and `--orphan` starts from an empty one. The downloaded artifact is
+          # untracked, so it survives either path - which is the only file that must.
           cp badge/verify-badge.json verify-badge.json
           git add -f verify-badge.json
           git commit -m "verify: $message" || { echo "badge unchanged"; exit 0; }

--- a/research/framework-probe/README.md
+++ b/research/framework-probe/README.md
@@ -8,6 +8,18 @@ of these projects, none of which claims to solve this problem.
 It answers a question CTRLRun has so far only asserted: *what actually happens when the
 response is lost and the framework retries?*
 
+> **The four framework adapters have never been executed.** They are written against each
+> framework's documented entry points and have not been run against a real installation or a
+> real model, so nothing here is a finding about LangGraph, CrewAI, the OpenAI Agents SDK or
+> AutoGen — and no README, changelog entry or post may say otherwise. The only true statement
+> today is *"adapters written from documented APIs, unexecuted"*. What **has** run, in this
+> repository's CI, is the harness itself: the fake remote, the two stubs and the plain MCP
+> client, end to end over a loopback socket.
+>
+> Before any results are published, each adapter has to be run against a real model, its
+> framework version recorded, and whatever the documented APIs got wrong fixed. Until then
+> there are no results, and `results/` is empty on purpose.
+
 ---
 
 ## What it is not

--- a/research/framework-probe/framework_probe/adapters/autogen.py
+++ b/research/framework-probe/framework_probe/adapters/autogen.py
@@ -4,7 +4,9 @@ One `AssistantAgent` with one tool, run once through `run()`. AutoGen's document
 is a conversational retry — the agent reflects on the failure and tries again — and whether
 that reaches the remote a second time is exactly the row.
 
-**Not run in this repository's CI.**
+**Never executed.** Not run in this repository's CI and not run anywhere else:
+written from the framework's documented entry points and unverified against a real
+installation. Nothing this adapter would report is a finding until somebody runs it.
 """
 
 from __future__ import annotations

--- a/research/framework-probe/framework_probe/adapters/crewai.py
+++ b/research/framework-probe/framework_probe/adapters/crewai.py
@@ -4,7 +4,9 @@ One agent, one task, one tool, `Crew.kickoff()` with the scenario prompt as the 
 description. `max_retry_limit` is left at its default: CrewAI's documented behaviour when a
 tool raises is what the row measures.
 
-**Not run in this repository's CI.**
+**Never executed.** Not run in this repository's CI and not run anywhere else:
+written from the framework's documented entry points and unverified against a real
+installation. Nothing this adapter would report is a finding until somebody runs it.
 """
 
 from __future__ import annotations

--- a/research/framework-probe/framework_probe/adapters/langgraph.py
+++ b/research/framework-probe/framework_probe/adapters/langgraph.py
@@ -4,7 +4,10 @@ A prebuilt ReAct agent with one tool, run once on the scenario prompt. No retry 
 attached to the tool node and no `RetryPolicy` is passed to the graph: §7.3 rule 3 says
 framework defaults, and what LangGraph does with a tool that raised is precisely the finding.
 
-**Not run in this repository's CI.** It needs `langgraph`, a chat model and a key.
+**Never executed.** Not run in this repository's CI and not run anywhere else:
+written from the framework's documented entry points and unverified against a real
+installation. Nothing this adapter would report is a finding until somebody runs it,
+and running it needs `langgraph`, a chat model and a key.
 """
 
 from __future__ import annotations

--- a/research/framework-probe/framework_probe/adapters/openai_agents.py
+++ b/research/framework-probe/framework_probe/adapters/openai_agents.py
@@ -4,7 +4,9 @@ One `Agent` with one `function_tool`, run once through `Runner.run_sync`. No
 `failure_error_function` is supplied, so the SDK's default handling of a tool that raised is
 what the row measures.
 
-**Not run in this repository's CI.**
+**Never executed.** Not run in this repository's CI and not run anywhere else:
+written from the framework's documented entry points and unverified against a real
+installation. Nothing this adapter would report is a finding until somebody runs it.
 """
 
 from __future__ import annotations

--- a/src/ctrlrun/verify/scenarios.py
+++ b/src/ctrlrun/verify/scenarios.py
@@ -44,6 +44,7 @@ from ..authority import (
     CONTAINMENT,
     DEEP_WILDCARD,
     DIMENSIONS,
+    REASON_PRECEDENCE,
     Authority,
     Grant,
     Subject,
@@ -1311,36 +1312,57 @@ class Engine:
             return self.na("G6", reg.NO_ACTIONS)
         digest = hashlib.sha256("\n".join(listed).encode("utf-8")).hexdigest()[:12]
         absent = f"ctrlrun.verify.absent.{digest}"
-        # SPEC: §2.2 fixes G6's observable as `ActionDenied(reason="unknown_action")`, and
-        # `v0.3 §4.3` evaluates authority **before** policy — so under an `authority:` section
-        # a name no grant covers is refused by the authority axis and the policy axis is never
-        # reached. G6 descends from `v0.1 §7` T6, which is about the policy axis and predates
-        # the authority model, so its scenario drives a `Control` composed from the policy
-        # alone. The kernel code under test is unchanged; what is left out is a second,
-        # independent refusal that G7 and G8 exercise directly.
-        control, store, recorder, _ = self.control("G6", authority=False)
+        # The guarantee is the **behaviour** - an action the policy does not list never
+        # executes - and not one particular reason string. §2.2 names `unknown_action`, which
+        # is what a v0.2 configuration produces; under an `authority:` section `v0.3 §4.3`
+        # evaluates authority first and no grant covers a name derived to collide with
+        # nothing, so the same refusal arrives as an authority denial before policy is
+        # reached. Both are the guarantee holding. What is asserted is that the refusal
+        # happened, that its reason is one this configuration can actually produce, and that
+        # nothing ran; the reason is reported so a reader can see which axis refused
+        # (SPEC-v0.4 §12.1).
+        reachable = {"unknown_action"}
+        if self.authority is not None:
+            reachable |= set(REASON_PRECEDENCE)
+        selection = self.select()
+        principal = Principal(agent=APPROVER) if selection is None else selection.principal
+        environment = self._default_environment if selection is None else selection.environment
+        control, store, recorder, _ = self._control_for(
+            "G6",
+            selection
+            or _Selection(
+                action=absent,
+                arguments={},
+                decision=Decision.DENY,
+                resource=None,
+                effect_key=None,
+                principal=principal,
+                environment=environment,
+            ),
+        )
 
         def body(detail: dict[str, Any]) -> None:
-            detail["axis"] = "policy"
             detail["absent_action"] = absent
+            detail["reachable_reasons"] = sorted(reachable)
             executor = _Executor()
             action = Action(
                 name=absent,
                 arguments={},
-                principal=Principal(agent=APPROVER),
-                environment=self._default_environment,
+                principal=principal,
+                environment=environment,
             )
             refusal = self.refused(
                 lambda: control.execute(action, executor, None),
                 (ActionDenied,),
-                "ActionDenied(reason='unknown_action')",
+                f"ActionDenied with a reason in {sorted(reachable)}",
                 f"the unlisted action {absent} was not refused",
             )
             reason = getattr(refusal, "reason", "")
+            detail["refused_by"] = reason
             _expect(
-                reason == "unknown_action",
-                "ActionDenied(reason='unknown_action')",
-                f"ActionDenied(reason={reason!r})",
+                reason in reachable,
+                f"ActionDenied with a reason in {sorted(reachable)}",
+                f"ActionDenied(reason={reason!r}), which this configuration cannot produce",
             )
             _expect(
                 executor.calls == 0,
@@ -1353,18 +1375,33 @@ class Engine:
                 "a `denied` receipt is written",
                 f"the receipt is {None if receipt is None else receipt.result}",
             )
-            known = Action(
-                name=listed[0],
-                arguments={},
-                principal=Principal(agent=APPROVER),
-                environment=self._default_environment,
-            )
-            evaluation = control.evaluate(known)
-            _expect_control(
-                evaluation.reason != "unknown_action",
-                f"the listed action {listed[0]} evaluates to something other than unknown_action",
-                f"it evaluated to {evaluation.decision}/{evaluation.reason}",
-            )
+            # The control. Without it the guarantee is satisfied by a Control that refuses
+            # everything, and the report would say so in green.
+            if selection is not None:
+                detail["control"] = "an action this configuration admits reaches a decision"
+                evaluation = control.evaluate(selection.build())
+                _expect_control(
+                    evaluation.decision is not Decision.DENY,
+                    f"{selection.action} evaluates to something other than a denial",
+                    f"it evaluated to {evaluation.decision}/{evaluation.reason}",
+                )
+            else:
+                # Nothing in this configuration can run, so the strongest control available
+                # is that a **listed** action is refused for some reason other than being
+                # unlisted. Recorded, because a weaker control is not the same control.
+                detail["control"] = "a listed action is refused for some other reason"
+                known = Action(
+                    name=listed[0],
+                    arguments={},
+                    principal=principal,
+                    environment=environment,
+                )
+                evaluation = control.evaluate(known)
+                _expect_control(
+                    evaluation.reason != "unknown_action",
+                    f"the listed action {listed[0]} does not evaluate to unknown_action",
+                    f"it evaluated to {evaluation.decision}/{evaluation.reason}",
+                )
 
         try:
             return self.graded("G6", None, store, recorder, body)

--- a/tests/test_framework_probe.py
+++ b/tests/test_framework_probe.py
@@ -379,3 +379,56 @@ def test_the_scenario_text_is_shared_and_not_per_adapter():
         source = inspect.getsource(sys.modules[type(adapter).__module__])
         assert scenario_module.TOOL_DESCRIPTION not in source, adapter.name
         assert scenario_module.DOUBLE_REFUND_SCENARIO.prompt not in source, adapter.name
+
+
+# --- nothing anywhere claims the harness has been run against a real framework ---------------
+
+#: The four whose adapters have never been executed. The stubs and the MCP client have — they
+#: run in this repository's CI, end to end over a loopback socket.
+UNEXECUTED = ("langgraph", "crewai", "openai-agents", "autogen")
+
+
+def test_the_readme_says_the_framework_adapters_have_never_been_executed():
+    """The study means nothing until the adapters have run, so the sentence that says they have
+    not is at the top of the harness README rather than in a per-adapter docstring nobody
+    reads. `results/` is empty for the same reason."""
+    readme = " ".join((PROBE_ROOT / "README.md").read_text(encoding="utf-8").split())
+
+    assert "The four framework adapters have never been executed" in readme
+    assert "adapters written from documented APIs, unexecuted" in readme
+    assert "no README, changelog entry or post may say otherwise" in readme
+
+
+@pytest.mark.parametrize("framework", UNEXECUTED)
+def test_every_unexecuted_adapter_says_so_in_its_own_docstring(framework):
+    module = __import__(
+        f"framework_probe.adapters.{framework.replace('-', '_')}", fromlist=["ADAPTER"]
+    )
+
+    docstring = " ".join((module.__doc__ or "").lower().split())
+
+    assert "never executed" in docstring, framework
+    assert "not run in this repository's ci" in docstring, framework
+
+
+def test_no_top_level_document_claims_the_harness_was_run_against_a_framework():
+    """A sentence naming one of these four outside the harness's own directory is the shape of
+    an overclaim, so there are none — and this test is what keeps it that way when somebody
+    writes the release post."""
+    checked = ["README.md", "CHANGELOG.md", "docs/verify.md", "docs/OWASP-AGENTIC-TOP10.md"]
+
+    offending = []
+    for name in checked:
+        path = REPO_ROOT / name
+        if not path.exists():  # pragma: no cover - not a checkout
+            continue
+        text = path.read_text(encoding="utf-8").lower()
+        offending += [(name, framework) for framework in UNEXECUTED if framework in text]
+
+    assert not offending, offending
+
+
+def test_the_results_directory_holds_nothing_but_its_placeholder():
+    present = sorted(path.name for path in (PROBE_ROOT / "results").iterdir())
+
+    assert present == [".gitkeep"], present

--- a/tests/test_verify_action.py
+++ b/tests/test_verify_action.py
@@ -457,3 +457,66 @@ def test_the_readme_says_what_not_applicable_means():
     assert "never `10/10`" in section
     assert "There is no flag that folds one into the count" in section
     assert "declared guarantees pass" in section
+
+
+# --- publishing the badge: the one place this repository asks for write access ---------------
+
+
+def test_the_badge_job_is_the_only_thing_that_can_write_to_the_repository():
+    """SPEC-v0.4 §5.2 — the action writes the badge and never publishes it, because publishing
+    needs `contents: write`. This repository publishes its own, and that grant is scoped to one
+    job rather than to the workflow: a workflow-level grant would hand every job in it write
+    access to buy one file."""
+    workflow = _workflow()
+
+    assert workflow["permissions"] == {"contents": "read"}
+    elevated = [name for name, job in workflow["jobs"].items() if "permissions" in job]
+    assert elevated == ["badge"], elevated
+    assert workflow["jobs"]["badge"]["permissions"] == {"contents": "write"}
+
+
+def test_the_badge_job_never_runs_on_a_pull_request():
+    """A pull request from a fork must not be able to write the badge.
+
+    Asserted on the condition rather than on the token: a fork's `GITHUB_TOKEN` is read-only
+    anyway, but relying on that is relying on a default instead of refusing.
+    """
+    guard = _workflow()["jobs"]["badge"]["if"]
+
+    assert "github.event_name == 'push'" in guard
+    assert "github.ref == 'refs/heads/main'" in guard
+
+
+def test_the_badge_job_publishes_the_badge_the_verify_job_produced():
+    """§5.1 across the job boundary: one verify run, so the badge, the job summary and the
+    uploaded report cannot disagree about what happened."""
+    badge = _workflow()["jobs"]["badge"]
+    steps = badge["steps"]
+    downloads = [
+        step for step in steps if str(step.get("uses", "")).startswith("actions/download-")
+    ]
+    script = "\n".join(step.get("run", "") for step in steps)
+
+    assert badge["needs"] == "verify"
+    assert downloads, "the badge job regenerates the badge instead of downloading it"
+    assert downloads[0]["with"]["name"] == "ctrlrun-verify-authority"
+    assert "ctrlrun verify" not in script
+    assert "git push origin badges" in script
+
+
+def test_the_readme_badge_points_at_the_branch_the_job_publishes():
+    """A badge whose URL and whose publisher disagree is a 404 on the front page."""
+    readme = _repository_file(README)
+    script = "\n".join(step.get("run", "") for step in _workflow()["jobs"]["badge"]["steps"])
+
+    assert "raw.githubusercontent.com/CTRLRun/ctrlrun/badges/verify-badge.json" in readme
+    assert "origin badges" in script
+    assert "verify-badge.json" in script
+
+
+def test_the_verify_page_documents_the_permission_the_publish_costs():
+    """§5.2 — the cost is shown once, where the reader can see it, and not buried."""
+    page = " ".join(_repository_file(VERIFY_DOC).split())
+
+    assert "contents: write" in page
+    assert "least privilege" in page

--- a/tests/test_verify_action.py
+++ b/tests/test_verify_action.py
@@ -520,3 +520,170 @@ def test_the_verify_page_documents_the_permission_the_publish_costs():
 
     assert "contents: write" in page
     assert "least privilege" in page
+
+
+def _publish_script() -> str:
+    """The badge job's publish step, lifted out of the workflow so it can be **run**."""
+    for step in _workflow()["jobs"]["badge"]["steps"]:
+        if step.get("name") == "Publish to the badges branch":
+            return str(step["run"])
+    raise AssertionError("the badge job has no publish step")
+
+
+def test_the_publish_script_fast_forwards_on_the_second_run(tmp_path):
+    """Run it **twice**, because the failure it guards against only appears the second time.
+
+    `actions/checkout` configures a single-branch refspec, so a plain `git fetch origin badges`
+    writes `FETCH_HEAD` and not `refs/remotes/origin/badges`. A `git switch badges` then fails,
+    falls through to a fresh orphan, and the push is rejected as a non-fast-forward — on the
+    second publish and never on the first. A test that ran the script once would be green
+    against exactly that bug, which is the whole reason this one runs it twice.
+
+    It also sets that refspec explicitly. Without it, `git remote add`'s default
+    `+refs/heads/*:refs/remotes/origin/*` creates the remote-tracking ref for free and the
+    broken script passes — which it did, until the line was added. A negative test proves
+    nothing unless the thing it forbids would otherwise happen.
+    """
+    import json
+    import subprocess
+
+    script = _publish_script()
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(remote)], check=True)
+
+    def publish(message: str) -> subprocess.CompletedProcess[str]:
+        work = tmp_path / f"work-{message}"
+        subprocess.run(["git", "init", "-q", "-b", "main", str(work)], check=True)
+        subprocess.run(["git", "remote", "add", "origin", str(remote)], cwd=work, check=True)
+        # **The condition that makes this test mean anything.** `actions/checkout` configures a
+        # single-branch refspec, and that is the whole reason the naive `git fetch origin
+        # badges` fails to create `refs/remotes/origin/badges`. A test with `git remote add`'s
+        # default `+refs/heads/*:refs/remotes/origin/*` passes against the broken script — it
+        # did, before this line was added, which is exactly the false green a negative test
+        # gives when the environment already prevents the thing it forbids.
+        subprocess.run(
+            ["git", "config", "remote.origin.fetch", "+refs/heads/main:refs/remotes/origin/main"],
+            cwd=work,
+            check=True,
+        )
+        (work / "placeholder").write_text("a checkout has other files in it\n", encoding="utf-8")
+        subprocess.run(["git", "add", "-A"], cwd=work, check=True)
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@example.com",
+                "commit",
+                "-qm",
+                "a checkout",
+            ],
+            cwd=work,
+            check=True,
+        )
+        # The artifact is **untracked**, as `actions/download-artifact` leaves it on a runner.
+        # That matters: `git switch --orphan` clears the tracked worktree, so an artifact this
+        # test had committed would vanish before the script could copy it, and the test would
+        # be failing on its own setup rather than on the script.
+        (work / "badge").mkdir()
+        (work / "badge" / "verify-badge.json").write_text(
+            json.dumps({"schemaVersion": 1, "label": "CTRLRun", "message": message}),
+            encoding="utf-8",
+        )
+        return subprocess.run(
+            ["bash", "-c", script], cwd=work, capture_output=True, text=True, check=False
+        )
+
+    first = publish("verified 1/1")
+    assert first.returncode == 0, f"{first.stdout}\n{first.stderr}"
+
+    second = publish("verified 2/2")
+    assert second.returncode == 0, f"{second.stdout}\n{second.stderr}"
+
+    # The second publish built on the first rather than replacing it, and the branch holds the
+    # badge and nothing else.
+    log = subprocess.run(
+        ["git", "log", "--oneline", "badges"],
+        cwd=remote,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert len(log.stdout.strip().splitlines()) == 2, log.stdout
+
+    listing = subprocess.run(
+        ["git", "ls-tree", "--name-only", "badges"],
+        cwd=remote,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert listing.stdout.split() == ["verify-badge.json"], listing.stdout
+
+    published = subprocess.run(
+        ["git", "show", "badges:verify-badge.json"],
+        cwd=remote,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert json.loads(published.stdout)["message"] == "verified 2/2"
+
+
+def test_the_publish_script_is_a_no_op_when_the_badge_has_not_changed(tmp_path):
+    """A push per green build, for a file nobody edited, is noise in the history."""
+    import json
+    import subprocess
+
+    script = _publish_script()
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(remote)], check=True)
+
+    def publish(index: int) -> subprocess.CompletedProcess[str]:
+        work = tmp_path / f"work-{index}"
+        subprocess.run(["git", "init", "-q", "-b", "main", str(work)], check=True)
+        subprocess.run(["git", "remote", "add", "origin", str(remote)], cwd=work, check=True)
+        subprocess.run(
+            ["git", "config", "remote.origin.fetch", "+refs/heads/main:refs/remotes/origin/main"],
+            cwd=work,
+            check=True,
+        )
+        (work / "placeholder").write_text("a checkout\n", encoding="utf-8")
+        subprocess.run(["git", "add", "-A"], cwd=work, check=True)
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@example.com",
+                "commit",
+                "-qm",
+                "a checkout",
+            ],
+            cwd=work,
+            check=True,
+        )
+        (work / "badge").mkdir(parents=True)
+        (work / "badge" / "verify-badge.json").write_text(
+            json.dumps({"schemaVersion": 1, "label": "CTRLRun", "message": "verified 9/9"}),
+            encoding="utf-8",
+        )
+        return subprocess.run(
+            ["bash", "-c", script], cwd=work, capture_output=True, text=True, check=False
+        )
+
+    assert publish(1).returncode == 0
+    unchanged = publish(2)
+
+    assert unchanged.returncode == 0, f"{unchanged.stdout}\n{unchanged.stderr}"
+    assert "badge unchanged" in unchanged.stdout
+    log = subprocess.run(
+        ["git", "log", "--oneline", "badges"],
+        cwd=remote,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert len(log.stdout.strip().splitlines()) == 1, log.stdout


### PR DESCRIPTION
Three corrections, each from review feedback on the v0.4 release.

## 1. G6 asserts the behaviour, not one reason string

The previous commit *documented* a deviation: G6 ran against a `Control` composed from the policy alone, because `v0.3 §4.3` evaluates authority first and §2.2's `unknown_action` observable is unreachable in any configuration with grants.

That was the wrong fix. **A guarantee's invariant is the behaviour** — an action the policy does not list never executes — and not one particular string. G6 now runs against the `Control` the operator's configuration actually composes, authority included, and asserts:

- the call raised `ActionDenied`;
- its reason is one **this configuration can produce** — `unknown_action`, plus `v0.3 §4.3`'s closed set of authority denials where an `authority:` section exists;
- the executor's call count is 0;
- a `denied` receipt was written.

The counterexample is any execution, or any receipt other than `denied`.

```
examples/authority/payments.yaml  ->  pass  refused_by=no_authority
examples/policies/payments.yaml   ->  pass  refused_by=unknown_action
```

The reason that fired is `detail.refused_by`, the set it was checked against is `detail.reachable_reasons`, so a reader sees **which axis refused** rather than inferring it. What it may *not* do is accept any refusal at all: that would pass against a kernel that refused everything, which is the failure §1.3 exists to prevent.

`SPEC-v0.4 §12.1` is rewritten to state this as the general rule, not a G6 special case: where a guarantee names one observable and a fail-closed kernel produces an equivalent one earlier in the same ordered sequence of checks, the guarantee holds and the report says which.

## 2. The badge is published

A 404 badge on the front page is worse than no badge. The new `badge` job is scoped as narrowly as the thing it does:

| Constraint | How |
|---|---|
| `contents: write` on **one job**, not the workflow | workflow is `permissions: contents: read`; `badge` is the only job with a `permissions:` block |
| Never on a pull request | `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` — asserted on the condition, not on the token, because a read-only fork token is a default rather than a refusal |
| One verify run behind the badge | `needs: verify` + `actions/download-artifact`, never a second `ctrlrun verify` — §5.1's rule, held across the job boundary |

Five tests hold those in place, including one asserting the README's badge URL and the branch the job pushes to are the same — a badge whose URL and publisher disagree is the 404 this fixes.

`docs/verify.md` now shows the job form with the permission it costs, replacing the step-level sketch.

## 3. The framework adapters say they have never been executed

At the top of the harness README, not only in per-adapter docstrings:

> **The four framework adapters have never been executed.** … nothing here is a finding about LangGraph, CrewAI, the OpenAI Agents SDK or AutoGen — and no README, changelog entry or post may say otherwise. The only true statement today is *"adapters written from documented APIs, unexecuted"*.

A test asserts **no top-level document names any of the four** — `README.md`, `CHANGELOG.md`, `docs/verify.md`, `docs/OWASP-AGENTIC-TOP10.md` — because that is the shape an overclaim takes when somebody writes the release post. Another asserts `results/` holds nothing but its placeholder.

What *has* run, in CI, is the harness itself: the fake remote, both stubs and the plain MCP client, end to end over a loopback socket.

---

`2048 passed`, `mypy --strict src/` clean, `ruff check` and `ruff format --check` clean.