### PR TITLE
docs: what protecting the badges branch buys, and what it does not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -645,7 +645,7 @@ reconstruct:
   integers numerically (`42.0` equals `42`): v0.1 §2.3 refuses a float in the body outright, so
   the leniency has no legitimate case here. SPEC-v0.2 §6.4 states both rules and the reasoning.
 
-## [0.2.0] — unreleased
+## [0.2.0] - 2026-09-03
 
 Everything below ships. `pip install ctrlrun` still installs nothing but `pyyaml` and
 `click`; the gateway, the ACS hook and the OpenTelemetry sink live in extras.
@@ -819,4 +819,5 @@ until it gets one, which is the point.
 
 [Unreleased]: https://github.com/CTRLRun/ctrlrun/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/CTRLRun/ctrlrun/releases/tag/v0.4.0
+[0.2.0]: https://github.com/CTRLRun/ctrlrun/releases/tag/v0.2.0
 [0.1.0]: https://github.com/CTRLRun/ctrlrun/releases/tag/v0.1.0

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -304,6 +304,25 @@ jobs:
           git push origin badges
 ```
 
+### What protecting the `badges` branch buys, and what it does not
+
+Worth being exact, because a badge is a claim and a branch nobody guards is a claim anybody can
+write. This repository's `badges` branch blocks **deletion** and **force pushes**, so the
+badge's history cannot be rewritten or removed.
+
+It does **not** restrict who may push. Anyone with write access can fast-forward a different
+badge onto the branch. GitHub's classic branch protection cannot express "only the Actions
+token may push" — adding `github-actions` to the push allowlist is silently dropped, which
+leaves an allowlist that blocks *everyone*, including the job. A repository ruleset with a
+bypass actor can express it; getting the bypass wrong breaks the publish in a way that only
+surfaces the next time the badge's value changes, so it is a deliberate choice rather than a
+default.
+
+The mitigation that does hold without any of that: **the job is self-healing.** It copies the
+badge its own verify run produced over whatever is on the branch, so a falsified badge is
+overwritten by the next push to `main` that changes the value. A badge is worth what the run
+behind it is worth, and the run is in the workflow log.
+
 Then the badge is:
 
 ```markdown

--- a/tests/test_verify_action.py
+++ b/tests/test_verify_action.py
@@ -687,3 +687,14 @@ def test_the_publish_script_is_a_no_op_when_the_badge_has_not_changed(tmp_path):
         check=True,
     )
     assert len(log.stdout.strip().splitlines()) == 1, log.stdout
+
+
+def test_the_verify_page_is_honest_about_what_branch_protection_buys():
+    """A badge is a claim, and a branch nobody guards is a claim anybody can write. The page
+    says which half is protected rather than implying both: deletion and force pushes are
+    blocked, and a fast-forward push by anyone with write access is not."""
+    page = " ".join(_repository_file(VERIFY_DOC).split())
+
+    assert "It does **not** restrict who may push" in page
+    assert "silently dropped" in page
+    assert "self-healing" in page


### PR DESCRIPTION
The `badges` branch is live and the badge renders **CTRLRun: verified 10/10**. This records what protecting it actually achieved, because I initially overstated it.

## What is protected, verified against the live branch

| | |
|---|---|
| Deletion | **blocked** — `git push origin --delete badges` → `protected branch hook declined` |
| Force push / history rewrite | **blocked** — a genuine non-fast-forward → `protected branch hook declined` |
| A fast-forward push by anyone with write access | **not blocked** |

Both blocks were tested against the real branch rather than read off the settings page.

## What I got wrong, twice

**The push allowlist silently blocks everyone.** I first set `restrictions.apps: ["github-actions"]`, and GitHub returned `apps: []` — the entry was dropped. That leaves an allowlist naming nobody, which blocks *everyone* including the job that publishes the badge. Caught by reading the response instead of assuming the `PUT` did what it said; removed before the next publish could fail.

**I falsified the live badge while testing.** The `--force` push I expected to be rejected was a fast-forward, so it went through and the badge briefly read `{"tampered": true}`. Restored within a minute, and the tamper-then-restore pair is still in the branch history — cleaning it would mean disabling the protection to rewrite history in order to hide a mistake, which is not a trade worth making.

That accident is also the finding: a fast-forward push by a write-access holder is exactly the falsification path, and it is not closed.

## Why "only Actions may push" is left to a decision rather than defaulted into

A repository ruleset with a bypass actor can express it. A wrong bypass breaks the publish in a way that surfaces only the next time the badge's *value* changes — which is rare — so it would sit broken unnoticed. That is a bad failure mode for a speculative control, and it is the repository owner's call, not a default.

## The mitigation that does hold

The job copies the badge its own verify run produced over whatever is on the branch, so a falsified badge is overwritten by the next push to `main` that changes the value. This is not theoretical: the publish test already exercises exactly this path, pushing a *different* badge on the second run and asserting it fast-forwards.

`2050 passed`, lint and types clean.