### PR TITLE
conformance: the suites, eleven broken fixtures, and what building them settled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ somebody tries it.
   Five decisions are written into it **with their arguments**, because a decision whose
   reasoning lives only in a build note is one the next session re-litigates:
   `ApprovalRequired` + `with_approval` rather than `Suspended` + `Control.resume`; a Protocol
-  rather than a base class; `ctrlrun[conformance]` rather than core or a third distribution;
+  rather than a base class; the conformance kit in this repository rather than a third distribution;
   one repository with separate distributions; and an adapter that **sees** the principal and
   never supplies one.
 
@@ -46,8 +46,20 @@ somebody tries it.
   `Control.resolve_principal` is promoted from private for it: the identity seam an adapter may
   **read** and may not supply.
 
-- **`conformance` extra** in `pyproject.toml` (`pytest`). `dependencies` is unchanged:
-  `pyyaml` and `click`.
+- **`ctrlrun.adapter`** — the adapter surface: the `FrameworkInterrupt` Protocol,
+  `PendingApproval`, `ApprovalAnswer`, `InterruptApprovalProvider`, `needs_approval` and
+  `banner`. Core and stdlib, re-exported from `ctrlrun`, and `Control.resolve_principal` is
+  promoted from private for it — the identity seam an adapter may **read** and may not supply.
+
+- **`ctrlrun.conformance`** — the adapter conformance kit: the `SPEC-v0.1.md` §7 and
+  `SPEC-v0.3.md` §10 acceptance suites runnable against any adapter through that surface, and
+  **eleven adapters broken in one named way each**, written before the reference adapters because
+  "two adapters pass the suites" means nothing until the suite can fail.
+
+  It is **core and stdlib-only**, not the extra `SPEC-v0.5.md` §5.1 originally specified. The
+  premise there was that a kit needs `pytest`; building it showed otherwise, and an extra with
+  no dependency behind it is an install line that installs nothing. §12.1 records the change.
+  `dependencies` is unchanged: `pyyaml` and `click`.
 
 ### Changed
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -190,7 +190,7 @@ import `policy.py`, so there is no cycle.
 
 v0.5 adds `conformance/` beside `verify/` and `cli/`, above `control.py`: it composes the
 kernel the way an application does, nothing in the kernel imports it, and `import ctrlrun` does
-not reach it. It is core and stdlib-only for `verify/`'s reason — a check somebody has to
+not reach it. It is core, and adds no dependency, for `verify/`'s reason — a check somebody has to
 remember to install is a check that does not run — and `SPEC-v0.5.md` §12.1 records why it is
 not the extra it was planned as.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,12 +152,13 @@ Pragmas: `journal_mode=WAL`, `busy_timeout=5000`, `synchronous=NORMAL`.
 | `identity.py` | `IdentityProvider`, `IdentityContext`, static and header providers | policy, authority, storage |
 | `authority.py` | `Grant`, `Subject`, `Authority`, matching, containment, delegation planning | approvals, effect state, executors, sinks |
 | `approval.py` | request/grant/consume, providers | executors |
-| `adapter.py` | `FrameworkInterrupt`, `PendingApproval`, `ApprovalAnswer`, `InterruptApprovalProvider`, `needs_approval`, `banner` | policy internals, authority, effect state, executors, sinks, any framework |
+| `adapter.py` | `FrameworkInterrupt`, `PendingApproval`, `ApprovalAnswer`, `InterruptApprovalProvider`, `needs_approval`, `banner` | the policy evaluator, authority, effect state, executors, sinks, any framework |
 | `effect.py` | key templating, state enum, transition rules | SQLite |
 | `state.py` | `StateStore` protocol + SQLite/in-memory impls | policy, decorator, sinks |
 | `control.py` | `Control` orchestration, decorator, context, suspend/resume | CLI |
 | `receipt.py` | Receipt/Event models, `EventSink`, JSONL sink | everything else |
 | `verify/` | the guarantee registry, scenario derivation, the scratch store, reporting | the gateway, `otel`, `jwt_identity`; anything from an extra |
+| `conformance/` | the adapter suites, the broken-adapter fixtures, the report | the gateway, `otel`, `jwt_identity`; anything from an extra |
 | `cli/` | click commands, demo | internals beyond `Control` |
 
 Dependencies point downward only. `Control` is the only module that composes the others.
@@ -187,9 +188,16 @@ security-critical enough that a second copy of it is worse than the import. Poli
 nothing of effect state — no records, no transitions, no reservations — and `effect.py` does not
 import `policy.py`, so there is no cycle.
 
+v0.5 adds `conformance/` beside `verify/` and `cli/`, above `control.py`: it composes the
+kernel the way an application does, nothing in the kernel imports it, and `import ctrlrun` does
+not reach it. It is core and stdlib-only for `verify/`'s reason — a check somebody has to
+remember to install is a check that does not run — and `SPEC-v0.5.md` §12.1 records why it is
+not the extra it was planned as.
+
 v0.5 adds `adapter.py` below `control.py` and does not change the direction. It imports
-`action.py` and `approval.py`, and takes a `Control` as a **parameter** in `needs_approval` and
-`banner` rather than importing it at module scope, so there is no cycle and no second composer:
+`action.py`, `approval.py`, `effect.py`, `errors.py` and two names from `policy.py` — `OBSERVE`
+for the banner and `Decision` for the predicate — and takes a `Control` as a **parameter** in
+`needs_approval` and `banner` rather than importing it at module scope, so there is no cycle and no second composer:
 it appends no event, owns no sink, and reserves nothing. The one place it writes is
 `grant_approval`/`deny_approval` in `InterruptApprovalProvider.wait`, which is the same call
 `ctrlrun approve` and the webhook make — and it is the *only* place, so no adapter can grow a

--- a/docs/SPEC-v0.5.md
+++ b/docs/SPEC-v0.5.md
@@ -51,7 +51,7 @@ build-list position.
 |---|---|---|---|
 | 1 | The framework probe, executed against LangGraph and the Agents SDK | not packaged | `v0.4 §7` |
 | 2 | The adapter surface `ctrlrun.adapter`, and the `v0.3 §4.3.1` rows | core | §2, §4 |
-| 3 | The conformance kit, `ctrlrun.conformance` | core, stdlib only (§12.1) | §5 |
+| 3 | The conformance kit, `ctrlrun.conformance` | core, no new dependency (§12.1) | §5 |
 | 4 | The LangGraph reference adapter, `ctrlrun-langgraph` | a separate distribution | §6 |
 | 5 | The OpenAI Agents SDK reference adapter, `ctrlrun-openai-agents` | a separate distribution | §6 |
 | 6 | A third adapter, written against this document alone | disposable | §8 |
@@ -61,8 +61,8 @@ The dependency rule of `v0.2 §1.1`, `v0.3 §1` and `v0.4 §1` is unchanged and 
 install ctrlrun` MUST continue to install nothing but `pyyaml` and `click`. **The adapter
 surface itself is core** — it is in the action path, it is stdlib, and an adapter is a separate
 distribution that depends on `ctrlrun` rather than the other way round. The **conformance kit**
-is core too, and stdlib only. It was planned as an extra on the premise that a kit needs
-`pytest`; building it showed the premise was wrong, and §12.1 records the correction.
+is core too, and adds no dependency. It was planned as an extra on the premise that a kit
+needs `pytest`; building it showed the premise was wrong, and §12.1 records the correction.
 
 ### 1.1 What an adapter is not, stated before anything else
 
@@ -778,11 +778,12 @@ programme, it certifies nothing, and passing it is not a claim about an adapter'
 answers one question: *does an action driven through this adapter get the same refusals as an
 action driven through `@protect`?*
 
-It ships in **core**, stdlib only, in this repository. §12.1 records why this changed during
+It ships in **core**, in this repository, needing nothing `pip install ctrlrun` does not already install. §12.1 records why this changed during
 item 3; the arguments as they now stand:
 
-- **It needs no third-party library.** The suites drive a `Control` and compare exceptions,
-  which is `assert` and `try`. An adapter author runs the report *inside* their own pytest —
+- **It needs nothing `pip install ctrlrun` does not already install.** The suites drive a
+  `Control` and compare exceptions, which is `assert` and `try`, and they build their scratch
+  policies with the YAML parser the kernel already depends on. An adapter author runs the report *inside* their own pytest —
   `assert run(adapter).ok` — rather than through one.
 - **An extra with nothing behind it is worse than no extra.** `ctrlrun[conformance]` would
   install nothing, and the `MissingDependency` its install line promised could never fire.
@@ -798,7 +799,7 @@ dependency nobody meant to take.
 ### 5.2 What an adapter hands the kit
 
 ```python
-# ctrlrun/conformance/__init__.py — ctrlrun[conformance]
+# ctrlrun/conformance/__init__.py — core, stdlib (§12.1)
 
 @dataclass(frozen=True)
 class CallRequest:
@@ -851,17 +852,23 @@ class SuiteResult:
 @dataclass(frozen=True)
 class ConformanceReport:
     framework: str
-    status: Literal["ok", "refused"]         # "refused" is §3.6's observing Control
+    status: Literal["ok", "refused"] = "ok"  # "refused" is §3.6's observing Control
     reason: str | None = None                # why, when refused
     suites: tuple[SuiteResult, ...] = ()
 
     @property
-    def applicable(self) -> int: ...         # suites that are not NOT_APPLICABLE
+    def applicable(self) -> tuple[SuiteResult, ...]: ...   # not NOT_APPLICABLE
     @property
-    def passed(self) -> int: ...
+    def not_applicable(self) -> tuple[SuiteResult, ...]: ...
     @property
-    def ok(self) -> bool: ...                # status "ok", applicable > 0, passed == applicable
-    def to_text(self) -> str: ...            # "4/4 (2 not applicable)", never "6/6"
+    def passed(self) -> tuple[SuiteResult, ...]: ...
+    @property
+    def ok(self) -> bool: ...                # status "ok", applicable non-empty, all passed
+    def to_dict(self) -> dict[str, Any]: ...
+    def to_text(self) -> str: ...            # "4/4 (1 not applicable)", never "5/5"
+
+#: The suites, in report order. Public because a name here is a name in an adapter's README.
+SUITES: Mapping[str, tuple[Case, ...]]
 
 
 def run(adapter: ConformanceAdapter, deployment: Control | None = None) -> ConformanceReport: ...
@@ -878,8 +885,16 @@ defect of exactly the class it exists to find. The one thing read from `deployme
 and an observing one is refused (§3.6). It is optional because an adapter author's CI has no
 deployment to hand it, and passing one is how the observe-mode refusal reaches anybody at all.
 
-**The kit wraps the adapter's `interrupt` in a counting proxy** before wiring it, and asserts
-the count on every case that expects a human and on every case that does not. That is not
+**The kit swaps a counting proxy in for the adapter's `interrupt`** — replacing the attribute,
+not merely wiring the proxy into the provider — and asserts the count on every case that expects
+a human and on every case that does not. `run()` restores the original when it is done.
+
+Replacing rather than wiring is the difference between a live guard and a dead one. A proxy
+wired only into `InterruptApprovalProvider` counts the calls that arrive through `wait()`, and
+`wait()` is reached only on `ApprovalRequired`, which an `ALLOW` policy never raises — so an
+adapter that put an allowed call to a human by reaching its **own** primitive out of band was
+invisible, and the case forbidding it was a negative test against behaviour the path already
+prevented. An independent review found it by writing that adapter: it scored 5/5. That is not
 belt-and-braces: `fixtures.GrantsForItself` grants the request before `@protect` reaches
 `wait()`, so the provider finds the record already `granted` and returns it — correctly, since
 `ctrlrun approve` grants out of band too — and the framework's primitive is never called. Every
@@ -956,6 +971,7 @@ adapters that are broken **in one named way each**, and each MUST fail the suite
 | `swallows-denial` | Catches `ActionDenied` and returns a value | `kernel` |
 | `replays-approval` | Keeps a `request_id` and presents it again on the next call | `kernel` |
 | `interrupts-on-allow` | Routes every call through the interrupt, `APPROVE` or not | `kernel` |
+| `interrupts-only-when-unasked` | Correct wherever a human is expected, and interrupts on exactly the calls where none is | `kernel` — **A1 alone** |
 | `grants-for-itself` | Takes `ApprovalRequired` with `wait=False`, writes the grant itself, and re-presents. The framework's primitive is never reached | `kernel` |
 | `ignores-authority` | Catches `AuthorityDenied` and returns a value | `authority` |
 | `self-asserts-principal` | Builds a `Principal` from the framework's session and reaches a `Control` with it | `identity` |
@@ -968,7 +984,10 @@ and "this is prevention, not attribution" are the sentences a security reviewer 
 a rule with no broken fixture is a rule the kit cannot tell you about. `ignores-authority` exists
 because `swallows-denial` failed the `authority` suite only incidentally — `AuthorityDenied`
 subclasses `ActionDenied` — and a suite whose only fixture fails it by accident is a suite
-nothing is aimed at.
+nothing is aimed at. `interrupts-only-when-unasked` exists for the same reason one level down:
+`interrupts-on-allow` bumps the interrupt count on T4, B2 and B3 as well, so deleting A1's own
+count left the kit still failing it — a **subsumed** check, found by mutation. This one is
+invisible to every other case.
 
 **Every suite is named by at least one fixture, and every fixture names a suite that exists.**
 Both directions are asserted (T130), because a fixture pointed at a renamed suite passes its own
@@ -995,6 +1014,11 @@ reason.
 - **Not the operator's executor.** The kit supplies its own, always.
 - **Not where the adapter was wired.** An agent that calls the unprotected function bypasses
   CTRLRun entirely, and no amount of driving the adapter finds that.
+- **Not whether the adapter logged the observe banner.** §3.6 requires it, and the kit
+  **refuses** an observing `Control` outright — so no case ever runs under one, and an adapter
+  that never calls `ctrlrun.adapter.banner` passes every suite. The requirement is real and the
+  kit is not what enforces it; saying so here is the alternative to a reader assuming a green
+  report covered it.
 - **Not whether the adapter is a good one.** No score, no grade, no ranking.
 
 ---
@@ -1177,7 +1201,7 @@ same way (§3.8).
 ### Item 3 — The conformance kit (§5)
 
 #### T130 — The kit fails a broken adapter, per suite and by name
-Each of §5.4's nine fixtures is driven through `conformance.run`, and each fails **the suite
+Each of §5.4's eleven fixtures is driven through `conformance.run`, and each fails **the suite
 named in its row**. A fixture that failed nothing, or whose named suite passed, is the failure
 this test catches; incidental failures of other suites are permitted and asserted as such,
 because "and no other" is false of an adapter broken badly enough.
@@ -1216,11 +1240,12 @@ absent from `sys.modules`, beside `ctrlrun.verify`, `httpx`, `jwt` and every `op
 module. `ctrlrun.adapter` **is** present: it is core and in the action path, and this test says
 which side of that line each module is on.
 
-#### T134b — Core installs no conformance dependency
-`pip install ctrlrun` installs `pyyaml` and `click` and nothing else; `import
-ctrlrun.conformance` without `pytest` raises `MissingDependency` naming
-`pip install ctrlrun[conformance]` (`v0.2 §10` T30's shape). The module ships inside the core
-wheel, as `gateway/` does; only its dependency is behind the extra.
+#### T134b — The kit is core and needs no extra
+`pip install ctrlrun` installs `pyyaml` and `click` and nothing else, **and declares no
+`conformance` extra** — §12.1 records why the one this document originally specified was
+removed while it was being built. The test asserts the extra's absence and that nothing under
+`conformance/` imports from one, because an extra with no dependency behind it is an install
+line that installs nothing and a `MissingDependency` that can never fire.
 
 ### Items 4 and 5 — The reference adapters (§3.5, §6, §7)
 
@@ -1364,7 +1389,7 @@ stand, and **v0.5 adds no table and no column to any store** — an adapter writ
 | Module | Owns | Must not know about |
 |---|---|---|
 | `adapter.py` | `FrameworkInterrupt`, `PendingApproval`, `ApprovalAnswer`, `InterruptApprovalProvider`, `needs_approval`, `banner` | the policy evaluator, authority, effect state, executors, sinks, any framework |
-| `conformance/` | the suites, the fixtures, the report — core, stdlib only | the gateway, `otel`, `jwt_identity`; anything from an extra |
+| `conformance/` | the suites, the fixtures, the report — core, no new dependency | the gateway, `otel`, `jwt_identity`, `acs`, `webhook`; anything from an extra |
 
 `adapter.py` imports `action.py`, `approval.py`, `effect.py` (`resolve_resource`), `errors.py`
 and two names from `policy.py` — `OBSERVE` and `Decision`, which are the mode and the decision
@@ -1467,12 +1492,14 @@ never through one.
 
 That leaves an extra with no dependency behind it: an install line that installs nothing, and a
 `MissingDependency` T134b would have asserted about a condition that can never arise. So the kit
-is core and stdlib-only, exactly as `verify/` is, and `v0.4 §1`'s argument turns out to apply
-after all — *a check somebody has to remember to install is a check that does not run* is as
+is core, exactly as `verify/` is, and `v0.4 §1`'s argument turns out to apply after all — *a check somebody has to remember to install is a check that does not run* is as
 true of an adapter author's CI as of an operator's deployment.
 
 `pip install ctrlrun` is unchanged: `pyyaml` and `click`. T134b asserts the absence of the extra
-rather than its behaviour, and asserts that nothing under `conformance/` imports from one.
+rather than its behaviour, and walks the package's imports to assert that nothing under
+`conformance/` reaches an extra or one of the three modules the module map forbids it. It does
+**not** assert "stdlib only": the suites parse YAML, and a claim that is loosely true is the
+kind this document keeps refusing.
 
 ### 12.2 The binding check applies to a grant and never to a refusal
 
@@ -1508,14 +1535,27 @@ needs the adapter's `FrameworkInterrupt`. The Protocol gained `interrupt` for th
 let the adapter build the `Control` would be testing a shape that does not ship, which is the
 same defect as a test double that can grant where the real code would not.
 
-### 12.5 Three acceptance tests are not reachable through a single `invoke`
+### 12.5 Two acceptance tests are not reachable through a single `invoke`. A third is, and
+the first draft of this subsection said it was not
 
-`v0.1 §7` T2 (mutation between grant and presentation) and T5 (an approval answered after its
-expiry) both need an interval *between* the request being created and being consumed, and
-`@protect(wait=True)` has none: both happen inside one call. `v0.3 §10` T78 (delegation
-escalation) drives `Control.delegate`, which is on §2.3's never-list.
+`v0.1 §7` T2 (mutation between a grant and its presentation) needs an interval between the
+request being created and being consumed that `@protect(wait=True)` has none of: both happen
+inside one call. `v0.3 §10` T78 (delegation escalation) drives `Control.delegate`, which is on
+§2.3's never-list, so a suite driving it would test nothing about the adapter. Both stay where
+they are, and §5.3 names the absences rather than leaving a reader to wonder why a suite sourced
+from `v0.1 §7` is missing one of its tests.
 
-All three stay where they are — in the kernel's suite, and for T5's other half at the provider
-(T129d) — and §5.3 names the absences rather than leaving a reader to wonder why a suite sourced
-from `v0.1 §7` is missing two of its tests. An absence that is not stated reads as an oversight,
-and the next session re-adds it.
+**T5 was on that list and should not have been.** This subsection said an approval answered
+after its expiry was unreachable "without a hook into the adapter's own primitive" — and §12.3
+had added exactly that hook two subsections earlier. The counting proxy runs immediately before
+the adapter's primitive, so moving the kit's clock there reproduces §2.4 step 5 through one
+`invoke`. An independent review pointed at the contradiction inside the same document.
+
+It is a meaningful *adapter* case and not only a provider one: what it asks is whether the
+adapter lets `ApprovalTimeout` propagate, or swallows it the way `swallows-denial` swallows
+`ActionDenied` — an adapter that returned a value there would have executed nothing and told its
+framework the refund went through. It is in the `kernel` suite.
+
+The general lesson is worth more than the case. A claim that something is untestable is a claim
+that ages badly, because the next thing built is often the thing that makes it testable — and
+nobody re-reads a paragraph that says "not reachable" to check whether it still is.

--- a/docs/SPEC-v0.5.md
+++ b/docs/SPEC-v0.5.md
@@ -51,7 +51,7 @@ build-list position.
 |---|---|---|---|
 | 1 | The framework probe, executed against LangGraph and the Agents SDK | not packaged | `v0.4 §7` |
 | 2 | The adapter surface `ctrlrun.adapter`, and the `v0.3 §4.3.1` rows | core | §2, §4 |
-| 3 | The conformance kit, `ctrlrun.conformance` | core wheel, `pytest` behind `ctrlrun[conformance]` | §5 |
+| 3 | The conformance kit, `ctrlrun.conformance` | core, stdlib only (§12.1) | §5 |
 | 4 | The LangGraph reference adapter, `ctrlrun-langgraph` | a separate distribution | §6 |
 | 5 | The OpenAI Agents SDK reference adapter, `ctrlrun-openai-agents` | a separate distribution | §6 |
 | 6 | A third adapter, written against this document alone | disposable | §8 |
@@ -61,10 +61,8 @@ The dependency rule of `v0.2 §1.1`, `v0.3 §1` and `v0.4 §1` is unchanged and 
 install ctrlrun` MUST continue to install nothing but `pyyaml` and `click`. **The adapter
 surface itself is core** — it is in the action path, it is stdlib, and an adapter is a separate
 distribution that depends on `ctrlrun` rather than the other way round. The **conformance kit**
-is not core: it is test machinery, it needs `pytest`, and `v0.4 §1`'s argument for putting
-verify in core does not transfer. Verify is a tool an *operator* runs against a deployment;
-the kit is a tool an *adapter author* runs against an adapter, and there is exactly one of
-those per adapter.
+is core too, and stdlib only. It was planned as an extra on the premise that a kit needs
+`pytest`; building it showed the premise was wrong, and §12.1 records the correction.
 
 ### 1.1 What an adapter is not, stated before anything else
 
@@ -565,6 +563,12 @@ within one framework call the action's name and environment come from the `Contr
 `resource` is a template over its arguments (`v0.1 §5.1`), and its principal from the
 `IdentityProvider`.
 
+**The check applies to a grant and never to a refusal.** An answer of `granted=False`
+authorizes nothing, so there is nothing to bind it to — and requiring `approved_arguments` on
+one would turn a human's *no* into an `ApprovalMismatch`, when §2.4 is explicit that a denial is
+an answer and gets `APPROVAL_DENIED` then `ACTION_DENIED`. The conformance kit found this by
+driving a denial through a declared carrier (§12.2).
+
 **An adapter MUST NOT synthesize `approved_arguments` from `pending.arguments`.** Handing back a
 copy of what it was just given makes every comparison trivially pass; it is manufacturing the
 check, and it is the one way to turn attribution into a lie about prevention. §5.4's
@@ -774,21 +778,22 @@ programme, it certifies nothing, and passing it is not a claim about an adapter'
 answers one question: *does an action driven through this adapter get the same refusals as an
 action driven through `@protect`?*
 
-It ships as **`ctrlrun[conformance]`**, in this repository. The arguments, since a build prompt
-is not where a decision should live:
+It ships in **core**, stdlib only, in this repository. §12.1 records why this changed during
+item 3; the arguments as they now stand:
 
-- **Core must not carry test machinery.** The kit needs `pytest`; `pip install ctrlrun` stays
-  `pyyaml` and `click` (`v0.2 §1.1`).
+- **It needs no third-party library.** The suites drive a `Control` and compare exceptions,
+  which is `assert` and `try`. An adapter author runs the report *inside* their own pytest —
+  `assert run(adapter).ok` — rather than through one.
+- **An extra with nothing behind it is worse than no extra.** `ctrlrun[conformance]` would
+  install nothing, and the `MissingDependency` its install line promised could never fire.
 - **A third distribution would be a third thing to version.** The kit tracks the kernel's
-  semantics — it is the kernel's acceptance tests — so it belongs to the kernel's version, and
-  an adapter author installs one extra rather than tracking a separate release line.
-- **`v0.4 §1`'s argument for core does not transfer.** Verify is run by every operator against
-  every deployment, so an extra would mean half of them never run it. The kit is run by an
-  adapter author, once per adapter, in that adapter's CI. There is no population of people who
-  need it and will not install it.
+  semantics — it *is* the kernel's acceptance tests — so it belongs to the kernel's version.
+- **`v0.4 §1`'s argument applies after all.** A check somebody has to remember to install is a
+  check that does not run, and that is as true of an adapter author's CI as of an operator's.
 
-`import ctrlrun` MUST NOT import `ctrlrun.conformance` (T134), for `v0.4 §1`'s reason: a testing
-tool in the execution path is a dependency nobody meant to take.
+`pip install ctrlrun` is unchanged: `pyyaml` and `click`. `import ctrlrun` MUST NOT import
+`ctrlrun.conformance` (T134), for `v0.4 §1`'s reason: a testing tool in the execution path is a
+dependency nobody meant to take.
 
 ### 5.2 What an adapter hands the kit
 
@@ -812,6 +817,10 @@ class ConformanceAdapter(Protocol):
     """What an adapter implements so the suites can drive it (§5.3)."""
 
     framework: str
+    #: The same `FrameworkInterrupt` an operator would wire into an
+    #: `InterruptApprovalProvider`. **The kit wires it**, because §2.3 says an adapter never
+    #: constructs a `Control` and a kit that let it would be testing a shape that does not ship.
+    interrupt: FrameworkInterrupt
 
     def invoke(self, request: CallRequest) -> Any: ...
 
@@ -855,12 +864,27 @@ class ConformanceReport:
     def to_text(self) -> str: ...            # "4/4 (2 not applicable)", never "6/6"
 
 
-def run(adapter: ConformanceAdapter, control: Control) -> ConformanceReport: ...
+def run(adapter: ConformanceAdapter, deployment: Control | None = None) -> ConformanceReport: ...
 ```
 
 `ok` is `False` for a refused report and `False` for `applicable == 0`, on `v0.4 §3.8`'s rule:
 `0/0` reported as success is the same false green as `6/6` with two N/As. `reason` is required
 on every `FAIL` and every `NOT_APPLICABLE` — an N/A without one is an N/A nobody can check.
+
+**`deployment` is the operator's `Control`, and the suites do not run against it.** They run
+against scratch `Control`s the kit builds — its own policies, its own store, its own clock —
+for the reason `v0.4 §3.5` gives about verify: a kit that reserved a real effect key would be a
+defect of exactly the class it exists to find. The one thing read from `deployment` is the mode,
+and an observing one is refused (§3.6). It is optional because an adapter author's CI has no
+deployment to hand it, and passing one is how the observe-mode refusal reaches anybody at all.
+
+**The kit wraps the adapter's `interrupt` in a counting proxy** before wiring it, and asserts
+the count on every case that expects a human and on every case that does not. That is not
+belt-and-braces: `fixtures.GrantsForItself` grants the request before `@protect` reaches
+`wait()`, so the provider finds the record already `granted` and returns it — correctly, since
+`ctrlrun approve` grants out of band too — and the framework's primitive is never called. Every
+suite passed. A suite asserting a refusal cannot tell *the human said no through the framework*
+from *the framework was never asked*, and only the count can.
 
 `invoke` runs **one** protected call end to end through the framework and returns the executor's
 value. Every CTRLRun exception propagates: the kit asserts on `ApprovalMismatch`,
@@ -879,20 +903,31 @@ allowed outright.
 
 Each is a named group, reported per suite and per case.
 
-| Suite | From | What it drives through the adapter |
+| Suite | Cases | What it drives through the adapter |
 |---|---|---|
-| `kernel` | `v0.1 §7` T1, T4, T5, T6, T8 | Lost response blocks a blind retry · replayed approval · expired approval · unknown action fails closed · `FAILED` permits retry |
-| `binding` | §3.4 | An answer whose `approved_arguments` differ from the proposal's is refused, and nothing is granted. `not_applicable` where `carries_approved_arguments` is `False`, with the adapter's reason |
-| `duplicate` | `v0.1 §7` T3, in one process | Two `invoke` calls on one effect key: exactly one commits and one is refused |
-| `authority` | `v0.3 §10` T66, T70, T74, T78 | No grant · expired grant · a denial by authority leaves no pending approval · delegation escalation |
-| `identity` | `v0.3 §10` T60, T63 | No principal, no action · the provider wins over anything the calling code says (§4.2) |
+| `kernel` | T1, T4, T6, T8, A1, B2, B3 | Lost response blocks a blind retry · a committed effect refuses a second attempt · unknown action fails closed · `NotExecuted` permits a retry · an allowed action is never put to a human · a matching answer authorizes · a refusal is a denial and not an error |
+| `binding` | B1 | An answer given against different arguments authorizes nothing. `not_applicable` where `carries_approved_arguments` is `False`, with the adapter's reason |
+| `duplicate` | D1 | Two `invoke` calls on one effect key: exactly one commits and one is refused |
+| `authority` | T66, T70, T74 | No grant · expired grant · a denial by authority leaves no pending approval |
+| `identity` | T60, T63 | No principal, no action · the provider wins over anything the framework's session says (§4.2) |
 
-**`binding` is sourced from §3.4 and not from `v0.1 §7` T2**, and the distinction matters. T2
-mutates the action *between* a human's grant and its presentation, which through
-`@protect(wait=True)` is unreachable: the request is created and consumed inside one call. What
-an adapter can get wrong is the other half — carrying back an answer that was given against a
-different proposal — and that is what this suite drives. T2 itself is unchanged and still runs
-against the kernel, where it belongs.
+**`binding` is the mutation check alone**, and that is why B2 (its control) and B3 (a denial is
+a denial) are in `kernel`. Both run whatever the framework carries back; a `binding` suite
+containing them would report `pass` for an adapter that cannot perform the one check the suite
+is named for. That is an N/A folded into the count, one level down.
+
+**`binding` is sourced from §3.4 and not from `v0.1 §7` T2.** T2 mutates the action *between* a
+human's grant and its presentation, which through `@protect(wait=True)` is unreachable: the
+request is created and consumed inside one call. What an adapter can get wrong is the other half
+— carrying back an answer that was given against a different proposal — and that is what this
+drives. T2 itself is unchanged and still runs against the kernel, where it belongs.
+
+**Three acceptance tests are deliberately absent, and the absences are stated rather than left
+to be noticed.** `v0.1 §7` T5 (an approval answered after its expiry) is not reachable through a
+single `invoke` for the same reason T2 is not; it is exercised at the provider (T129d, both
+halves) and in the kernel. `v0.3 §10` T78 (delegation escalation) drives `Control.delegate`,
+which §2.3 puts on an adapter's never-list — a suite driving it would test nothing about the
+adapter. Both stay where they are.
 
 **`duplicate` is not `v0.1 §7` T3**, and says so. T3 uses `multiprocessing` and is a statement
 about SQLite's `BEGIN IMMEDIATE` across OS processes (`v0.1 §5.3 E1`); a framework
@@ -918,24 +953,33 @@ adapters that are broken **in one named way each**, and each MUST fail the suite
 |---|---|---|
 | `never-executes` | Returns a plausible value without calling `request.executor` | `kernel` |
 | `swallows-not-executed` | Catches `NotExecuted` and returns `None` | `kernel` |
-| `replays-approval` | Keeps a `request_id` and presents it again on the next call | `kernel` |
-| `self-asserts-principal` | Builds a `Principal` from the framework's session and reaches a `Control` with it | `identity` |
 | `swallows-denial` | Catches `ActionDenied` and returns a value | `kernel` |
+| `replays-approval` | Keeps a `request_id` and presents it again on the next call | `kernel` |
 | `interrupts-on-allow` | Routes every call through the interrupt, `APPROVE` or not | `kernel` |
-| `grants-for-itself` | Calls `store.grant_approval` rather than returning an `ApprovalAnswer` | `kernel` — an approval no interrupt produced |
+| `grants-for-itself` | Takes `ApprovalRequired` with `wait=False`, writes the grant itself, and re-presents. The framework's primitive is never reached | `kernel` |
+| `ignores-authority` | Catches `AuthorityDenied` and returns a value | `authority` |
+| `self-asserts-principal` | Builds a `Principal` from the framework's session and reaches a `Control` with it | `identity` |
 | `echoes-the-payload` | Declares `carries_approved_arguments = True` and returns `pending.arguments` as the answer's `approved_arguments` | `binding` — §3.4's manufactured check |
 | `caches-the-decision` | Memoizes the first call's result and returns it for the second | `duplicate` |
 
 `grants-for-itself` and `echoes-the-payload` exist because the document's second rule and its
 mutation check were the two claims with no fixture behind them. "Never a second approval path"
 and "this is prevention, not attribution" are the sentences a security reviewer reads first, and
-a rule with no broken fixture is a rule the kit cannot tell you about.
+a rule with no broken fixture is a rule the kit cannot tell you about. `ignores-authority` exists
+because `swallows-denial` failed the `authority` suite only incidentally — `AuthorityDenied`
+subclasses `ActionDenied` — and a suite whose only fixture fails it by accident is a suite
+nothing is aimed at.
+
+**Every suite is named by at least one fixture, and every fixture names a suite that exists.**
+Both directions are asserted (T130), because a fixture pointed at a renamed suite passes its own
+test by never being checked against anything, and a suite no fixture fails would report `pass`
+for every adapter ever written.
 
 Each fixture fails **the suite named in its row**. Several also fail others incidentally — an
 adapter that never reaches the executor fails anything whose control counts executor calls — and
 the assertion is on the named suite rather than on an exclusive one, because "and no other" is
 false of a fixture broken badly enough. What T130 forbids is a fixture that fails *nothing* and a
-fixture whose named suite passes.
+fixture whose named suite passed.
 
 These are written **before** the reference adapters (build-list order: item 3 precedes items 4
 and 5), because "two adapters pass the suites" is this milestone's exit criterion and it means
@@ -1243,7 +1287,7 @@ from .adapter import (
     banner,
     needs_approval,
 )
-# ctrlrun[conformance], lazily importable, NOT re-exported at package import:
+# ctrlrun.conformance — core and stdlib (§12.1), NOT re-exported at package import:
 #   ctrlrun.conformance.run
 #   ctrlrun.conformance.CallRequest
 #   ctrlrun.conformance.ConformanceAdapter
@@ -1319,10 +1363,12 @@ stand, and **v0.5 adds no table and no column to any store** — an adapter writ
 
 | Module | Owns | Must not know about |
 |---|---|---|
-| `adapter.py` | `FrameworkInterrupt`, `PendingApproval`, `ApprovalAnswer`, `InterruptApprovalProvider`, `needs_approval`, `banner` | policy internals, authority, effect state, executors, sinks, any framework |
-| `conformance/` | the suites, the fixtures, the report — `ctrlrun[conformance]` | the gateway, `otel`, `jwt_identity`; anything from another extra |
+| `adapter.py` | `FrameworkInterrupt`, `PendingApproval`, `ApprovalAnswer`, `InterruptApprovalProvider`, `needs_approval`, `banner` | the policy evaluator, authority, effect state, executors, sinks, any framework |
+| `conformance/` | the suites, the fixtures, the report — core, stdlib only | the gateway, `otel`, `jwt_identity`; anything from an extra |
 
-`adapter.py` imports `action.py` and `approval.py`, and takes a `Control` as a *parameter* in
+`adapter.py` imports `action.py`, `approval.py`, `effect.py` (`resolve_resource`), `errors.py`
+and two names from `policy.py` — `OBSERVE` and `Decision`, which are the mode and the decision
+vocabulary rather than the evaluator — and takes a `Control` as a *parameter* in
 `needs_approval` and `banner` without importing it at module scope — the same shape `verify/`
 has, one layer down. It appends no event and owns no sink: `Control` is still the only thing
 that fans evidence out (§2.4). `conformance/` sits **above** `control.py`, beside `verify/` and
@@ -1408,6 +1454,68 @@ specifically:
 
 ## 12. What building v0.5 settled
 
-*Filled in as items land, in the item that settles each. `SPEC-v0.4.md §12` is the format: one
-subsection per question the drafting could not close, each stating what the code decided and
-which section carries it.*
+*One subsection per question the drafting could not close, each stating what the code decided
+and which section carries it. `SPEC-v0.4.md §12` is the format.*
+
+### 12.1 The conformance kit is core, not an extra
+
+§5.1's first draft made it `ctrlrun[conformance]`, on the stated premise that *"the kit needs
+`pytest`"*. Building it showed the premise was false. The suites drive a `Control` and compare
+exceptions, which is `assert` and `try`; there is nothing in the kit a third-party library does.
+An adapter author runs the result **inside** their own pytest — `assert run(adapter).ok` — and
+never through one.
+
+That leaves an extra with no dependency behind it: an install line that installs nothing, and a
+`MissingDependency` T134b would have asserted about a condition that can never arise. So the kit
+is core and stdlib-only, exactly as `verify/` is, and `v0.4 §1`'s argument turns out to apply
+after all — *a check somebody has to remember to install is a check that does not run* is as
+true of an adapter author's CI as of an operator's deployment.
+
+`pip install ctrlrun` is unchanged: `pyyaml` and `click`. T134b asserts the absence of the extra
+rather than its behaviour, and asserts that nothing under `conformance/` imports from one.
+
+### 12.2 The binding check applies to a grant and never to a refusal
+
+§3.4's first draft made `approved_arguments` mandatory whenever the adapter declared it carried
+them, without qualifying it by the answer's verdict. The kit's `B3` case — a human's *no*,
+driven through a declared carrier — was refused with `ApprovalMismatch` before it could become a
+denial.
+
+That is the exact failure §2.4 forbids in the other direction: *a denial is a human's answer*,
+and it gets `APPROVAL_DENIED` then `ACTION_DENIED`, never the `APPROVAL_INVALIDATED` umbrella. A
+refusal authorizes nothing, so there is nothing for the hash to bind it to. §3.4 now says so, and
+the case that found it is in the `kernel` suite where it will keep saying so.
+
+### 12.3 An already-granted request is a hole the provider cannot close, and the kit must
+
+`fixtures.GrantsForItself` writes the grant itself and then re-presents, so `wait()` finds the
+record already `granted` and returns it without calling `interrupt()`. Every suite passed.
+
+The provider is **right** to return an already-granted record: `ctrlrun approve` grants out of
+band, so does a webhook, and `v0.1 §4.3` says a provider never invents an answer. Refusing there
+would break the legitimate paths. So the hole is not in `wait()` — it is that a suite asserting a
+*refusal* cannot distinguish "the human said no through the framework" from "the framework was
+never asked".
+
+The kit therefore wraps the adapter's `interrupt` in a counting proxy and asserts the count: `1`
+on every case that expects a human, `0` on every case that does not. `v0.4 §1.3` one level up,
+and the reason §5.2 now specifies the proxy rather than leaving it to an implementation.
+
+### 12.4 `ConformanceAdapter` exposes its interrupt, and the kit plays operator
+
+§2.3 says an adapter never constructs a `Control`, so the kit must — and to wire the provider it
+needs the adapter's `FrameworkInterrupt`. The Protocol gained `interrupt` for that. A kit that
+let the adapter build the `Control` would be testing a shape that does not ship, which is the
+same defect as a test double that can grant where the real code would not.
+
+### 12.5 Three acceptance tests are not reachable through a single `invoke`
+
+`v0.1 §7` T2 (mutation between grant and presentation) and T5 (an approval answered after its
+expiry) both need an interval *between* the request being created and being consumed, and
+`@protect(wait=True)` has none: both happen inside one call. `v0.3 §10` T78 (delegation
+escalation) drives `Control.delegate`, which is on §2.3's never-list.
+
+All three stay where they are — in the kernel's suite, and for T5's other half at the provider
+(T129d) — and §5.3 names the absences rather than leaving a reader to wonder why a suite sourced
+from `v0.1 §7` is missing two of its tests. An absence that is not stated reads as an oversight,
+and the next session re-adds it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,11 +73,6 @@ otel = [
 # rather than at install time. An extra that installs cleanly and then cannot verify an RS256
 # token is worse than one that names its dependency.
 identity = ["pyjwt[crypto]>=2.8"]
-# SPEC-v0.5 §5.1 — the conformance kit runs this repository's own acceptance suites against an
-# adapter, so it needs `pytest`, and core must not carry test machinery. It is an extra rather
-# than core because SPEC-v0.4 §1's argument does not transfer: verify is run by every operator
-# against every deployment, and the kit is run by an adapter author, once, in that adapter's CI.
-conformance = ["pytest>=8"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -159,6 +154,11 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "ANN", "SIM", "RUF"]
 # refusal names follow this codebase's convention (DuplicateEffect, AmbiguousEffect), not the
 # suffix rule, as `errors.py` already does.
 "src/ctrlrun/verify/*.py" = ["ANN401", "N818"]
+# The conformance kit's subject matter is an adapter's return value, which is whatever the
+# operator's executor returned and has no narrower type — the same reasoning that exempts
+# `state.py`'s `commit_effect(result: Any)`. `ConformanceAdapter.invoke -> Any` is frozen in
+# SPEC-v0.5 §9 for that reason.
+"src/ctrlrun/conformance/*.py" = ["ANN401"]
 # The research harness is outside `src/` and outside the package (SPEC-v0.4 §7.1). It keeps
 # the line length and the import rules, because those are about reading it — but it is not
 # held to the kernel's typing discipline: its subject matter is a `BaseHTTPRequestHandler`

--- a/src/ctrlrun/adapter.py
+++ b/src/ctrlrun/adapter.py
@@ -26,10 +26,13 @@ which SPEC-v0.3 §8.1 removed from the gateway by name and §8.4 then removed ag
 hook. It reached this document's first draft as well, and an independent review found it; SPEC-v0.5
 §9.1 is the record.
 
-This module imports `action.py` and `approval.py` and nothing else from the kernel. `Control`
-arrives as a *parameter*, never as a module-scope import, so `adapter.py` stays below
-`control.py` in the dependency order of `ARCHITECTURE.md` §6 and `Control` remains the only
-module that composes the others. It appends no event and owns no sink.
+This module imports `action.py`, `approval.py`, `effect.py` and `errors.py`, and two names
+from `policy.py`: `OBSERVE`, which is the mode the banner reads, and `Decision`, which is the
+vocabulary the predicate answers in. Neither is the evaluator, which is what the module map
+means by policy internals. `Control` arrives as a *parameter*, never as a module-scope
+import, so `adapter.py` stays below `control.py` in the dependency order of
+`ARCHITECTURE.md` §6 and `Control` remains the only module that composes the others. It
+appends no event and owns no sink.
 """
 
 from __future__ import annotations
@@ -341,6 +344,13 @@ class InterruptApprovalProvider:
                 f"{self._interrupt.framework}: an ApprovalAnswer must name an approver; "
                 "an approval with no approver is evidence that answers the wrong question"
             )
+        if not answer.granted:
+            # A refusal authorizes nothing, so there is nothing to bind it to. Requiring
+            # `approved_arguments` here would turn a human's *no* into an `ApprovalMismatch`,
+            # and §2.4 is explicit that a denial is an answer: it gets `APPROVAL_DENIED` then
+            # `ACTION_DENIED`, never the `APPROVAL_INVALIDATED` umbrella. The conformance kit
+            # found this by driving a denial through a declared carrier (SPEC-v0.5 §12.2).
+            return
         if not self._interrupt.carries_approved_arguments:
             # SPEC-v0.5 §3.4's second bullet. The binding across the interrupt is the
             # framework's checkpoint, not this hash -- attribution, declared, and reported as

--- a/src/ctrlrun/conformance/__init__.py
+++ b/src/ctrlrun/conformance/__init__.py
@@ -1,0 +1,46 @@
+"""The adapter conformance kit. Build-list item 3; SPEC-v0.5 §5.
+
+It runs **this repository's own acceptance tests** -- the suites of `v0.1 §7` and `v0.3 §10` --
+against an adapter, through the surface `adapter.py` defines. It is not a conformance programme,
+it certifies nothing, and passing it is not a claim about an adapter's quality. It answers one
+question: *does an action driven through this adapter get the same refusals as an action driven
+through `@protect`?*
+
+**A kit that only ever passes is a kit nothing exercises.** So `fixtures.py` ships nine adapters
+broken in one named way each, and the kit's own tests require each to fail the suite named for
+it. That is `v0.4 §1.3`'s positive-control rule, one level up, and it is why item 3 comes before
+the reference adapters: "two adapters pass the suites" is this milestone's exit criterion and it
+means nothing until the suite can fail.
+
+**Not applicable is not a pass**, here as everywhere. An adapter whose framework carries nothing
+back from its resumption cannot exercise the binding suite, and that suite is reported
+`not_applicable` with the adapter's own reason, excluded from the denominator, and shown
+separately. `report.ok` is `False` for a zero denominator, because `0/0` reported as success is
+the same false green as `6/6` with two of them uncounted.
+
+**Stdlib only, and in core.** SPEC-v0.5 §5.1 planned this as `ctrlrun[conformance]` on the
+premise that a kit needs `pytest`. Building it showed the premise was wrong -- the suites drive a
+`Control` and compare exceptions, which is `assert` and `try`, and an adapter author runs the
+result *inside* their own pytest rather than through one. An extra with no dependency behind it
+is a `MissingDependency` that can never fire and an install line that installs nothing, so the
+kit is core, exactly as `verify/` is, for the reason `v0.4 §1` gives: a check somebody has to
+remember to install is a check that does not run. SPEC-v0.5 §12.1 records it.
+
+Nothing in the kernel imports this package, and `import ctrlrun` does not reach it (T134).
+"""
+
+from __future__ import annotations
+
+from .report import CaseResult, ConformanceReport, SuiteResult, SuiteStatus
+from .suites import SUITES, CallRequest, ConformanceAdapter, run
+
+__all__ = [
+    "SUITES",
+    "CallRequest",
+    "CaseResult",
+    "ConformanceAdapter",
+    "ConformanceReport",
+    "SuiteResult",
+    "SuiteStatus",
+    "run",
+]

--- a/src/ctrlrun/conformance/__init__.py
+++ b/src/ctrlrun/conformance/__init__.py
@@ -18,13 +18,20 @@ back from its resumption cannot exercise the binding suite, and that suite is re
 separately. `report.ok` is `False` for a zero denominator, because `0/0` reported as success is
 the same false green as `6/6` with two of them uncounted.
 
-**Stdlib only, and in core.** SPEC-v0.5 §5.1 planned this as `ctrlrun[conformance]` on the
-premise that a kit needs `pytest`. Building it showed the premise was wrong -- the suites drive a
-`Control` and compare exceptions, which is `assert` and `try`, and an adapter author runs the
-result *inside* their own pytest rather than through one. An extra with no dependency behind it
-is a `MissingDependency` that can never fire and an install line that installs nothing, so the
-kit is core, exactly as `verify/` is, for the reason `v0.4 §1` gives: a check somebody has to
-remember to install is a check that does not run. SPEC-v0.5 §12.1 records it.
+**In core, and needing nothing `ctrlrun` does not already install.** SPEC-v0.5 §5.1 planned this
+as `ctrlrun[conformance]` on the premise that a kit needs `pytest`. Building it showed the premise
+was wrong -- the suites drive a `Control` and compare exceptions, which is `assert` and `try`, and
+an adapter author runs the result *inside* their own pytest rather than through one. An extra with
+no dependency behind it is a `MissingDependency` that can never fire and an install line that
+installs nothing, so the kit is core, exactly as `verify/` is, for the reason `v0.4 §1` gives: a
+check somebody has to remember to install is a check that does not run. SPEC-v0.5 §12.1 records
+it.
+
+"Stdlib" is the loose word and is not used: the suites build their scratch policies with
+`Policy.from_yaml`, so pyyaml is a runtime dependency here as it is everywhere in the kernel. What
+matters is the claim that holds — **nothing from an extra**, and nothing the module map puts in
+`conformance/`'s "must not know about" column — and T134b asserts that by walking the package's
+imports rather than by asserting a word.
 
 Nothing in the kernel imports this package, and `import ctrlrun` does not reach it (T134).
 """

--- a/src/ctrlrun/conformance/fixtures.py
+++ b/src/ctrlrun/conformance/fixtures.py
@@ -16,6 +16,7 @@ reports on frameworks, and neither is allowed to editorialize about the other's 
 
 from __future__ import annotations
 
+import contextlib
 from typing import Any
 
 from ..action import Action
@@ -198,14 +199,47 @@ class InterruptsOnAllow(Reference):
 
     def invoke(self, request: CallRequest) -> Any:
         self.interrupt.answer = request.answer
-        self.interrupt.interrupt(
-            PendingApproval(
-                request_id="apr_invented", action_id="act_invented", action=request.action,
-                action_hash="sha256:invented", arguments=dict(request.arguments), resource=None,
-                environment=request.control.environment, agent="?", user=None,
-                created_at=request.control._clock(), expires_at=request.control._clock(),
-            )
-        )
+        # A real framework's primitive does not raise when nobody was expected: it prompts,
+        # somebody answers, and the tool runs. So the kit double's complaint is suppressed and
+        # this carries on -- because a fixture that failed *because the double raised* would be
+        # caught by the double rather than by the kit, and an adapter with a real primitive
+        # would sail through. The interrupt **count** is what catches this, and suppressing
+        # here is what makes the count the only thing that can.
+        with contextlib.suppress(AssertionError):
+            self.interrupt.interrupt(_invented(request))
+        return self._call(request)
+
+
+def _invented(request: CallRequest) -> PendingApproval:
+    """A pending approval this adapter made up, to put in front of somebody who was not asked
+    about anything: the shape of an adapter that routes every call through its framework's
+    approval UI whether the policy asked for one or not."""
+    now = request.control._clock()
+    return PendingApproval(
+        request_id="apr_invented", action_id="act_invented", action=request.action,
+        action_hash="sha256:invented", arguments=dict(request.arguments), resource=None,
+        environment=request.control.environment, agent="?", user=None,
+        created_at=now, expires_at=now,
+    )
+
+
+class InterruptsOnlyWhenUnasked(Reference):
+    """Correct on every call the policy sends to a human, and wrong on exactly the ones it does
+    not: it puts an `ALLOW` through its framework's approval UI and nothing else.
+
+    It exists because a mutation table found A1's interrupt count **subsumed**.
+    `InterruptsOnAllow` interrupts on every call, so it bumps the count on T4, B2 and B3 as
+    well, and deleting A1's check left the kit still failing that adapter -- for a reason that
+    has nothing to do with the case A1 is. This one is invisible to every other case, so A1's
+    count is the only thing that can catch it, which is what makes A1 a check rather than a
+    restatement.
+    """
+
+    def invoke(self, request: CallRequest) -> Any:
+        self.interrupt.answer = request.answer
+        if request.answer is None:
+            with contextlib.suppress(AssertionError):
+                self.interrupt.interrupt(_invented(request))
         return self._call(request)
 
 
@@ -291,6 +325,7 @@ BROKEN: dict[str, tuple[type[Reference], str]] = {
     "swallows-denial": (SwallowsDenial, "kernel"),
     "replays-approval": (ReplaysApproval, "kernel"),
     "interrupts-on-allow": (InterruptsOnAllow, "kernel"),
+    "interrupts-only-when-unasked": (InterruptsOnlyWhenUnasked, "kernel"),
     "grants-for-itself": (GrantsForItself, "kernel"),
     "ignores-authority": (IgnoresAuthority, "authority"),
     "self-asserts-principal": (SelfAssertsPrincipal, "identity"),

--- a/src/ctrlrun/conformance/fixtures.py
+++ b/src/ctrlrun/conformance/fixtures.py
@@ -86,9 +86,7 @@ def _protected(request: CallRequest, *, wait: bool = True) -> Any:
     parameters = ", ".join(request.arguments)
     forwarded = ", ".join(f"{name}={name}" for name in request.arguments)
     namespace: dict[str, Any] = {"_executor": request.executor}
-    exec(
-        f"def tool({parameters}):\n    return _executor({forwarded})", namespace
-    )
+    exec(f"def tool({parameters}):\n    return _executor({forwarded})", namespace)
     return protect(
         request.action,
         effect=request.effect,
@@ -216,10 +214,17 @@ def _invented(request: CallRequest) -> PendingApproval:
     approval UI whether the policy asked for one or not."""
     now = request.control._clock()
     return PendingApproval(
-        request_id="apr_invented", action_id="act_invented", action=request.action,
-        action_hash="sha256:invented", arguments=dict(request.arguments), resource=None,
-        environment=request.control.environment, agent="?", user=None,
-        created_at=now, expires_at=now,
+        request_id="apr_invented",
+        action_id="act_invented",
+        action=request.action,
+        action_hash="sha256:invented",
+        arguments=dict(request.arguments),
+        resource=None,
+        environment=request.control.environment,
+        agent="?",
+        user=None,
+        created_at=now,
+        expires_at=now,
     )
 
 

--- a/src/ctrlrun/conformance/fixtures.py
+++ b/src/ctrlrun/conformance/fixtures.py
@@ -1,0 +1,299 @@
+"""Adapters broken in one named way each, and one that is not. SPEC-v0.5 §5.4.
+
+**A kit that only ever passes is a kit nothing exercises.** These exist so the kit's own tests
+can require each fixture to fail the suite named for it -- which is `v0.4 §1.3`'s
+positive-control rule one level up, and the reason item 3 comes before the reference adapters.
+"Two adapters pass the suites" means nothing until the suite can fail.
+
+`Reference` is the pair to all of them: no framework at all, just the surface, correct. Without
+it, "the kit fails a broken adapter" is satisfied by a kit that fails everything.
+
+None of these is a framework adapter. They implement `ConformanceAdapter` directly, in process,
+so that what they break is the *contract* and never a framework's behaviour -- which is
+`v0.4 §7.3` rule 6's line, held from the other side: the kit reports on adapters and the probe
+reports on frameworks, and neither is allowed to editorialize about the other's subject.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..action import Action
+from ..adapter import ApprovalAnswer, PendingApproval
+from ..control import protect, with_approval
+from ..errors import ActionDenied, ApprovalRequired, AuthorityDenied, NotExecuted
+from .suites import CallRequest
+
+
+class Courier:
+    """The `FrameworkInterrupt` a correct in-process adapter uses.
+
+    It stands in for a framework's primitive and does the one thing the contract asks of one:
+    carry the pending approval out and the human's answer back, unchanged. The kit's answer is
+    the ground truth, and this hands it over untouched.
+    """
+
+    framework = "reference"
+
+    def __init__(self, *, carries: bool = True) -> None:
+        self.carries_approved_arguments = carries
+        self.answer: ApprovalAnswer | None = None
+        self.calls: list[PendingApproval] = []
+
+    def interrupt(self, pending: PendingApproval) -> ApprovalAnswer:
+        self.calls.append(pending)
+        if self.answer is None:
+            # `request.answer is None` means no human was expected. An adapter whose framework
+            # interrupted anyway has asked about something the policy allowed outright, and the
+            # kit's A1 case is what notices; raising here rather than inventing an answer keeps
+            # SPEC-v0.5 §2.4's "a framework error is never an answer" true of the double too.
+            raise AssertionError("interrupted when no human was expected")
+        return self.answer
+
+
+class Reference:
+    """A correct adapter with no framework behind it. The pair to every fixture below."""
+
+    def __init__(self, *, carries: bool = True, framework: str = "reference") -> None:
+        self.framework = framework
+        self.interrupt = Courier(carries=carries)
+        self.interrupt.framework = framework
+
+    def invoke(self, request: CallRequest) -> Any:
+        self.interrupt.answer = request.answer
+        return self._call(request)
+
+    def _call(self, request: CallRequest) -> Any:
+        """The whole of a correct in-process adapter: `@protect(wait=True)`, and nothing else.
+
+        `wait=True` is what routes an `APPROVE` through the provider -- and therefore through
+        the framework's primitive -- instead of raising `ApprovalRequired` past it. That single
+        keyword is the entire difference an adapter makes (SPEC-v0.5 §1.1).
+        """
+        return _protected(request)(**request.arguments)
+
+
+def _protected(request: CallRequest, *, wait: bool = True) -> Any:
+    """The kit's executor, wrapped in `@protect` under the call's own parameter names.
+
+    `@protect` refuses `*args` and `**kwargs` (`v0.1 §8`) -- an Action's arguments are a mapping
+    of *named* values and a variadic parameter has no name a policy rule could address -- so the
+    tool is built with a signature matching this call. A framework registers its tools once and
+    this stands in for that registration; building it per call is the only difference, and it is
+    the kit's, not the contract's.
+    """
+    parameters = ", ".join(request.arguments)
+    forwarded = ", ".join(f"{name}={name}" for name in request.arguments)
+    namespace: dict[str, Any] = {"_executor": request.executor}
+    exec(
+        f"def tool({parameters}):\n    return _executor({forwarded})", namespace
+    )
+    return protect(
+        request.action,
+        effect=request.effect,
+        resource="payment:{payment_id}",
+        wait=wait,
+        control=request.control,
+    )(namespace["tool"])
+
+
+class NeverExecutes(Reference):
+    """Returns a plausible value without calling the kit's executor.
+
+    The fixture every refusal case needs, because "the second attempt was refused" is satisfied
+    just as well by an adapter that never ran anything at all.
+    """
+
+    def invoke(self, request: CallRequest) -> Any:
+        return "committed"
+
+
+class SwallowsNotExecuted(Reference):
+    """Catches `NotExecuted` and returns. The whole of `v0.1 §5.5`'s asymmetry, undone: the one
+    exception an agent may read as permission to retry stops reaching it."""
+
+    def invoke(self, request: CallRequest) -> Any:
+        try:
+            return super().invoke(request)
+        except NotExecuted:
+            return None
+
+
+class SwallowsDenial(Reference):
+    """Catches `ActionDenied` and returns a value. A policy that said no, reported as a yes."""
+
+    def invoke(self, request: CallRequest) -> Any:
+        try:
+            return super().invoke(request)
+        except ActionDenied:
+            return "committed"
+
+
+class ReplaysApproval(Reference):
+    """Keeps a `request_id` and re-presents it on the next call, reaching past `@protect`.
+
+    An author who thought they had to carry the approval themselves writes this. It is a second
+    approval path in miniature: the id is minted by the kernel and then held by the adapter.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._held: str | None = None
+
+    def invoke(self, request: CallRequest) -> Any:
+        if self._held is not None:
+            with with_approval(self._held):
+                return super().invoke(request)
+        result = super().invoke(request)
+        if self.interrupt.calls:
+            self._held = self.interrupt.calls[-1].request_id
+        return result
+
+
+class SelfAssertsPrincipal(Reference):
+    """Builds a `Principal` from its framework's session and reaches a `Control` with it.
+
+    `--principal-from-client-info` (`v0.3 §8.1`) in an adapter's clothes, which is the third
+    place it has turned up. §4.2 forbids the surface from having a name that takes one; this is
+    what an author does anyway, and the identity suite is what catches it.
+    """
+
+    SESSION = "whoever-the-framework-said"
+
+    def invoke(self, request: CallRequest) -> Any:
+        from .suites import principal_named
+
+        action = Action(
+            name=request.action,
+            arguments=request.arguments,
+            principal=principal_named(self.SESSION),
+            resource=f"payment:{request.arguments.get('payment_id')}",
+            environment=request.control.environment,
+        )
+        return request.control.execute(
+            action, lambda: request.executor(**request.arguments), request.effect
+        )
+
+
+class IgnoresAuthority(Reference):
+    """Catches `AuthorityDenied` and returns a value.
+
+    Written by an author who read `AuthorityDenied(ActionDenied)` and concluded that authority
+    is advisory. It is not: a denial there is the action being denied, and it happens *before*
+    policy runs and before any human is asked (`v0.3 §4.3`). Distinct from `SwallowsDenial`
+    because the two catch different exceptions for different reasons, and a suite whose only
+    fixture failed it incidentally is a suite nothing is aimed at.
+    """
+
+    def invoke(self, request: CallRequest) -> Any:
+        try:
+            return super().invoke(request)
+        except AuthorityDenied:
+            return "committed"
+
+
+class InterruptsOnAllow(Reference):
+    """Routes every call through the interrupt, `APPROVE` or not: a human asked about an action
+    the policy allowed outright is a human who stops reading the queue."""
+
+    def invoke(self, request: CallRequest) -> Any:
+        self.interrupt.answer = request.answer
+        self.interrupt.interrupt(
+            PendingApproval(
+                request_id="apr_invented", action_id="act_invented", action=request.action,
+                action_hash="sha256:invented", arguments=dict(request.arguments), resource=None,
+                environment=request.control.environment, agent="?", user=None,
+                created_at=request.control._clock(), expires_at=request.control._clock(),
+            )
+        )
+        return self._call(request)
+
+
+class GrantsForItself(Reference):
+    """Writes the grant rather than returning an answer.
+
+    The fixture for the document's **second rule**. "Never a second approval path" is the
+    sentence a security reviewer reads first, and until this existed it was the one claim in
+    SPEC-v0.5 with no broken adapter behind it.
+    """
+
+    def invoke(self, request: CallRequest) -> Any:
+        self.interrupt.answer = request.answer
+        try:
+            return _unattended(request)(**request.arguments)
+        except ApprovalRequired as pending:
+            # The whole defect, in three lines: the adapter decides the human said yes, writes
+            # the grant with `ctrlrun approve`'s own call, and re-presents. The framework's
+            # primitive is never reached, so nobody was ever asked -- and every refusal the kit
+            # asserts is still refused, because the *kernel* is intact. Only the interrupt count
+            # tells them apart.
+            request.control.store.grant_approval(pending.request_id, "the-adapter")
+            with with_approval(pending.request_id):
+                return _unattended(request)(**request.arguments)
+
+
+class EchoesThePayload(Reference):
+    """Declares `carries_approved_arguments = True` and hands back `pending.arguments`.
+
+    The fixture for the document's **mutation check**. Handing back what you were just given
+    makes every comparison trivially pass: it is manufacturing the check, and it is the one way
+    to turn attribution into a lie about prevention. Until this existed, §3.4's claim had no
+    broken adapter behind it either.
+    """
+
+    def invoke(self, request: CallRequest) -> Any:
+        self.interrupt.answer = request.answer
+        self.interrupt.__class__ = _EchoingCourier
+        return self._call(request)
+
+
+class _EchoingCourier(Courier):
+    def interrupt(self, pending: PendingApproval) -> ApprovalAnswer:
+        self.calls.append(pending)
+        if self.answer is None:
+            raise AssertionError("interrupted when no human was expected")
+        return ApprovalAnswer(
+            granted=self.answer.granted,
+            approver=self.answer.approver,
+            approved_arguments=dict(pending.arguments),
+        )
+
+
+class CachesTheDecision(Reference):
+    """Memoizes the first call's result and returns it for the second, so a duplicate effect
+    never reaches the kernel that would have refused it."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._seen: dict[str, Any] = {}
+
+    def invoke(self, request: CallRequest) -> Any:
+        key = f"{request.action}:{request.effect}"
+        if key in self._seen:
+            return self._seen[key]
+        result = super().invoke(request)
+        self._seen[key] = result
+        return result
+
+
+#: Every fixture, and the suite each must fail (§5.4). Read by the kit's own tests, which is
+#: why it lives here rather than in them: a fixture added without a suite to fail is a fixture
+#: that proves nothing, and this mapping is what makes that a type error rather than an
+#: oversight.
+def _unattended(request: CallRequest) -> Any:
+    """`_protected`, but with `wait=False`: the adapter catches `ApprovalRequired` itself."""
+    return _protected(request, wait=False)
+
+
+BROKEN: dict[str, tuple[type[Reference], str]] = {
+    "never-executes": (NeverExecutes, "kernel"),
+    "swallows-not-executed": (SwallowsNotExecuted, "kernel"),
+    "swallows-denial": (SwallowsDenial, "kernel"),
+    "replays-approval": (ReplaysApproval, "kernel"),
+    "interrupts-on-allow": (InterruptsOnAllow, "kernel"),
+    "grants-for-itself": (GrantsForItself, "kernel"),
+    "ignores-authority": (IgnoresAuthority, "authority"),
+    "self-asserts-principal": (SelfAssertsPrincipal, "identity"),
+    "echoes-the-payload": (EchoesThePayload, "binding"),
+    "caches-the-decision": (CachesTheDecision, "duplicate"),
+}

--- a/src/ctrlrun/conformance/report.py
+++ b/src/ctrlrun/conformance/report.py
@@ -1,0 +1,163 @@
+"""What the kit reports. SPEC-v0.5 §5.2.
+
+`v0.4 §4.1`'s output rules, one level up: a denominator of **applicable** suites, an N/A that
+carries the reason that made it inapplicable, and no flag that folds one into the count.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Literal
+
+#: Why a report carries no suites at all. The only value, and it is not a failure of the
+#: adapter: SPEC-v0.5 §3.6 refuses an observing `Control` rather than reporting ten results
+#: about a configuration nobody deployed.
+REFUSED: Literal["refused"] = "refused"
+OK: Literal["ok"] = "ok"
+
+
+class SuiteStatus(StrEnum):
+    """`StrEnum` for `v0.1 §6.1`'s reason: these render into reports read by tools that never
+    imported CTRLRun, and `"SuiteStatus.PASS"` is not a status."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    NOT_APPLICABLE = "not_applicable"
+
+
+@dataclass(frozen=True)
+class CaseResult:
+    """One acceptance test, driven through the adapter."""
+
+    id: str
+    title: str
+    status: SuiteStatus
+    reason: str | None = None
+    detail: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.status is not SuiteStatus.PASS and not self.reason:
+            raise ValueError(
+                f"{self.id}: a {self.status} case must carry a reason. An N/A without one is an "
+                "N/A nobody can check, and a failure without one is a failure nobody can fix"
+            )
+
+
+@dataclass(frozen=True)
+class SuiteResult:
+    """One named group of cases, and what it came to."""
+
+    name: str
+    status: SuiteStatus
+    reason: str | None = None
+    cases: tuple[CaseResult, ...] = ()
+
+    @classmethod
+    def of(cls, name: str, cases: tuple[CaseResult, ...]) -> SuiteResult:
+        """A suite's status, derived from its cases and never set independently.
+
+        `FAIL` if any case failed. `NOT_APPLICABLE` only if **every** case is -- a suite with one
+        applicable case that passed is a pass, and reporting the whole suite N/A because part of
+        it could not run would hide the part that did.
+        """
+        failed = [case for case in cases if case.status is SuiteStatus.FAIL]
+        if failed:
+            return cls(name, SuiteStatus.FAIL, failed[0].reason, cases)
+        applicable = [case for case in cases if case.status is not SuiteStatus.NOT_APPLICABLE]
+        if not applicable:
+            reason = cases[0].reason if cases else "the suite has no cases"
+            return cls(name, SuiteStatus.NOT_APPLICABLE, reason, cases)
+        return cls(name, SuiteStatus.PASS, None, cases)
+
+
+@dataclass(frozen=True)
+class ConformanceReport:
+    """What `run()` returns (SPEC-v0.5 §5.2)."""
+
+    framework: str
+    status: Literal["ok", "refused"] = OK
+    reason: str | None = None
+    suites: tuple[SuiteResult, ...] = ()
+
+    @property
+    def applicable(self) -> tuple[SuiteResult, ...]:
+        return tuple(
+            suite for suite in self.suites if suite.status is not SuiteStatus.NOT_APPLICABLE
+        )
+
+    @property
+    def not_applicable(self) -> tuple[SuiteResult, ...]:
+        return tuple(suite for suite in self.suites if suite.status is SuiteStatus.NOT_APPLICABLE)
+
+    @property
+    def passed(self) -> tuple[SuiteResult, ...]:
+        return tuple(suite for suite in self.suites if suite.status is SuiteStatus.PASS)
+
+    @property
+    def ok(self) -> bool:
+        """Did every applicable suite pass, and was there at least one?
+
+        The second clause is the rule rather than a detail. A refused report has no suites and a
+        fully-inapplicable one has no denominator, and `0/0` reported as success is exactly the
+        false green `v0.4 §3.8` refuses by name -- the same defect as `6/6` with two of them
+        quietly uncounted, wearing the other costume.
+        """
+        if self.status != OK:
+            return False
+        applicable = self.applicable
+        return bool(applicable) and len(self.passed) == len(applicable)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "framework": self.framework,
+            "status": self.status,
+            "reason": self.reason,
+            "ok": self.ok,
+            "suites": [
+                {
+                    "name": suite.name,
+                    "status": str(suite.status),
+                    "reason": suite.reason,
+                    "cases": [
+                        {
+                            "id": case.id,
+                            "title": case.title,
+                            "status": str(case.status),
+                            "reason": case.reason,
+                            "detail": dict(case.detail),
+                        }
+                        for case in suite.cases
+                    ],
+                }
+                for suite in self.suites
+            ],
+        }
+
+    def to_text(self) -> str:
+        """`4/4 (1 not applicable)`, never `5/5`.
+
+        The N/A count is outside the fraction and never inside it, and each one names the reason
+        that made it inapplicable. There is no flag that folds one in.
+        """
+        if self.status != OK:
+            return f"{self.framework}: REFUSED - {self.reason}"
+        lines = []
+        for suite in self.suites:
+            mark = {
+                SuiteStatus.PASS: "PASS",
+                SuiteStatus.FAIL: "FAIL",
+                SuiteStatus.NOT_APPLICABLE: "N/A ",
+            }[suite.status]
+            reason = f"  - {suite.reason}" if suite.reason else ""
+            lines.append(f"  {mark}  {suite.name}{reason}")
+            for case in suite.cases:
+                if case.status is SuiteStatus.FAIL:
+                    lines.append(f"          {case.id} {case.title}: {case.reason}")
+        counted = len(self.applicable)
+        skipped = len(self.not_applicable)
+        tail = f" ({skipped} not applicable)" if skipped else ""
+        lines.append("")
+        lines.append(f"{self.framework}: {len(self.passed)}/{counted}{tail}")
+        return "\n".join(lines)

--- a/src/ctrlrun/conformance/suites.py
+++ b/src/ctrlrun/conformance/suites.py
@@ -35,6 +35,7 @@ from ..errors import (
     ActionDenied,
     AmbiguousEffect,
     ApprovalMismatch,
+    ApprovalTimeout,
     AuthorityDenied,
     DuplicateEffect,
     NotExecuted,
@@ -183,6 +184,17 @@ class Executor:
         return "committed"
 
 
+def unwrapped(interrupt: FrameworkInterrupt) -> FrameworkInterrupt:
+    """The adapter's own interrupt, however many proxies are around it.
+
+    A case builds more than one `World`, and each would otherwise wrap the previous wrapper --
+    so a count would be of the innermost proxy's calls rather than of the framework's.
+    """
+    while isinstance(interrupt, Watched):
+        interrupt = interrupt._inner
+    return interrupt
+
+
 class Watched:
     """The adapter's own interrupt, with a call count the kit can read.
 
@@ -199,18 +211,42 @@ class Watched:
     forbids would otherwise have been visible.
     """
 
+    #: The proxy's own attributes. Everything else belongs to the adapter's interrupt and is
+    #: forwarded, because the kit swaps this object in for that one: an adapter that sets state
+    #: on `self.interrupt` before invoking -- which the reference does, to hand the kit's answer
+    #: to its primitive -- must reach the real object and not the wrapper.
+    _OWN = frozenset({"_inner", "calls", "before"})
+
+    #: Declared so the type checker sees them: `__init__` sets them past `__setattr__`, and
+    #: everything else on this object is forwarded.
+    _inner: FrameworkInterrupt
+    calls: int
+    #: Run just before the adapter's primitive, where a case needs the world to change while a
+    #: human deliberates. The kit's only way into that interval, and T5 is what it is for.
+    before: Callable[[], None] | None
+
     def __init__(self, inner: FrameworkInterrupt) -> None:
-        self._inner = inner
-        self.calls = 0
-        # Copied rather than proxied: `FrameworkInterrupt` declares both as attributes, and a
-        # read-only property does not satisfy that. Both are declarations about the framework
-        # and neither changes after construction, so a copy is faithful -- and the copy is what
-        # `InterruptApprovalProvider` validates, so a broken declaration is still refused.
-        self.framework = inner.framework
-        self.carries_approved_arguments = inner.carries_approved_arguments
+        object.__setattr__(self, "_inner", unwrapped(inner))
+        object.__setattr__(self, "calls", 0)
+        object.__setattr__(self, "before", None)
+        # `framework` and `carries_approved_arguments` are **forwarded**, not copied. A copy
+        # would diverge from the adapter's own declaration the moment anything changed it, and
+        # the provider validates what it is handed -- so forwarding keeps one truth.
+
+    def __getattr__(self, name: str) -> Any:
+        # Reached only for names not found on the instance, so `_OWN` never lands here.
+        return getattr(self._inner, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in self._OWN:
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._inner, name, value)
 
     def interrupt(self, pending: PendingApproval) -> ApprovalAnswer:
         self.calls += 1
+        if self.before is not None:
+            self.before()
         return self._inner.interrupt(pending)
 
 
@@ -227,6 +263,14 @@ class World:
     ) -> None:
         self.clock = Clock()
         self.watched = Watched(adapter.interrupt)
+        # **Swapped in place**, not merely wired. Wiring the proxy into the provider counts
+        # only the calls that arrive through `wait()` -- and `wait()` is reached only on
+        # `ApprovalRequired`, which an `ALLOW` policy never raises. So an adapter that put an
+        # allowed call to a human by reaching its *own* primitive out of band was invisible,
+        # and the A1 case that forbids it was a negative test against behaviour the path
+        # already prevented. Replacing the attribute puts every route through the count.
+        # `run()` restores the original.
+        adapter.interrupt = self.watched
         self.store = InMemoryStateStore(clock=self.clock)
         policy = Policy.from_yaml(document, source="<conformance>")
         authority = (
@@ -436,6 +480,43 @@ def kernel_failed_permits_retry(adapter: ConformanceAdapter) -> CaseResult:
     return passed("T8", kernel_failed_permits_retry.title)
 
 
+@case("T5", "an approval answered after its expiry authorizes nothing")
+def kernel_expired_approval(adapter: ConformanceAdapter) -> CaseResult:
+    """`v0.1 §7` T5 driven through an adapter, which an earlier draft of §12.5 said was not
+    reachable through a single `invoke`. It is: the counting proxy the kit already wraps around
+    the adapter's primitive is the hook, and moving the kit's clock inside it reproduces
+    SPEC-v0.5 §2.4 step 5 exactly -- a human who deliberated past the request's own expiry.
+
+    It is an adapter case and not only a provider one, because what it asks is whether the
+    adapter lets `ApprovalTimeout` propagate or swallows it the way `swallows-denial` swallows
+    `ActionDenied`. An adapter that returned a value here would have executed nothing and told
+    its framework the refund went through.
+    """
+    world = World(adapter, APPROVE)
+    executor = Executor()
+    arguments = {"payment_id": "t5", "amount": 2000}
+    request = CallRequest(world.control, REFUND, arguments, "refund:t5", executor,
+                          answer=granted(arguments))
+    world.watched.before = lambda: world.clock.advance(timedelta(hours=1))
+
+    problem = expect("T5", kernel_expired_approval.title, lambda: adapter.invoke(request),
+                     ApprovalTimeout)
+    if problem:
+        return problem
+    if world.watched.calls != 1:
+        return failed("T5", kernel_expired_approval.title,
+                      f"the framework's primitive was reached {world.watched.calls} times, "
+                      "expected 1")
+    if executor.calls:
+        return failed("T5", kernel_expired_approval.title,
+                      f"an expired approval reached the executor {executor.calls} times")
+    if not world.pending():
+        return failed("T5", kernel_expired_approval.title,
+                      "the request was not left pending: an answer that arrived too late must "
+                      "not move the record a human could still be shown")
+    return passed("T5", kernel_expired_approval.title)
+
+
 @case("A1", "an allowed action is never put to a human")
 def kernel_no_interrupt_on_allow(adapter: ConformanceAdapter) -> CaseResult:
     """`request.answer is None` means no human is expected. The positive control for every
@@ -456,7 +537,10 @@ def kernel_no_interrupt_on_allow(adapter: ConformanceAdapter) -> CaseResult:
     if "APPROVAL_REQUESTED" in world.events() or world.watched.calls:
         return failed("A1", kernel_no_interrupt_on_allow.title,
                       f"the adapter put an action the policy allowed outright to a human "
-                      f"({world.watched.calls} interrupts)")
+                      f"({world.watched.calls} interrupts, "
+                      f"{world.events().count('APPROVAL_REQUESTED')} requests). A human asked "
+                      "about something nobody needed to approve is a human who stops reading "
+                      "the queue")
     return passed("A1", kernel_no_interrupt_on_allow.title)
 
 
@@ -668,7 +752,7 @@ def identity_no_principal(adapter: ConformanceAdapter) -> CaseResult:
     bare = Control(
         world.control.policy,
         world.store,
-        InterruptApprovalProvider(world.store, adapter.interrupt, clock=world.clock),
+        InterruptApprovalProvider(world.store, world.watched, clock=world.clock),
         clock=world.clock,
         environment="production",
     )
@@ -695,8 +779,8 @@ SUITES: Mapping[str, tuple[Case, ...]] = {
     #: exercised where it lives: at the provider (SPEC-v0.5 T129d, both halves) and in the
     #: kernel (`v0.1 §7` T5). Same treatment T2 and T3 get in §5.3.
     "kernel": (kernel_lost_response, kernel_duplicate_after_approval, kernel_unknown_action,
-               kernel_failed_permits_retry, kernel_no_interrupt_on_allow,
-               binding_matching_answer, binding_denial),
+               kernel_failed_permits_retry, kernel_expired_approval,
+               kernel_no_interrupt_on_allow, binding_matching_answer, binding_denial),
     #: `binding` is the mutation check **alone**, and that is why it is its own suite. Its
     #: control (B2) and the denial case (B3) live in `kernel`, because both run whatever the
     #: framework carries back -- and a suite containing them would report `pass` for an adapter
@@ -732,18 +816,25 @@ def run(adapter: ConformanceAdapter, deployment: Control | None = None) -> Confo
             "guarantees about a configuration nobody deployed (SPEC-v0.5 §3.6)",
         )
 
+    own = unwrapped(adapter.interrupt)
     results = []
-    for name, cases in SUITES.items():
-        outcomes = []
-        for item in cases:
-            try:
-                outcomes.append(item.body(adapter))
-            except BaseException as broke:
-                outcomes.append(
-                    failed(item.id, item.title,
-                           f"the case raised {type(broke).__name__}: {broke}")
-                )
-        results.append(SuiteResult.of(name, tuple(outcomes)))
+    try:
+        for name, cases in SUITES.items():
+            outcomes = []
+            for item in cases:
+                try:
+                    outcomes.append(item.body(adapter))
+                except BaseException as broke:
+                    outcomes.append(
+                        failed(item.id, item.title,
+                               f"the case raised {type(broke).__name__}: {broke}")
+                    )
+            results.append(SuiteResult.of(name, tuple(outcomes)))
+    finally:
+        # Each `World` swaps the counting proxy in for the run; the kit put it there, so the
+        # kit takes it out, whatever a case did on the way through. Leaving a test double
+        # bolted to an object the caller still holds is how a kit changes what it measured.
+        adapter.interrupt = own
     return ConformanceReport(framework=adapter.framework, suites=tuple(results))
 
 

--- a/src/ctrlrun/conformance/suites.py
+++ b/src/ctrlrun/conformance/suites.py
@@ -381,28 +381,40 @@ def expect(
 def kernel_lost_response(adapter: ConformanceAdapter) -> CaseResult:
     world = World(adapter, ALLOW)
     executor = Executor(TimeoutError("the response was lost"), None)
-    request = CallRequest(world.control, REFUND, {"payment_id": "t1", "amount": 2000},
-                          "refund:t1", executor)
+    request = CallRequest(
+        world.control, REFUND, {"payment_id": "t1", "amount": 2000}, "refund:t1", executor
+    )
 
-    problem = expect("T1", kernel_lost_response.title,
-                     lambda: adapter.invoke(request), TimeoutError)
+    problem = expect(
+        "T1", kernel_lost_response.title, lambda: adapter.invoke(request), TimeoutError
+    )
     if problem:
         return problem
     if executor.calls != 1:
-        return failed("T1", kernel_lost_response.title,
-                      f"the executor ran {executor.calls} times on the first attempt, expected 1")
+        return failed(
+            "T1",
+            kernel_lost_response.title,
+            f"the executor ran {executor.calls} times on the first attempt, expected 1",
+        )
 
-    problem = expect("T1", kernel_lost_response.title, lambda: adapter.invoke(request),
-                     AmbiguousEffect)
+    problem = expect(
+        "T1", kernel_lost_response.title, lambda: adapter.invoke(request), AmbiguousEffect
+    )
     if problem:
         return problem
     if executor.calls != 1:
-        return failed("T1", kernel_lost_response.title,
-                      f"the retry reached the executor: {executor.calls} calls, expected 1")
+        return failed(
+            "T1",
+            kernel_lost_response.title,
+            f"the retry reached the executor: {executor.calls} calls, expected 1",
+        )
     record = world.store.get_effect("refund:t1")
     if record is None or str(record.state) != "ambiguous":
-        return failed("T1", kernel_lost_response.title,
-                      f"the effect is {record and record.state}, expected ambiguous")
+        return failed(
+            "T1",
+            kernel_lost_response.title,
+            f"the effect is {record and record.state}, expected ambiguous",
+        )
     return passed("T1", kernel_lost_response.title)
 
 
@@ -411,25 +423,39 @@ def kernel_duplicate_after_approval(adapter: ConformanceAdapter) -> CaseResult:
     world = World(adapter, APPROVE)
     executor = Executor()
     arguments = {"payment_id": "t4", "amount": 2000}
-    request = CallRequest(world.control, REFUND, arguments, "refund:t4", executor,
-                          answer=granted(arguments))
+    request = CallRequest(
+        world.control, REFUND, arguments, "refund:t4", executor, answer=granted(arguments)
+    )
 
     adapter.invoke(request)
     if executor.calls != 1:
-        return failed("T4", kernel_duplicate_after_approval.title,
-                      f"the approved call ran {executor.calls} times, expected 1")
+        return failed(
+            "T4",
+            kernel_duplicate_after_approval.title,
+            f"the approved call ran {executor.calls} times, expected 1",
+        )
     if world.watched.calls != 1:
-        return failed("T4", kernel_duplicate_after_approval.title,
-                      f"the framework's primitive was reached {world.watched.calls} times, "
-                      "expected 1: an approval nobody was asked for is not an approval")
+        return failed(
+            "T4",
+            kernel_duplicate_after_approval.title,
+            f"the framework's primitive was reached {world.watched.calls} times, "
+            "expected 1: an approval nobody was asked for is not an approval",
+        )
 
-    problem = expect("T4", kernel_duplicate_after_approval.title,
-                     lambda: adapter.invoke(request), DuplicateEffect)
+    problem = expect(
+        "T4",
+        kernel_duplicate_after_approval.title,
+        lambda: adapter.invoke(request),
+        DuplicateEffect,
+    )
     if problem:
         return problem
     if executor.calls != 1:
-        return failed("T4", kernel_duplicate_after_approval.title,
-                      f"the second attempt reached the executor: {executor.calls} calls")
+        return failed(
+            "T4",
+            kernel_duplicate_after_approval.title,
+            f"the second attempt reached the executor: {executor.calls} calls",
+        )
     return passed("T4", kernel_duplicate_after_approval.title)
 
 
@@ -437,19 +463,31 @@ def kernel_duplicate_after_approval(adapter: ConformanceAdapter) -> CaseResult:
 def kernel_unknown_action(adapter: ConformanceAdapter) -> CaseResult:
     world = World(adapter, EMPTY)
     executor = Executor()
-    request = CallRequest(world.control, REFUND, {"payment_id": "t6", "amount": 1},
-                          "refund:t6", executor)
+    request = CallRequest(
+        world.control, REFUND, {"payment_id": "t6", "amount": 1}, "refund:t6", executor
+    )
 
-    problem = expect("T6", kernel_unknown_action.title, lambda: adapter.invoke(request),
-                     ActionDenied, "unknown_action")
+    problem = expect(
+        "T6",
+        kernel_unknown_action.title,
+        lambda: adapter.invoke(request),
+        ActionDenied,
+        "unknown_action",
+    )
     if problem:
         return problem
     if executor.calls:
-        return failed("T6", kernel_unknown_action.title,
-                      f"a denied action reached the executor {executor.calls} times")
+        return failed(
+            "T6",
+            kernel_unknown_action.title,
+            f"a denied action reached the executor {executor.calls} times",
+        )
     if [receipt.result for receipt in world.receipts()] != ["denied"]:
-        return failed("T6", kernel_unknown_action.title,
-                      f"receipts are {[r.result for r in world.receipts()]}, expected ['denied']")
+        return failed(
+            "T6",
+            kernel_unknown_action.title,
+            f"receipts are {[r.result for r in world.receipts()]}, expected ['denied']",
+        )
     return passed("T6", kernel_unknown_action.title)
 
 
@@ -457,26 +495,37 @@ def kernel_unknown_action(adapter: ConformanceAdapter) -> CaseResult:
 def kernel_failed_permits_retry(adapter: ConformanceAdapter) -> CaseResult:
     world = World(adapter, ALLOW)
     executor = Executor(NotExecuted("the remote rejected it before acting"), None)
-    request = CallRequest(world.control, REFUND, {"payment_id": "t8", "amount": 2000},
-                          "refund:t8", executor)
+    request = CallRequest(
+        world.control, REFUND, {"payment_id": "t8", "amount": 2000}, "refund:t8", executor
+    )
 
-    problem = expect("T8", kernel_failed_permits_retry.title,
-                     lambda: adapter.invoke(request), NotExecuted)
+    problem = expect(
+        "T8", kernel_failed_permits_retry.title, lambda: adapter.invoke(request), NotExecuted
+    )
     if problem:
         return problem
 
     try:
         adapter.invoke(request)
     except BaseException as refused:
-        return failed("T8", kernel_failed_permits_retry.title,
-                      f"a FAILED effect refused the retry with {type(refused).__name__}: {refused}")
+        return failed(
+            "T8",
+            kernel_failed_permits_retry.title,
+            f"a FAILED effect refused the retry with {type(refused).__name__}: {refused}",
+        )
     if executor.calls != 2:
-        return failed("T8", kernel_failed_permits_retry.title,
-                      f"the executor ran {executor.calls} times, expected 2")
+        return failed(
+            "T8",
+            kernel_failed_permits_retry.title,
+            f"the executor ran {executor.calls} times, expected 2",
+        )
     record = world.store.get_effect("refund:t8")
     if record is None or record.attempt != 2:
-        return failed("T8", kernel_failed_permits_retry.title,
-                      f"attempt is {record and record.attempt}, expected 2")
+        return failed(
+            "T8",
+            kernel_failed_permits_retry.title,
+            f"attempt is {record and record.attempt}, expected 2",
+        )
     return passed("T8", kernel_failed_permits_retry.title)
 
 
@@ -495,25 +544,35 @@ def kernel_expired_approval(adapter: ConformanceAdapter) -> CaseResult:
     world = World(adapter, APPROVE)
     executor = Executor()
     arguments = {"payment_id": "t5", "amount": 2000}
-    request = CallRequest(world.control, REFUND, arguments, "refund:t5", executor,
-                          answer=granted(arguments))
+    request = CallRequest(
+        world.control, REFUND, arguments, "refund:t5", executor, answer=granted(arguments)
+    )
     world.watched.before = lambda: world.clock.advance(timedelta(hours=1))
 
-    problem = expect("T5", kernel_expired_approval.title, lambda: adapter.invoke(request),
-                     ApprovalTimeout)
+    problem = expect(
+        "T5", kernel_expired_approval.title, lambda: adapter.invoke(request), ApprovalTimeout
+    )
     if problem:
         return problem
     if world.watched.calls != 1:
-        return failed("T5", kernel_expired_approval.title,
-                      f"the framework's primitive was reached {world.watched.calls} times, "
-                      "expected 1")
+        return failed(
+            "T5",
+            kernel_expired_approval.title,
+            f"the framework's primitive was reached {world.watched.calls} times, expected 1",
+        )
     if executor.calls:
-        return failed("T5", kernel_expired_approval.title,
-                      f"an expired approval reached the executor {executor.calls} times")
+        return failed(
+            "T5",
+            kernel_expired_approval.title,
+            f"an expired approval reached the executor {executor.calls} times",
+        )
     if not world.pending():
-        return failed("T5", kernel_expired_approval.title,
-                      "the request was not left pending: an answer that arrived too late must "
-                      "not move the record a human could still be shown")
+        return failed(
+            "T5",
+            kernel_expired_approval.title,
+            "the request was not left pending: an answer that arrived too late must "
+            "not move the record a human could still be shown",
+        )
     return passed("T5", kernel_expired_approval.title)
 
 
@@ -523,24 +582,34 @@ def kernel_no_interrupt_on_allow(adapter: ConformanceAdapter) -> CaseResult:
     approval case: without it, an adapter that interrupts on everything passes them all."""
     world = World(adapter, ALLOW)
     executor = Executor()
-    request = CallRequest(world.control, REFUND, {"payment_id": "a1", "amount": 2000},
-                          "refund:a1", executor)
+    request = CallRequest(
+        world.control, REFUND, {"payment_id": "a1", "amount": 2000}, "refund:a1", executor
+    )
 
     try:
         adapter.invoke(request)
     except BaseException as raised:
-        return failed("A1", kernel_no_interrupt_on_allow.title,
-                      f"an allowed action raised {type(raised).__name__}: {raised}")
+        return failed(
+            "A1",
+            kernel_no_interrupt_on_allow.title,
+            f"an allowed action raised {type(raised).__name__}: {raised}",
+        )
     if executor.calls != 1:
-        return failed("A1", kernel_no_interrupt_on_allow.title,
-                      f"the executor ran {executor.calls} times, expected 1")
+        return failed(
+            "A1",
+            kernel_no_interrupt_on_allow.title,
+            f"the executor ran {executor.calls} times, expected 1",
+        )
     if "APPROVAL_REQUESTED" in world.events() or world.watched.calls:
-        return failed("A1", kernel_no_interrupt_on_allow.title,
-                      f"the adapter put an action the policy allowed outright to a human "
-                      f"({world.watched.calls} interrupts, "
-                      f"{world.events().count('APPROVAL_REQUESTED')} requests). A human asked "
-                      "about something nobody needed to approve is a human who stops reading "
-                      "the queue")
+        return failed(
+            "A1",
+            kernel_no_interrupt_on_allow.title,
+            f"the adapter put an action the policy allowed outright to a human "
+            f"({world.watched.calls} interrupts, "
+            f"{world.events().count('APPROVAL_REQUESTED')} requests). A human asked "
+            "about something nobody needed to approve is a human who stops reading "
+            "the queue",
+        )
     return passed("A1", kernel_no_interrupt_on_allow.title)
 
 
@@ -560,22 +629,37 @@ def binding_mutated_answer(adapter: ConformanceAdapter) -> CaseResult:
     world = World(adapter, APPROVE)
     executor = Executor()
     request = CallRequest(
-        world.control, REFUND, {"payment_id": "b1", "amount": 2000}, "refund:b1", executor,
+        world.control,
+        REFUND,
+        {"payment_id": "b1", "amount": 2000},
+        "refund:b1",
+        executor,
         # The human answered about 500. The action proposes 2000.
         answer=granted({"payment_id": "b1", "amount": 500}),
     )
 
-    problem = expect("B1", binding_mutated_answer.title, lambda: adapter.invoke(request),
-                     ApprovalMismatch, "mismatch")
+    problem = expect(
+        "B1",
+        binding_mutated_answer.title,
+        lambda: adapter.invoke(request),
+        ApprovalMismatch,
+        "mismatch",
+    )
     if problem:
         return problem
     if executor.calls:
-        return failed("B1", binding_mutated_answer.title,
-                      f"a mutated answer reached the executor {executor.calls} times")
+        return failed(
+            "B1",
+            binding_mutated_answer.title,
+            f"a mutated answer reached the executor {executor.calls} times",
+        )
     if not world.pending():
-        return failed("B1", binding_mutated_answer.title,
-                      "the refused request was not left pending: a mutated answer must leave the "
-                      "approval the human actually saw still grantable")
+        return failed(
+            "B1",
+            binding_mutated_answer.title,
+            "the refused request was not left pending: a mutated answer must leave the "
+            "approval the human actually saw still grantable",
+        )
     return passed("B1", binding_mutated_answer.title)
 
 
@@ -585,25 +669,38 @@ def binding_matching_answer(adapter: ConformanceAdapter) -> CaseResult:
     world = World(adapter, APPROVE)
     executor = Executor()
     arguments = {"payment_id": "b2", "amount": 2000}
-    request = CallRequest(world.control, REFUND, arguments, "refund:b2", executor,
-                          answer=granted(arguments))
+    request = CallRequest(
+        world.control, REFUND, arguments, "refund:b2", executor, answer=granted(arguments)
+    )
 
     try:
         adapter.invoke(request)
     except BaseException as raised:
-        return failed("B2", binding_matching_answer.title,
-                      f"a matching answer was refused with {type(raised).__name__}: {raised}")
+        return failed(
+            "B2",
+            binding_matching_answer.title,
+            f"a matching answer was refused with {type(raised).__name__}: {raised}",
+        )
     if executor.calls != 1:
-        return failed("B2", binding_matching_answer.title,
-                      f"the executor ran {executor.calls} times, expected 1")
+        return failed(
+            "B2",
+            binding_matching_answer.title,
+            f"the executor ran {executor.calls} times, expected 1",
+        )
     if world.watched.calls != 1:
-        return failed("B2", binding_matching_answer.title,
-                      f"the framework's primitive was reached {world.watched.calls} times, "
-                      "expected 1: an adapter that granted for itself never asked anybody")
+        return failed(
+            "B2",
+            binding_matching_answer.title,
+            f"the framework's primitive was reached {world.watched.calls} times, "
+            "expected 1: an adapter that granted for itself never asked anybody",
+        )
     approvers = [receipt.approver for receipt in world.receipts()]
     if approvers != [APPROVER]:
-        return failed("B2", binding_matching_answer.title,
-                      f"the receipt names {approvers}, expected [{APPROVER!r}]")
+        return failed(
+            "B2",
+            binding_matching_answer.title,
+            f"the receipt names {approvers}, expected [{APPROVER!r}]",
+        )
     return passed("B2", binding_matching_answer.title)
 
 
@@ -612,7 +709,11 @@ def binding_denial(adapter: ConformanceAdapter) -> CaseResult:
     world = World(adapter, APPROVE)
     executor = Executor()
     request = CallRequest(
-        world.control, REFUND, {"payment_id": "b3", "amount": 2000}, "refund:b3", executor,
+        world.control,
+        REFUND,
+        {"payment_id": "b3", "amount": 2000},
+        "refund:b3",
+        executor,
         answer=ApprovalAnswer(granted=False, approver=APPROVER),
     )
 
@@ -620,15 +721,23 @@ def binding_denial(adapter: ConformanceAdapter) -> CaseResult:
     if problem:
         return problem
     if executor.calls:
-        return failed("B3", binding_denial.title,
-                      f"a denied action reached the executor {executor.calls} times")
+        return failed(
+            "B3",
+            binding_denial.title,
+            f"a denied action reached the executor {executor.calls} times",
+        )
     if world.watched.calls != 1:
-        return failed("B3", binding_denial.title,
-                      f"the framework's primitive was reached {world.watched.calls} times, "
-                      "expected 1")
+        return failed(
+            "B3",
+            binding_denial.title,
+            f"the framework's primitive was reached {world.watched.calls} times, expected 1",
+        )
     if "APPROVAL_DENIED" not in world.events():
-        return failed("B3", binding_denial.title,
-                      "no APPROVAL_DENIED: a human's no is an answer, and it belongs in the log")
+        return failed(
+            "B3",
+            binding_denial.title,
+            "no APPROVAL_DENIED: a human's no is an answer, and it belongs in the log",
+        )
     return passed("B3", binding_denial.title)
 
 
@@ -643,23 +752,28 @@ def duplicate_one_commit(adapter: ConformanceAdapter) -> CaseResult:
     that cached a decision, reused a request id, or memoized a receipt."""
     world = World(adapter, ALLOW)
     executor = Executor()
-    first = CallRequest(world.control, REFUND, {"payment_id": "d1", "amount": 2000},
-                        "refund:d1", executor)
-    second = CallRequest(world.control, REFUND, {"payment_id": "d1", "amount": 2000},
-                         "refund:d1", executor)
+    first = CallRequest(
+        world.control, REFUND, {"payment_id": "d1", "amount": 2000}, "refund:d1", executor
+    )
+    second = CallRequest(
+        world.control, REFUND, {"payment_id": "d1", "amount": 2000}, "refund:d1", executor
+    )
 
     adapter.invoke(first)
-    problem = expect("D1", duplicate_one_commit.title, lambda: adapter.invoke(second),
-                     DuplicateEffect)
+    problem = expect(
+        "D1", duplicate_one_commit.title, lambda: adapter.invoke(second), DuplicateEffect
+    )
     if problem:
         return problem
     if executor.calls != 1:
-        return failed("D1", duplicate_one_commit.title,
-                      f"the executor ran {executor.calls} times, expected 1")
+        return failed(
+            "D1", duplicate_one_commit.title, f"the executor ran {executor.calls} times, expected 1"
+        )
     committed = [receipt for receipt in world.receipts() if receipt.result == "committed"]
     if len(committed) != 1:
-        return failed("D1", duplicate_one_commit.title,
-                      f"{len(committed)} committed receipts, expected 1")
+        return failed(
+            "D1", duplicate_one_commit.title, f"{len(committed)} committed receipts, expected 1"
+        )
     return passed("D1", duplicate_one_commit.title)
 
 
@@ -670,20 +784,32 @@ def duplicate_one_commit(adapter: ConformanceAdapter) -> CaseResult:
 def authority_no_grant(adapter: ConformanceAdapter) -> CaseResult:
     world = World(adapter, NO_GRANT)
     executor = Executor()
-    request = CallRequest(world.control, REFUND, {"payment_id": "a66", "amount": 2000},
-                          "refund:a66", executor)
+    request = CallRequest(
+        world.control, REFUND, {"payment_id": "a66", "amount": 2000}, "refund:a66", executor
+    )
 
-    problem = expect("T66", authority_no_grant.title, lambda: adapter.invoke(request),
-                     AuthorityDenied, "no_authority")
+    problem = expect(
+        "T66",
+        authority_no_grant.title,
+        lambda: adapter.invoke(request),
+        AuthorityDenied,
+        "no_authority",
+    )
     if problem:
         return problem
     if executor.calls:
-        return failed("T66", authority_no_grant.title,
-                      f"an unauthorized action reached the executor {executor.calls} times")
+        return failed(
+            "T66",
+            authority_no_grant.title,
+            f"an unauthorized action reached the executor {executor.calls} times",
+        )
     if "POLICY_EVALUATED" in world.events():
-        return failed("T66", authority_no_grant.title,
-                      "POLICY_EVALUATED after an authority denial: authority runs first and a "
-                      "denial there skips policy (v0.3 §4.3)")
+        return failed(
+            "T66",
+            authority_no_grant.title,
+            "POLICY_EVALUATED after an authority denial: authority runs first and a "
+            "denial there skips policy (v0.3 §4.3)",
+        )
     return passed("T66", authority_no_grant.title)
 
 
@@ -691,16 +817,25 @@ def authority_no_grant(adapter: ConformanceAdapter) -> CaseResult:
 def authority_expired(adapter: ConformanceAdapter) -> CaseResult:
     world = World(adapter, EXPIRED_GRANT)
     executor = Executor()
-    request = CallRequest(world.control, REFUND, {"payment_id": "a70", "amount": 2000},
-                          "refund:a70", executor)
+    request = CallRequest(
+        world.control, REFUND, {"payment_id": "a70", "amount": 2000}, "refund:a70", executor
+    )
 
-    problem = expect("T70", authority_expired.title, lambda: adapter.invoke(request),
-                     AuthorityDenied, "authority_expired")
+    problem = expect(
+        "T70",
+        authority_expired.title,
+        lambda: adapter.invoke(request),
+        AuthorityDenied,
+        "authority_expired",
+    )
     if problem:
         return problem
     if executor.calls:
-        return failed("T70", authority_expired.title,
-                      f"an expired grant reached the executor {executor.calls} times")
+        return failed(
+            "T70",
+            authority_expired.title,
+            f"an expired grant reached the executor {executor.calls} times",
+        )
     return passed("T70", authority_expired.title)
 
 
@@ -708,20 +843,30 @@ def authority_expired(adapter: ConformanceAdapter) -> CaseResult:
 def authority_leaves_no_request(adapter: ConformanceAdapter) -> CaseResult:
     world = World(adapter, APPROVE_WITHOUT_AUTHORITY)
     executor = Executor()
-    request = CallRequest(world.control, REFUND, {"payment_id": "a74", "amount": 2000},
-                          "refund:a74", executor, answer=granted({"payment_id": "a74",
-                                                                  "amount": 2000}))
+    request = CallRequest(
+        world.control,
+        REFUND,
+        {"payment_id": "a74", "amount": 2000},
+        "refund:a74",
+        executor,
+        answer=granted({"payment_id": "a74", "amount": 2000}),
+    )
 
-    problem = expect("T74", authority_leaves_no_request.title, lambda: adapter.invoke(request),
-                     AuthorityDenied)
+    problem = expect(
+        "T74", authority_leaves_no_request.title, lambda: adapter.invoke(request), AuthorityDenied
+    )
     if problem:
         return problem
     if world.pending():
-        return failed("T74", authority_leaves_no_request.title,
-                      "a human was left a request for an action that could never run")
+        return failed(
+            "T74",
+            authority_leaves_no_request.title,
+            "a human was left a request for an action that could never run",
+        )
     if "APPROVAL_REQUESTED" in world.events():
-        return failed("T74", authority_leaves_no_request.title,
-                      "APPROVAL_REQUESTED after an authority denial")
+        return failed(
+            "T74", authority_leaves_no_request.title, "APPROVAL_REQUESTED after an authority denial"
+        )
     return passed("T74", authority_leaves_no_request.title)
 
 
@@ -732,15 +877,19 @@ def authority_leaves_no_request(adapter: ConformanceAdapter) -> CaseResult:
 def identity_provider_wins(adapter: ConformanceAdapter) -> CaseResult:
     world = World(adapter, ALLOW, principal="the-provider-said-this")
     executor = Executor()
-    request = CallRequest(world.control, REFUND, {"payment_id": "i63", "amount": 2000},
-                          "refund:i63", executor)
+    request = CallRequest(
+        world.control, REFUND, {"payment_id": "i63", "amount": 2000}, "refund:i63", executor
+    )
 
     adapter.invoke(request)
     agents = [receipt.principal.agent for receipt in world.receipts()]
     if agents != ["the-provider-said-this"]:
-        return failed("T63", identity_provider_wins.title,
-                      f"receipts name {agents}, expected ['the-provider-said-this']: an adapter "
-                      "sees the principal and never supplies one (SPEC-v0.5 §4.2)")
+        return failed(
+            "T63",
+            identity_provider_wins.title,
+            f"receipts name {agents}, expected ['the-provider-said-this']: an adapter "
+            "sees the principal and never supplies one (SPEC-v0.5 §4.2)",
+        )
     return passed("T63", identity_provider_wins.title)
 
 
@@ -757,16 +906,25 @@ def identity_no_principal(adapter: ConformanceAdapter) -> CaseResult:
         environment="production",
     )
     executor = Executor()
-    request = CallRequest(bare, REFUND, {"payment_id": "i60", "amount": 2000},
-                          "refund:i60", executor)
+    request = CallRequest(
+        bare, REFUND, {"payment_id": "i60", "amount": 2000}, "refund:i60", executor
+    )
 
-    problem = expect("T60", identity_no_principal.title, lambda: adapter.invoke(request),
-                     ActionDenied, "no_principal")
+    problem = expect(
+        "T60",
+        identity_no_principal.title,
+        lambda: adapter.invoke(request),
+        ActionDenied,
+        "no_principal",
+    )
     if problem:
         return problem
     if executor.calls:
-        return failed("T60", identity_no_principal.title,
-                      f"an unattributed action reached the executor {executor.calls} times")
+        return failed(
+            "T60",
+            identity_no_principal.title,
+            f"an unattributed action reached the executor {executor.calls} times",
+        )
     return passed("T60", identity_no_principal.title)
 
 
@@ -778,9 +936,16 @@ SUITES: Mapping[str, tuple[Case, ...]] = {
     #: that the kit can reach without a hook into the adapter's own primitive. Expiry is
     #: exercised where it lives: at the provider (SPEC-v0.5 T129d, both halves) and in the
     #: kernel (`v0.1 §7` T5). Same treatment T2 and T3 get in §5.3.
-    "kernel": (kernel_lost_response, kernel_duplicate_after_approval, kernel_unknown_action,
-               kernel_failed_permits_retry, kernel_expired_approval,
-               kernel_no_interrupt_on_allow, binding_matching_answer, binding_denial),
+    "kernel": (
+        kernel_lost_response,
+        kernel_duplicate_after_approval,
+        kernel_unknown_action,
+        kernel_failed_permits_retry,
+        kernel_expired_approval,
+        kernel_no_interrupt_on_allow,
+        binding_matching_answer,
+        binding_denial,
+    ),
     #: `binding` is the mutation check **alone**, and that is why it is its own suite. Its
     #: control (B2) and the denial case (B3) live in `kernel`, because both run whatever the
     #: framework carries back -- and a suite containing them would report `pass` for an adapter
@@ -826,8 +991,9 @@ def run(adapter: ConformanceAdapter, deployment: Control | None = None) -> Confo
                     outcomes.append(item.body(adapter))
                 except BaseException as broke:
                     outcomes.append(
-                        failed(item.id, item.title,
-                               f"the case raised {type(broke).__name__}: {broke}")
+                        failed(
+                            item.id, item.title, f"the case raised {type(broke).__name__}: {broke}"
+                        )
                     )
             results.append(SuiteResult.of(name, tuple(outcomes)))
     finally:

--- a/src/ctrlrun/conformance/suites.py
+++ b/src/ctrlrun/conformance/suites.py
@@ -1,0 +1,753 @@
+"""The suites, and what an adapter hands the kit. SPEC-v0.5 §5.2, §5.3.
+
+Every case drives **one** protected call through the adapter's own framework and asserts what
+the kernel would have done. The kit supplies the policy, the store, the `Control` and the
+executor; the adapter supplies the framework and the courier that carries a human's answer
+back. That division is the whole test: an adapter's only contribution to an action's fate
+should be *where the human answers*, and a case that came out differently through an adapter
+than through `@protect` is the finding.
+
+Two things every case does, and both are `v0.4 §1.3`'s positive-control rule one level up:
+
+- **It counts executor calls.** "The second attempt was refused" is satisfied just as well by
+  an adapter that never reached the executor at all, and that adapter passes every refusal.
+- **It names the exception and its reason**, not merely that something was raised. A guard
+  that can only be distinguished from a later guard by reading the source is documentation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol, runtime_checkable
+
+from ..action import Principal
+from ..adapter import (
+    ApprovalAnswer,
+    FrameworkInterrupt,
+    InterruptApprovalProvider,
+    PendingApproval,
+)
+from ..authority import Authority
+from ..control import Control
+from ..errors import (
+    ActionDenied,
+    AmbiguousEffect,
+    ApprovalMismatch,
+    AuthorityDenied,
+    DuplicateEffect,
+    NotExecuted,
+)
+from ..identity import StaticIdentityProvider
+from ..policy import OBSERVE, Policy
+from ..state import InMemoryStateStore
+from .report import CaseResult, ConformanceReport, SuiteResult, SuiteStatus
+
+REFUND = "stripe.refund"
+AGENT = "conformance-agent"
+APPROVER = "conformance:human"
+
+#: A fixed instant, so a case that turns on expiry is exact rather than nearly exact. Every
+#: `Control` the kit builds runs on a clock only the kit moves: a waiting test bound by wall
+#: time is a test that hangs CI instead of failing.
+T0 = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+
+ALLOW = """
+schema: ctrlrun.policy/v1
+actions:
+  stripe.refund:
+    decision: allow
+"""
+
+APPROVE = """
+schema: ctrlrun.policy/v1
+actions:
+  stripe.refund:
+    decision: approve
+"""
+
+EMPTY = """
+schema: ctrlrun.policy/v1
+actions: {}
+"""
+
+NO_GRANT = """
+schema: ctrlrun.policy/v3
+authority:
+  grants:
+    - id: somebody-else
+      subject: {agent: somebody-else}
+      actions: ["stripe.*"]
+      resources: ["payment:*"]
+      environments: [production]
+actions:
+  stripe.refund:
+    decision: allow
+"""
+
+EXPIRED_GRANT = """
+schema: ctrlrun.policy/v3
+authority:
+  grants:
+    - id: lapsed
+      subject: {agent: conformance-agent}
+      actions: ["stripe.*"]
+      resources: ["payment:*"]
+      environments: [production]
+      expires_at: 2025-01-01T00:00:00+00:00
+actions:
+  stripe.refund:
+    decision: allow
+"""
+
+APPROVE_WITHOUT_AUTHORITY = """
+schema: ctrlrun.policy/v3
+authority:
+  grants:
+    - id: somebody-else
+      subject: {agent: somebody-else}
+      actions: ["stripe.*"]
+      resources: ["payment:*"]
+      environments: [production]
+actions:
+  stripe.refund:
+    decision: approve
+"""
+
+
+@dataclass(frozen=True)
+class CallRequest:
+    """One protected call the kit wants driven through the framework (SPEC-v0.5 §5.2)."""
+
+    control: Control
+    action: str
+    arguments: Mapping[str, Any]
+    effect: str | None
+    executor: Callable[..., Any]
+    #: What the human says if the framework interrupts. `None` means **no human is expected**:
+    #: an adapter whose framework interrupts anyway has asked about something the policy allowed
+    #: outright, and the case fails.
+    answer: ApprovalAnswer | None = None
+
+
+@runtime_checkable
+class ConformanceAdapter(Protocol):
+    """What an adapter implements so the suites can drive it (SPEC-v0.5 §5.2).
+
+    `interrupt` is the same `FrameworkInterrupt` the operator would wire into a
+    `InterruptApprovalProvider`, and the kit wires it into the `Control` it hands back in
+    `CallRequest.control` -- the kit plays operator here, because §2.3 says an adapter never
+    constructs a `Control` and a kit that let it would be testing a shape that does not ship.
+
+    `invoke` runs **one** protected call end to end through the framework and returns the
+    executor's value. Every CTRLRun exception propagates: the kit asserts on them by type and by
+    `reason`, so an adapter that swallowed one fails rather than passing quietly.
+
+    The adapter is a **courier** for `request.answer`: it carries the kit's answer to its
+    framework's primitive and the primitive's reply back, unchanged. Substituting one is
+    `fixtures.EchoesThePayload`, and the binding suite is what catches it.
+    """
+
+    framework: str
+    interrupt: FrameworkInterrupt
+
+    def invoke(self, request: CallRequest) -> Any: ...
+
+
+class Clock:
+    """A clock only the kit moves: a waiting path bound by wall time hangs CI instead of failing."""
+
+    def __init__(self) -> None:
+        self.now = T0
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, delta: timedelta) -> None:
+        self.now += delta
+
+
+class Executor:
+    """The kit's function, and the count that makes every refusal mean something."""
+
+    def __init__(self, *behaviour: BaseException | None) -> None:
+        self._behaviour = list(behaviour) or [None]
+        self.calls = 0
+
+    def __call__(self, **arguments: Any) -> str:
+        self.calls += 1
+        step = self._behaviour[min(self.calls - 1, len(self._behaviour) - 1)]
+        if step is not None:
+            raise step
+        return "committed"
+
+
+class Watched:
+    """The adapter's own interrupt, with a call count the kit can read.
+
+    It exists because of a fixture. `GrantsForItself` wrote the grant before `@protect` ever
+    reached `wait()`, so the provider found the record already `granted`, returned it, and the
+    framework's primitive was never called -- and every suite passed. The provider is right to
+    return an already-granted record (`ctrlrun approve` grants out of band, and so does a
+    webhook, and `v0.1 §4.3` says a provider never invents an answer), so the hole is not
+    there: it is that a suite asserting a *refusal* cannot tell "the human said no through the
+    framework" from "the framework was never asked".
+
+    So the kit counts. A case that expects a human asserts the count is 1, and one that expects
+    none asserts it is 0. `v0.4 §1.3` again: a refusal proves nothing unless the thing it
+    forbids would otherwise have been visible.
+    """
+
+    def __init__(self, inner: FrameworkInterrupt) -> None:
+        self._inner = inner
+        self.calls = 0
+        # Copied rather than proxied: `FrameworkInterrupt` declares both as attributes, and a
+        # read-only property does not satisfy that. Both are declarations about the framework
+        # and neither changes after construction, so a copy is faithful -- and the copy is what
+        # `InterruptApprovalProvider` validates, so a broken declaration is still refused.
+        self.framework = inner.framework
+        self.carries_approved_arguments = inner.carries_approved_arguments
+
+    def interrupt(self, pending: PendingApproval) -> ApprovalAnswer:
+        self.calls += 1
+        return self._inner.interrupt(pending)
+
+
+class World:
+    """One scratch deployment: a store, a clock and a `Control` wired to the adapter.
+
+    Scratch, always. The kit never touches an operator's store, for the reason `v0.4 §3.5`
+    gives about verify: a kit that reserved a real effect key would be a defect of exactly the
+    class it exists to find.
+    """
+
+    def __init__(
+        self, adapter: ConformanceAdapter, document: str, *, principal: str = AGENT
+    ) -> None:
+        self.clock = Clock()
+        self.watched = Watched(adapter.interrupt)
+        self.store = InMemoryStateStore(clock=self.clock)
+        policy = Policy.from_yaml(document, source="<conformance>")
+        authority = (
+            Authority.from_yaml(document, source="<conformance>")
+            if "authority:" in document
+            else None
+        )
+        self.control = Control(
+            policy,
+            self.store,
+            InterruptApprovalProvider(self.store, self.watched, clock=self.clock),
+            clock=self.clock,
+            authority=authority,
+            identity=StaticIdentityProvider(principal),
+            environment="production",
+        )
+
+    def receipts(self) -> tuple[Any, ...]:
+        return self.store.receipts()
+
+    def events(self) -> list[str]:
+        return [str(event.type) for event in self.store.events()]
+
+    def pending(self) -> list[Any]:
+        """Every request still awaiting an answer, found through the events the kernel writes.
+
+        The `StateStore` protocol has no "list every approval", and it should not grow one for
+        a test: `APPROVAL_REQUESTED` is the evidence an action awaiting a human leaves
+        (`v0.1 §6.1`), and reading it is reading the same trail an operator would.
+        """
+        records = []
+        for event in self.store.events():
+            if str(event.type) == "APPROVAL_REQUESTED" and event.approval_id:
+                record = self.store.get_approval(event.approval_id)
+                if record is not None and str(record.status) == "pending":
+                    records.append(record)
+        return records
+
+
+def granted(arguments: Mapping[str, Any] | None = None) -> ApprovalAnswer:
+    return ApprovalAnswer(granted=True, approver=APPROVER, approved_arguments=arguments)
+
+
+@dataclass(frozen=True)
+class Case:
+    """One acceptance test, and where it came from."""
+
+    id: str
+    title: str
+    body: Callable[[ConformanceAdapter], CaseResult]
+
+
+def case(identifier: str, title: str) -> Callable[..., Case]:
+    def wrap(body: Callable[[ConformanceAdapter], CaseResult]) -> Case:
+        return Case(identifier, title, body)
+
+    return wrap
+
+
+def failed(identifier: str, title: str, reason: str, **detail: Any) -> CaseResult:
+    return CaseResult(identifier, title, SuiteStatus.FAIL, reason, detail)
+
+
+def passed(identifier: str, title: str) -> CaseResult:
+    return CaseResult(identifier, title, SuiteStatus.PASS)
+
+
+def na(identifier: str, title: str, reason: str) -> CaseResult:
+    return CaseResult(identifier, title, SuiteStatus.NOT_APPLICABLE, reason)
+
+
+def expect(
+    identifier: str,
+    title: str,
+    call: Callable[[], Any],
+    error: type[BaseException],
+    reason: str | None = None,
+) -> CaseResult | None:
+    """Run `call`, requiring it to raise `error` (and, where given, with that `reason`).
+
+    Returns `None` when it did, and the failing `CaseResult` when it did not -- so a case body
+    reads as a sequence of requirements rather than as nested try/except.
+    """
+    try:
+        call()
+    except error as raised:
+        got = getattr(raised, "reason", None)
+        if reason is not None and got != reason:
+            return failed(
+                identifier,
+                title,
+                f"raised {type(raised).__name__} with reason {got!r}, expected {reason!r}",
+            )
+        return None
+    except BaseException as other:
+        return failed(
+            identifier,
+            title,
+            f"raised {type(other).__name__}: {other}; expected {error.__name__}",
+        )
+    return failed(identifier, title, f"did not raise {error.__name__}")
+
+
+# --- kernel (v0.1 §7) -------------------------------------------------------------------
+
+
+@case("T1", "a lost response blocks a blind retry")
+def kernel_lost_response(adapter: ConformanceAdapter) -> CaseResult:
+    world = World(adapter, ALLOW)
+    executor = Executor(TimeoutError("the response was lost"), None)
+    request = CallRequest(world.control, REFUND, {"payment_id": "t1", "amount": 2000},
+                          "refund:t1", executor)
+
+    problem = expect("T1", kernel_lost_response.title,
+                     lambda: adapter.invoke(request), TimeoutError)
+    if problem:
+        return problem
+    if executor.calls != 1:
+        return failed("T1", kernel_lost_response.title,
+                      f"the executor ran {executor.calls} times on the first attempt, expected 1")
+
+    problem = expect("T1", kernel_lost_response.title, lambda: adapter.invoke(request),
+                     AmbiguousEffect)
+    if problem:
+        return problem
+    if executor.calls != 1:
+        return failed("T1", kernel_lost_response.title,
+                      f"the retry reached the executor: {executor.calls} calls, expected 1")
+    record = world.store.get_effect("refund:t1")
+    if record is None or str(record.state) != "ambiguous":
+        return failed("T1", kernel_lost_response.title,
+                      f"the effect is {record and record.state}, expected ambiguous")
+    return passed("T1", kernel_lost_response.title)
+
+
+@case("T4", "a committed effect refuses a second attempt, approval or not")
+def kernel_duplicate_after_approval(adapter: ConformanceAdapter) -> CaseResult:
+    world = World(adapter, APPROVE)
+    executor = Executor()
+    arguments = {"payment_id": "t4", "amount": 2000}
+    request = CallRequest(world.control, REFUND, arguments, "refund:t4", executor,
+                          answer=granted(arguments))
+
+    adapter.invoke(request)
+    if executor.calls != 1:
+        return failed("T4", kernel_duplicate_after_approval.title,
+                      f"the approved call ran {executor.calls} times, expected 1")
+    if world.watched.calls != 1:
+        return failed("T4", kernel_duplicate_after_approval.title,
+                      f"the framework's primitive was reached {world.watched.calls} times, "
+                      "expected 1: an approval nobody was asked for is not an approval")
+
+    problem = expect("T4", kernel_duplicate_after_approval.title,
+                     lambda: adapter.invoke(request), DuplicateEffect)
+    if problem:
+        return problem
+    if executor.calls != 1:
+        return failed("T4", kernel_duplicate_after_approval.title,
+                      f"the second attempt reached the executor: {executor.calls} calls")
+    return passed("T4", kernel_duplicate_after_approval.title)
+
+
+@case("T6", "an unknown action fails closed")
+def kernel_unknown_action(adapter: ConformanceAdapter) -> CaseResult:
+    world = World(adapter, EMPTY)
+    executor = Executor()
+    request = CallRequest(world.control, REFUND, {"payment_id": "t6", "amount": 1},
+                          "refund:t6", executor)
+
+    problem = expect("T6", kernel_unknown_action.title, lambda: adapter.invoke(request),
+                     ActionDenied, "unknown_action")
+    if problem:
+        return problem
+    if executor.calls:
+        return failed("T6", kernel_unknown_action.title,
+                      f"a denied action reached the executor {executor.calls} times")
+    if [receipt.result for receipt in world.receipts()] != ["denied"]:
+        return failed("T6", kernel_unknown_action.title,
+                      f"receipts are {[r.result for r in world.receipts()]}, expected ['denied']")
+    return passed("T6", kernel_unknown_action.title)
+
+
+@case("T8", "NotExecuted permits a retry, and nothing else does")
+def kernel_failed_permits_retry(adapter: ConformanceAdapter) -> CaseResult:
+    world = World(adapter, ALLOW)
+    executor = Executor(NotExecuted("the remote rejected it before acting"), None)
+    request = CallRequest(world.control, REFUND, {"payment_id": "t8", "amount": 2000},
+                          "refund:t8", executor)
+
+    problem = expect("T8", kernel_failed_permits_retry.title,
+                     lambda: adapter.invoke(request), NotExecuted)
+    if problem:
+        return problem
+
+    try:
+        adapter.invoke(request)
+    except BaseException as refused:
+        return failed("T8", kernel_failed_permits_retry.title,
+                      f"a FAILED effect refused the retry with {type(refused).__name__}: {refused}")
+    if executor.calls != 2:
+        return failed("T8", kernel_failed_permits_retry.title,
+                      f"the executor ran {executor.calls} times, expected 2")
+    record = world.store.get_effect("refund:t8")
+    if record is None or record.attempt != 2:
+        return failed("T8", kernel_failed_permits_retry.title,
+                      f"attempt is {record and record.attempt}, expected 2")
+    return passed("T8", kernel_failed_permits_retry.title)
+
+
+@case("A1", "an allowed action is never put to a human")
+def kernel_no_interrupt_on_allow(adapter: ConformanceAdapter) -> CaseResult:
+    """`request.answer is None` means no human is expected. The positive control for every
+    approval case: without it, an adapter that interrupts on everything passes them all."""
+    world = World(adapter, ALLOW)
+    executor = Executor()
+    request = CallRequest(world.control, REFUND, {"payment_id": "a1", "amount": 2000},
+                          "refund:a1", executor)
+
+    try:
+        adapter.invoke(request)
+    except BaseException as raised:
+        return failed("A1", kernel_no_interrupt_on_allow.title,
+                      f"an allowed action raised {type(raised).__name__}: {raised}")
+    if executor.calls != 1:
+        return failed("A1", kernel_no_interrupt_on_allow.title,
+                      f"the executor ran {executor.calls} times, expected 1")
+    if "APPROVAL_REQUESTED" in world.events() or world.watched.calls:
+        return failed("A1", kernel_no_interrupt_on_allow.title,
+                      f"the adapter put an action the policy allowed outright to a human "
+                      f"({world.watched.calls} interrupts)")
+    return passed("A1", kernel_no_interrupt_on_allow.title)
+
+
+# --- binding (SPEC-v0.5 §3.4) -----------------------------------------------------------
+
+
+@case("B1", "an answer given against different arguments authorizes nothing")
+def binding_mutated_answer(adapter: ConformanceAdapter) -> CaseResult:
+    if not adapter.interrupt.carries_approved_arguments:
+        return na(
+            "B1",
+            binding_mutated_answer.title,
+            f"{adapter.framework} declares carries_approved_arguments=False: its resumption "
+            "carries nothing the adapter can inspect, so the binding across the interrupt is "
+            "the framework's checkpoint and not CTRLRun's hash. Attribution, not prevention",
+        )
+    world = World(adapter, APPROVE)
+    executor = Executor()
+    request = CallRequest(
+        world.control, REFUND, {"payment_id": "b1", "amount": 2000}, "refund:b1", executor,
+        # The human answered about 500. The action proposes 2000.
+        answer=granted({"payment_id": "b1", "amount": 500}),
+    )
+
+    problem = expect("B1", binding_mutated_answer.title, lambda: adapter.invoke(request),
+                     ApprovalMismatch, "mismatch")
+    if problem:
+        return problem
+    if executor.calls:
+        return failed("B1", binding_mutated_answer.title,
+                      f"a mutated answer reached the executor {executor.calls} times")
+    if not world.pending():
+        return failed("B1", binding_mutated_answer.title,
+                      "the refused request was not left pending: a mutated answer must leave the "
+                      "approval the human actually saw still grantable")
+    return passed("B1", binding_mutated_answer.title)
+
+
+@case("B2", "an answer given against the proposal does authorize it")
+def binding_matching_answer(adapter: ConformanceAdapter) -> CaseResult:
+    """B1's control. Without it, B1 passes against an adapter that refuses every answer."""
+    world = World(adapter, APPROVE)
+    executor = Executor()
+    arguments = {"payment_id": "b2", "amount": 2000}
+    request = CallRequest(world.control, REFUND, arguments, "refund:b2", executor,
+                          answer=granted(arguments))
+
+    try:
+        adapter.invoke(request)
+    except BaseException as raised:
+        return failed("B2", binding_matching_answer.title,
+                      f"a matching answer was refused with {type(raised).__name__}: {raised}")
+    if executor.calls != 1:
+        return failed("B2", binding_matching_answer.title,
+                      f"the executor ran {executor.calls} times, expected 1")
+    if world.watched.calls != 1:
+        return failed("B2", binding_matching_answer.title,
+                      f"the framework's primitive was reached {world.watched.calls} times, "
+                      "expected 1: an adapter that granted for itself never asked anybody")
+    approvers = [receipt.approver for receipt in world.receipts()]
+    if approvers != [APPROVER]:
+        return failed("B2", binding_matching_answer.title,
+                      f"the receipt names {approvers}, expected [{APPROVER!r}]")
+    return passed("B2", binding_matching_answer.title)
+
+
+@case("B3", "a refused answer is a denial and not an error")
+def binding_denial(adapter: ConformanceAdapter) -> CaseResult:
+    world = World(adapter, APPROVE)
+    executor = Executor()
+    request = CallRequest(
+        world.control, REFUND, {"payment_id": "b3", "amount": 2000}, "refund:b3", executor,
+        answer=ApprovalAnswer(granted=False, approver=APPROVER),
+    )
+
+    problem = expect("B3", binding_denial.title, lambda: adapter.invoke(request), ActionDenied)
+    if problem:
+        return problem
+    if executor.calls:
+        return failed("B3", binding_denial.title,
+                      f"a denied action reached the executor {executor.calls} times")
+    if world.watched.calls != 1:
+        return failed("B3", binding_denial.title,
+                      f"the framework's primitive was reached {world.watched.calls} times, "
+                      "expected 1")
+    if "APPROVAL_DENIED" not in world.events():
+        return failed("B3", binding_denial.title,
+                      "no APPROVAL_DENIED: a human's no is an answer, and it belongs in the log")
+    return passed("B3", binding_denial.title)
+
+
+# --- duplicate (v0.1 §7 T3, in one process) ---------------------------------------------
+
+
+@case("D1", "two attempts on one effect key, one commit")
+def duplicate_one_commit(adapter: ConformanceAdapter) -> CaseResult:
+    """**Not** `v0.1 §7` T3. That one uses `multiprocessing` and is a statement about SQLite's
+    `BEGIN IMMEDIATE` across OS processes; a framework runtime driven across spawned processes
+    measures the framework's process model and not the adapter. What this catches is an adapter
+    that cached a decision, reused a request id, or memoized a receipt."""
+    world = World(adapter, ALLOW)
+    executor = Executor()
+    first = CallRequest(world.control, REFUND, {"payment_id": "d1", "amount": 2000},
+                        "refund:d1", executor)
+    second = CallRequest(world.control, REFUND, {"payment_id": "d1", "amount": 2000},
+                         "refund:d1", executor)
+
+    adapter.invoke(first)
+    problem = expect("D1", duplicate_one_commit.title, lambda: adapter.invoke(second),
+                     DuplicateEffect)
+    if problem:
+        return problem
+    if executor.calls != 1:
+        return failed("D1", duplicate_one_commit.title,
+                      f"the executor ran {executor.calls} times, expected 1")
+    committed = [receipt for receipt in world.receipts() if receipt.result == "committed"]
+    if len(committed) != 1:
+        return failed("D1", duplicate_one_commit.title,
+                      f"{len(committed)} committed receipts, expected 1")
+    return passed("D1", duplicate_one_commit.title)
+
+
+# --- authority (v0.3 §10) ---------------------------------------------------------------
+
+
+@case("T66", "no grant, no action")
+def authority_no_grant(adapter: ConformanceAdapter) -> CaseResult:
+    world = World(adapter, NO_GRANT)
+    executor = Executor()
+    request = CallRequest(world.control, REFUND, {"payment_id": "a66", "amount": 2000},
+                          "refund:a66", executor)
+
+    problem = expect("T66", authority_no_grant.title, lambda: adapter.invoke(request),
+                     AuthorityDenied, "no_authority")
+    if problem:
+        return problem
+    if executor.calls:
+        return failed("T66", authority_no_grant.title,
+                      f"an unauthorized action reached the executor {executor.calls} times")
+    if "POLICY_EVALUATED" in world.events():
+        return failed("T66", authority_no_grant.title,
+                      "POLICY_EVALUATED after an authority denial: authority runs first and a "
+                      "denial there skips policy (v0.3 §4.3)")
+    return passed("T66", authority_no_grant.title)
+
+
+@case("T70", "an expired grant is not a grant")
+def authority_expired(adapter: ConformanceAdapter) -> CaseResult:
+    world = World(adapter, EXPIRED_GRANT)
+    executor = Executor()
+    request = CallRequest(world.control, REFUND, {"payment_id": "a70", "amount": 2000},
+                          "refund:a70", executor)
+
+    problem = expect("T70", authority_expired.title, lambda: adapter.invoke(request),
+                     AuthorityDenied, "authority_expired")
+    if problem:
+        return problem
+    if executor.calls:
+        return failed("T70", authority_expired.title,
+                      f"an expired grant reached the executor {executor.calls} times")
+    return passed("T70", authority_expired.title)
+
+
+@case("T74", "an authority denial leaves no pending approval")
+def authority_leaves_no_request(adapter: ConformanceAdapter) -> CaseResult:
+    world = World(adapter, APPROVE_WITHOUT_AUTHORITY)
+    executor = Executor()
+    request = CallRequest(world.control, REFUND, {"payment_id": "a74", "amount": 2000},
+                          "refund:a74", executor, answer=granted({"payment_id": "a74",
+                                                                  "amount": 2000}))
+
+    problem = expect("T74", authority_leaves_no_request.title, lambda: adapter.invoke(request),
+                     AuthorityDenied)
+    if problem:
+        return problem
+    if world.pending():
+        return failed("T74", authority_leaves_no_request.title,
+                      "a human was left a request for an action that could never run")
+    if "APPROVAL_REQUESTED" in world.events():
+        return failed("T74", authority_leaves_no_request.title,
+                      "APPROVAL_REQUESTED after an authority denial")
+    return passed("T74", authority_leaves_no_request.title)
+
+
+# --- identity (v0.3 §10) ----------------------------------------------------------------
+
+
+@case("T63", "the provider's principal wins, whatever the framework's session says")
+def identity_provider_wins(adapter: ConformanceAdapter) -> CaseResult:
+    world = World(adapter, ALLOW, principal="the-provider-said-this")
+    executor = Executor()
+    request = CallRequest(world.control, REFUND, {"payment_id": "i63", "amount": 2000},
+                          "refund:i63", executor)
+
+    adapter.invoke(request)
+    agents = [receipt.principal.agent for receipt in world.receipts()]
+    if agents != ["the-provider-said-this"]:
+        return failed("T63", identity_provider_wins.title,
+                      f"receipts name {agents}, expected ['the-provider-said-this']: an adapter "
+                      "sees the principal and never supplies one (SPEC-v0.5 §4.2)")
+    return passed("T63", identity_provider_wins.title)
+
+
+@case("T60", "no principal, no action")
+def identity_no_principal(adapter: ConformanceAdapter) -> CaseResult:
+    world = World(adapter, ALLOW)
+    # A Control with no identity provider and no ambient context() has nobody to attribute an
+    # action to. v0.1 §2.1: that is a wiring bug, not an agent action.
+    bare = Control(
+        world.control.policy,
+        world.store,
+        InterruptApprovalProvider(world.store, adapter.interrupt, clock=world.clock),
+        clock=world.clock,
+        environment="production",
+    )
+    executor = Executor()
+    request = CallRequest(bare, REFUND, {"payment_id": "i60", "amount": 2000},
+                          "refund:i60", executor)
+
+    problem = expect("T60", identity_no_principal.title, lambda: adapter.invoke(request),
+                     ActionDenied, "no_principal")
+    if problem:
+        return problem
+    if executor.calls:
+        return failed("T60", identity_no_principal.title,
+                      f"an unattributed action reached the executor {executor.calls} times")
+    return passed("T60", identity_no_principal.title)
+
+
+#: The suites, in report order. A name here is a name in an adapter's README (§7 item 7).
+SUITES: Mapping[str, tuple[Case, ...]] = {
+    #: `v0.1 §7` T5 -- an approval answered after its expiry -- is **not** here, and the
+    #: absence is deliberate rather than an omission. Through `@protect(wait=True)` the request
+    #: is created and consumed inside one `invoke`, so there is no interval for it to expire in
+    #: that the kit can reach without a hook into the adapter's own primitive. Expiry is
+    #: exercised where it lives: at the provider (SPEC-v0.5 T129d, both halves) and in the
+    #: kernel (`v0.1 §7` T5). Same treatment T2 and T3 get in §5.3.
+    "kernel": (kernel_lost_response, kernel_duplicate_after_approval, kernel_unknown_action,
+               kernel_failed_permits_retry, kernel_no_interrupt_on_allow,
+               binding_matching_answer, binding_denial),
+    #: `binding` is the mutation check **alone**, and that is why it is its own suite. Its
+    #: control (B2) and the denial case (B3) live in `kernel`, because both run whatever the
+    #: framework carries back -- and a suite containing them would report `pass` for an adapter
+    #: that cannot perform the one check the suite is named for. That is `8/8` with an N/A
+    #: folded in, one level down.
+    "binding": (binding_mutated_answer,),
+    "duplicate": (duplicate_one_commit,),
+    "authority": (authority_no_grant, authority_expired, authority_leaves_no_request),
+    "identity": (identity_provider_wins, identity_no_principal),
+}
+
+
+def run(adapter: ConformanceAdapter, deployment: Control | None = None) -> ConformanceReport:
+    """Drive every suite through `adapter` and report what each came to (SPEC-v0.5 §5).
+
+    `deployment` is the operator's `Control`, where the kit is being run inside one. **The
+    suites do not run against it.** They run against scratch `Control`s the kit builds, for the
+    reason `v0.4 §3.5` gives about verify: a kit that reserved a real effect key would be a
+    defect of exactly the class it exists to find. The one thing read from it is the mode, and
+    an observing one is **refused** -- no suites, no denominator, `ok` is `False` -- because
+    running the suites in a synthetic enforce mode would report guarantees about a configuration
+    nobody deployed, and running them as-is would report a wall of failures that are true and
+    useless (§3.6).
+
+    A case that raises out of its own body is reported as a failed case naming the exception,
+    never as a crashed run: one broken suite must not be able to hide the eight that worked.
+    """
+    if deployment is not None and deployment.policy.mode == OBSERVE:
+        return ConformanceReport(
+            framework=adapter.framework,
+            status="refused",
+            reason="mode: observe - nothing is enforced, so these suites would report "
+            "guarantees about a configuration nobody deployed (SPEC-v0.5 §3.6)",
+        )
+
+    results = []
+    for name, cases in SUITES.items():
+        outcomes = []
+        for item in cases:
+            try:
+                outcomes.append(item.body(adapter))
+            except BaseException as broke:
+                outcomes.append(
+                    failed(item.id, item.title,
+                           f"the case raised {type(broke).__name__}: {broke}")
+                )
+        results.append(SuiteResult.of(name, tuple(outcomes)))
+    return ConformanceReport(framework=adapter.framework, suites=tuple(results))
+
+
+def principal_named(agent: str) -> Principal:
+    """A principal an adapter must never build. Exported for `fixtures.SelfAssertsPrincipal`,
+    which is a **broken** adapter, and for nothing else."""
+    return Principal(agent=agent)

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -896,6 +896,31 @@ def test_an_unrepresentable_answer_is_refused_at_the_gate():
         provider.wait(request.request_id, None)
 
 
+def test_a_refusal_is_never_refused_for_carrying_no_arguments():
+    """SPEC-v0.5 §3.4, §12.2. An answer of `granted=False` authorizes nothing, so there is
+    nothing to bind it to -- and requiring `approved_arguments` on one turned a human's *no*
+    into an `ApprovalMismatch`, when §2.4 is explicit that a denial is an answer and gets
+    `APPROVAL_DENIED` then `ACTION_DENIED`.
+
+    The conformance kit found this by driving a denial through a declared carrier. It has a
+    test here too, because a defect in `adapter.py` whose only coverage is `conformance/` is a
+    defect that comes back the moment somebody edits one without running the other.
+    """
+    store = InMemoryStateStore()
+    double = CountingInterrupt(
+        ApprovalAnswer(granted=False, approver="double:interrupt"), carries=True
+    )
+    provider = InterruptApprovalProvider(store, double)
+    request = provider.request(_action(), timedelta(minutes=15))
+
+    assert provider.wait(request.request_id, None) is None
+
+    record = store.get_approval(request.request_id)
+    assert record is not None
+    assert str(record.status) == "denied"
+    assert record.approver == "double:interrupt"
+
+
 def test_a_non_carrier_is_not_checked_and_says_so():
     """§3.4's second bullet: attribution, declared. The kit turns this into `not_applicable`."""
     store = InMemoryStateStore()

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -124,8 +124,15 @@ def test_T131_the_reference_adapter_is_the_surface_and_nothing_else():
     # Both the class and `_protected`, which is where the wiring actually is: a scan of a
     # twelve-line body that delegates the interesting part elsewhere checks the wrong lines.
     wiring = source + inspect.getsource(fixtures._protected)
-    for forbidden in ("grant_approval", "deny_approval", "reserve_effect", "Principal(",
-                      "append_event", "put_receipt", "Control("):
+    for forbidden in (
+        "grant_approval",
+        "deny_approval",
+        "reserve_effect",
+        "Principal(",
+        "append_event",
+        "put_receipt",
+        "Control(",
+    ):
         assert forbidden not in wiring, forbidden
 
 
@@ -443,7 +450,8 @@ class GrantsForItselfFaithfully(Reference):
 
 
 @pytest.mark.parametrize(
-    "broken", [QuietlyInterruptsOnAllow, GrantsForItselfFaithfully],
+    "broken",
+    [QuietlyInterruptsOnAllow, GrantsForItselfFaithfully],
     ids=lambda cls: cls.__name__,
 )
 def test_an_adapter_that_reaches_its_own_primitive_is_still_counted(broken):
@@ -548,6 +556,15 @@ def _invented(request):
 
     now = datetime(2026, 1, 1, tzinfo=UTC)
     return PendingApproval(
-        "apr_x", "act_x", request.action, "sha256:x", dict(request.arguments), None,
-        "production", "?", None, now, now,
+        "apr_x",
+        "act_x",
+        request.action,
+        "sha256:x",
+        dict(request.arguments),
+        None,
+        "production",
+        "?",
+        None,
+        now,
+        now,
     )

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1,13 +1,14 @@
 """The conformance kit. SPEC-v0.5 §5; T130-T134b.
 
 The kit's own tests are the answer to the question the kit itself cannot answer: *would it
-notice?* Nine adapters broken in one named way each, and one that is not, and the pair is the
-whole point -- a kit that failed everything would satisfy T130 as surely as one that failed
+notice?* Eleven adapters broken in one named way each, and one that is not, and the pair is
+the whole point -- a kit that failed everything would satisfy T130 as surely as one that failed
 nothing.
 """
 
 from __future__ import annotations
 
+import contextlib
 import subprocess
 import sys
 import textwrap
@@ -120,8 +121,12 @@ def test_T131_the_reference_adapter_is_the_surface_and_nothing_else():
     # adapter that answers it itself has become the second approval path.
     assert inspect.signature(fixtures._protected).parameters["wait"].default is True
     assert "wait=False" not in source
-    for forbidden in ("grant_approval", "deny_approval", "reserve_effect", "Principal("):
-        assert forbidden not in source, forbidden
+    # Both the class and `_protected`, which is where the wiring actually is: a scan of a
+    # twelve-line body that delegates the interesting part elsewhere checks the wrong lines.
+    wiring = source + inspect.getsource(fixtures._protected)
+    for forbidden in ("grant_approval", "deny_approval", "reserve_effect", "Principal(",
+                      "append_event", "put_receipt", "Control("):
+        assert forbidden not in wiring, forbidden
 
 
 # --- T132: not applicable is not a pass, one level up --------------------------------------
@@ -359,18 +364,27 @@ def test_T134b_the_kit_imports_nothing_from_an_extra():
     import ast
 
     package = REPO_ROOT / "src" / "ctrlrun" / "conformance"
-    forbidden = {"httpx", "jwt", "opentelemetry", "pytest", "yaml"}
+    #: Anything from an extra, and the three modules `ARCHITECTURE.md`'s `conformance/` row
+    #: names in its "must not know about" column. `yaml` is **not** here: `Policy.from_yaml` is
+    #: how the kit builds its scratch policies, and pyyaml is a core dependency -- claiming
+    #: "stdlib only" about a package that parses YAML would be the loose kind of true.
+    forbidden = {"httpx", "jwt", "opentelemetry", "pytest"}
+    kernel_forbidden = {"gateway", "otel", "jwt_identity", "acs", "webhook"}
 
     for module in sorted(package.glob("*.py")):
         tree = ast.parse(module.read_text(encoding="utf-8"))
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
-                names = [alias.name.split(".")[0] for alias in node.names]
+                names = [alias.name for alias in node.names]
             elif isinstance(node, ast.ImportFrom):
-                names = [(node.module or "").split(".")[0]]
+                names = [node.module or ""]
+                # `from ..gateway import x` arrives as module="..gateway" with level=2.
+                names += [f"{'.' * node.level}{node.module or ''}"]
             else:
                 continue
-            assert not set(names) & forbidden, (module.name, names)
+            roots = {name.lstrip(".").split(".")[0] for name in names}
+            assert not roots & forbidden, (module.name, sorted(roots))
+            assert not roots & kernel_forbidden, (module.name, sorted(roots))
 
 
 # --- the kit is deterministic ----------------------------------------------------------------
@@ -384,3 +398,156 @@ def test_two_runs_of_the_same_adapter_report_identically():
 
     assert first == second
     assert T0.year == 2026
+
+
+# --- What the independent review of this kit found -----------------------------------------
+
+
+class QuietlyInterruptsOnAllow(Reference):
+    """The adapter the review wrote to break the kit: it routes every call through its **own**
+    primitive, out of band, and its primitive does not raise -- it prompts and returns, as a
+    real framework's does. Before the proxy was swapped in place rather than merely wired, this
+    scored 5/5."""
+
+    def invoke(self, request):
+        self.interrupt.answer = request.answer
+        with contextlib.suppress(AssertionError):
+            self.interrupt.interrupt(_invented(request))
+        return self._call(request)
+
+
+class GrantsForItselfFaithfully(Reference):
+    """The other one: it honours the verdict and checks the arguments itself, so every refusal
+    the kit asserts is still refused. Only the interrupt count can tell it from a correct
+    adapter -- which is what makes the count load-bearing rather than belt-and-braces."""
+
+    def invoke(self, request):
+        from ctrlrun.conformance.fixtures import _unattended
+        from ctrlrun.control import with_approval
+        from ctrlrun.errors import ApprovalRequired
+
+        try:
+            return _unattended(request)(**request.arguments)
+        except ApprovalRequired as pending:
+            answer = request.answer
+            record = request.control.store.get_approval(pending.request_id)
+            proposed = dict(record.request.action.canonical_arguments)
+            if answer and answer.granted and answer.approved_arguments == proposed:
+                request.control.store.grant_approval(pending.request_id, answer.approver)
+            else:
+                request.control.store.deny_approval(
+                    pending.request_id, answer.approver if answer else "x"
+                )
+            with with_approval(pending.request_id):
+                return _unattended(request)(**request.arguments)
+
+
+@pytest.mark.parametrize(
+    "broken", [QuietlyInterruptsOnAllow, GrantsForItselfFaithfully],
+    ids=lambda cls: cls.__name__,
+)
+def test_an_adapter_that_reaches_its_own_primitive_is_still_counted(broken):
+    """Both of these were written by a session trying to get a green report out of a broken
+    adapter, and both got one. They are here so that the fix has a subject."""
+    report = run(broken(framework=broken.__name__))
+
+    assert report.ok is False
+    assert "kernel" in {s.name for s in report.suites if s.status is SuiteStatus.FAIL}
+
+
+def test_the_kit_swaps_the_proxy_in_place_and_puts_the_original_back():
+    """The swap is what makes the count reachable from the adapter; the restore is what stops
+    the kit leaving a test double bolted to an object the caller still holds."""
+    from ctrlrun.conformance.suites import Watched
+
+    adapter = Reference()
+    own = adapter.interrupt
+    seen: list[object] = []
+
+    class Peeking(Reference):
+        def invoke(self, request):
+            seen.append(self.interrupt)
+            return super().invoke(request)
+
+    peeking = Peeking()
+    inner = peeking.interrupt
+    run(peeking)
+
+    assert seen, "no case ran"
+    assert all(isinstance(one, Watched) for one in seen), "the proxy was not swapped in"
+    assert peeking.interrupt is inner, "the kit left its proxy attached"
+    assert adapter.interrupt is own
+
+
+def test_the_proxy_forwards_state_to_the_adapters_own_primitive():
+    """An adapter sets state on `self.interrupt` before invoking -- the reference hands the
+    kit's answer to its primitive that way -- and it must reach the real object. A proxy that
+    swallowed the assignment would make every approval case fail for the wrong reason."""
+    from ctrlrun.conformance.suites import Watched
+
+    reference = Reference()
+    own = reference.interrupt
+    proxy = Watched(own)
+    proxy.answer = "carried"
+
+    assert own.answer == "carried"
+    assert proxy.answer == "carried"
+    assert proxy.framework == own.framework
+    assert proxy.carries_approved_arguments is own.carries_approved_arguments
+
+
+def test_wrapping_a_proxy_does_not_stack_proxies():
+    """A case builds more than one World, and each would otherwise wrap the previous wrapper --
+    so the count would be of the innermost proxy rather than of the framework."""
+    from ctrlrun.conformance.suites import Watched
+
+    own = Reference().interrupt
+
+    assert Watched(Watched(Watched(own)))._inner is own
+
+
+def test_T5_is_in_the_kernel_suite_and_is_reachable_through_one_invoke():
+    """§12.5. An earlier draft said this was unreachable "without a hook into the adapter's own
+    primitive" -- and §12.3 had added exactly that hook two subsections earlier."""
+    assert "T5" in {case.id for case in SUITES["kernel"]}
+
+    report = run(Reference())
+    kernel = next(suite for suite in report.suites if suite.name == "kernel")
+    t5 = next(case for case in kernel.cases if case.id == "T5")
+
+    assert t5.status is SuiteStatus.PASS
+
+
+class SwallowsTheTimeout(Reference):
+    """An adapter that catches `ApprovalTimeout` and returns. It executed nothing and told its
+    framework the refund went through -- which is why T5 is an adapter case and not only a
+    provider one."""
+
+    def invoke(self, request):
+        from ctrlrun.errors import ApprovalTimeout
+
+        try:
+            return super().invoke(request)
+        except ApprovalTimeout:
+            return "committed"
+
+
+def test_T5_catches_an_adapter_that_swallows_the_timeout():
+    report = run(SwallowsTheTimeout(framework="swallows-the-timeout"))
+    kernel = next(suite for suite in report.suites if suite.name == "kernel")
+    t5 = next(case for case in kernel.cases if case.id == "T5")
+
+    assert t5.status is SuiteStatus.FAIL
+    assert report.ok is False
+
+
+def _invented(request):
+    from datetime import UTC, datetime
+
+    from ctrlrun.adapter import PendingApproval
+
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    return PendingApproval(
+        "apr_x", "act_x", request.action, "sha256:x", dict(request.arguments), None,
+        "production", "?", None, now, now,
+    )

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1,0 +1,386 @@
+"""The conformance kit. SPEC-v0.5 §5; T130-T134b.
+
+The kit's own tests are the answer to the question the kit itself cannot answer: *would it
+notice?* Nine adapters broken in one named way each, and one that is not, and the pair is the
+whole point -- a kit that failed everything would satisfy T130 as surely as one that failed
+nothing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from ctrlrun.conformance import ConformanceReport, SuiteResult, SuiteStatus, run
+from ctrlrun.conformance.fixtures import BROKEN, Reference
+from ctrlrun.conformance.report import CaseResult
+from ctrlrun.conformance.suites import ALLOW, SUITES, T0
+from ctrlrun.control import Control
+from ctrlrun.policy import Policy
+from ctrlrun.state import InMemoryStateStore
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: Every `run()` drives the `authority` suite, which builds an `authority:` section and appends
+#: SPEC-v0.3 §7 events. `conftest`'s guard asks that a test say so rather than leak them, and
+#: here it is true of the whole module rather than of nine tests individually.
+pytestmark = pytest.mark.authority
+
+OBSERVING = """
+schema: ctrlrun.policy/v3
+mode: observe
+actions:
+  stripe.refund:
+    decision: approve
+"""
+
+
+# --- T130: the kit fails a broken adapter, per suite and by name ---------------------------
+
+
+@pytest.mark.parametrize("name", sorted(BROKEN))
+def test_T130_each_broken_fixture_fails_the_suite_named_for_it(name):
+    """§5.4. Each fails **the suite named in its row**; incidental failures of other suites are
+    permitted and expected, because "and no other" is false of an adapter broken badly enough.
+
+    What this forbids is a fixture that fails *nothing* — the false green the whole kit exists
+    to make impossible — and a fixture whose named suite passed, which would mean the suite is
+    not testing what its name says.
+    """
+    broken, expected = BROKEN[name]
+
+    report = run(broken(framework=name))
+
+    failed = {suite.name for suite in report.suites if suite.status is SuiteStatus.FAIL}
+    assert expected in failed, (
+        f"{name} was supposed to fail the {expected!r} suite and did not; "
+        f"it failed {sorted(failed)}"
+    )
+    assert report.ok is False
+
+
+def test_T130_every_fixture_names_a_suite_that_exists():
+    """A fixture pointed at a suite that was renamed away would pass its own test by never
+    being checked against anything."""
+    assert {suite for _, suite in BROKEN.values()} <= set(SUITES)
+
+
+def test_T130_every_suite_has_at_least_one_fixture_that_fails_it():
+    """The other direction, and the one that catches a suite nothing exercises: a suite no
+    broken adapter can fail is a suite that would report `pass` for every adapter ever written.
+    """
+    covered = {suite for _, suite in BROKEN.values()}
+
+    assert set(SUITES) == covered, f"no fixture fails: {sorted(set(SUITES) - covered)}"
+
+
+def test_T130_a_failing_suite_says_which_case_and_why():
+    """A report that said only "kernel: fail" would send an adapter author to read the kit."""
+    broken, _ = BROKEN["swallows-not-executed"]
+
+    report = run(broken(framework="swallows-not-executed"))
+    kernel = next(suite for suite in report.suites if suite.name == "kernel")
+    failures = [case for case in kernel.cases if case.status is SuiteStatus.FAIL]
+
+    assert failures
+    assert all(case.reason for case in failures)
+    assert any(case.id == "T8" for case in failures), [case.id for case in failures]
+    assert "T8" in report.to_text()
+
+
+# --- T131: the kit passes a correct adapter ------------------------------------------------
+
+
+def test_T131_a_correct_adapter_passes_every_suite():
+    """Without this, T130 is satisfied by a kit that fails everything."""
+    report = run(Reference())
+
+    assert report.ok is True
+    assert [suite.status for suite in report.suites] == [SuiteStatus.PASS] * len(SUITES)
+    assert report.not_applicable == ()
+    assert report.to_text().endswith("reference: 5/5")
+
+
+def test_T131_the_reference_adapter_is_the_surface_and_nothing_else():
+    """It is `@protect(wait=True)` with an `InterruptApprovalProvider`, and that single keyword
+    is the entire difference an adapter makes (§1.1). If this ever needs more, the contract has
+    grown something an adapter author will have to discover for themselves."""
+    import inspect
+
+    from ctrlrun.conformance import fixtures
+
+    source = inspect.getsource(fixtures.Reference)
+
+    # `wait=True` is the default and the reference never overrides it. `GrantsForItself` does,
+    # which is exactly its defect: `wait=False` hands `ApprovalRequired` to the adapter, and an
+    # adapter that answers it itself has become the second approval path.
+    assert inspect.signature(fixtures._protected).parameters["wait"].default is True
+    assert "wait=False" not in source
+    for forbidden in ("grant_approval", "deny_approval", "reserve_effect", "Principal("):
+        assert forbidden not in source, forbidden
+
+
+# --- T132: not applicable is not a pass, one level up --------------------------------------
+
+
+def test_T132_a_non_carrier_reports_binding_not_applicable_with_its_reason():
+    report = run(Reference(carries=False, framework="no-carry"))
+
+    binding = next(suite for suite in report.suites if suite.name == "binding")
+    assert binding.status is SuiteStatus.NOT_APPLICABLE
+    assert "carries_approved_arguments=False" in (binding.reason or "")
+    assert "attribution" in (binding.reason or "").lower()
+
+
+def test_T132_the_denominator_counts_applicable_suites_only():
+    report = run(Reference(carries=False, framework="no-carry"))
+
+    assert len(report.applicable) == len(SUITES) - 1
+    assert report.to_text().endswith("no-carry: 4/4 (1 not applicable)")
+    assert "5/5" not in report.to_text()
+    assert report.ok is True
+
+
+def test_T132_there_is_no_flag_that_folds_an_na_into_the_count():
+    """§5.3, and `v0.4 §1`. Asserted the way v0.4 asserts it: by signature."""
+    import inspect
+
+    for parameter in inspect.signature(run).parameters.values():
+        assert parameter.name in {"adapter", "deployment"}, parameter.name
+
+
+def test_T132_the_binding_suite_is_the_mutation_check_alone():
+    """Its control and the denial case live in `kernel` on purpose: a `binding` suite containing
+    them would report `pass` for an adapter that cannot perform the one check it is named for,
+    which is an N/A folded into the count one level down."""
+    assert [case.id for case in SUITES["binding"]] == ["B1"]
+    assert {case.id for case in SUITES["kernel"]} >= {"B2", "B3"}
+
+
+# --- T132b / T132c: refusal, and a zero denominator ----------------------------------------
+
+
+def test_T132b_the_kit_refuses_an_observing_control():
+    store = InMemoryStateStore()
+    observing = Control(
+        Policy.from_yaml(OBSERVING, source="<test>"), store, environment="production"
+    )
+
+    report = run(Reference(), observing)
+
+    assert report.status == "refused"
+    assert "mode: observe" in (report.reason or "")
+    assert report.suites == ()
+    assert report.ok is False
+    assert "REFUSED" in report.to_text()
+
+
+def test_T132b_an_enforcing_deployment_is_not_refused():
+    """The control. Without it, the refusal is satisfied by a kit that refuses every Control."""
+    store = InMemoryStateStore()
+    enforcing = Control(Policy.from_yaml(ALLOW, source="<test>"), store, environment="production")
+
+    report = run(Reference(), enforcing)
+
+    assert report.status == "ok"
+    assert report.ok is True
+
+
+def test_T132c_a_report_whose_every_suite_is_not_applicable_is_not_a_pass():
+    """`0/0` reported as success is the same false green as `6/6` with two of them uncounted.
+    Asserted on `ConformanceReport` directly, because it is the rule and not a property of any
+    particular adapter."""
+    report = ConformanceReport(
+        framework="hypothetical",
+        suites=(
+            SuiteResult(
+                "kernel",
+                SuiteStatus.NOT_APPLICABLE,
+                "nothing here applies",
+                (CaseResult("T1", "t", SuiteStatus.NOT_APPLICABLE, "nothing here applies"),),
+            ),
+        ),
+    )
+
+    assert report.applicable == ()
+    assert report.ok is False
+
+
+def test_a_failing_or_not_applicable_case_must_carry_a_reason():
+    """An N/A without one is an N/A nobody can check."""
+    for status in (SuiteStatus.FAIL, SuiteStatus.NOT_APPLICABLE):
+        with pytest.raises(ValueError):
+            CaseResult("T1", "t", status)
+
+
+def test_a_suite_is_not_applicable_only_when_every_case_is():
+    """One applicable case that passed is a pass. Reporting the whole suite N/A because part of
+    it could not run would hide the part that did."""
+    mixed = SuiteResult.of(
+        "mixed",
+        (
+            CaseResult("A", "a", SuiteStatus.NOT_APPLICABLE, "not here"),
+            CaseResult("B", "b", SuiteStatus.PASS),
+        ),
+    )
+
+    assert mixed.status is SuiteStatus.PASS
+
+
+# --- T133: neither the kit nor an adapter reaches the network ------------------------------
+
+
+NO_SOCKETS = textwrap.dedent(
+    """
+    import socket
+
+    class _Refused(socket.socket):
+        def __init__(self, *args, **kwargs):
+            raise OSError("the conformance kit opened a socket")
+
+    socket.socket = _Refused
+    socket.create_connection = lambda *a, **k: (_ for _ in ()).throw(OSError("no network"))
+    socket.getaddrinfo = lambda *a, **k: (_ for _ in ()).throw(OSError("no network"))
+    """
+)
+
+RUN_THE_KIT = textwrap.dedent(
+    """
+    import logging
+    logging.disable(logging.CRITICAL)
+    from ctrlrun.conformance import run
+    from ctrlrun.conformance.fixtures import Reference
+    report = run(Reference())
+    assert report.ok, report.to_text()
+    print("ok")
+    """
+)
+
+OPENS_A_SOCKET = RUN_THE_KIT + textwrap.dedent(
+    """
+    import urllib.request
+    urllib.request.urlopen("http://127.0.0.1:1/", timeout=1)
+    """
+)
+
+
+def guarded(tmp_path: Path, script: str) -> subprocess.CompletedProcess[str]:
+    (tmp_path / "sitecustomize.py").write_text(NO_SOCKETS, encoding="utf-8")
+    (tmp_path / "script.py").write_text(script, encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, str(tmp_path / "script.py")],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env={"PYTHONPATH": f"{tmp_path}:{REPO_ROOT / 'src'}", "PATH": "/usr/bin:/bin"},
+        timeout=180,
+    )
+
+
+def test_T133_the_kit_runs_with_the_network_taken_away(tmp_path):
+    result = guarded(tmp_path, RUN_THE_KIT)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_T133_and_the_guard_can_see_a_socket_when_there_is_one(tmp_path):
+    """The precondition, without which the negative test proves nothing: a run that opens no
+    socket passes the guard whether the guard works or not."""
+    result = guarded(tmp_path, OPENS_A_SOCKET)
+
+    assert result.returncode != 0
+    assert "no network" in result.stderr or "opened a socket" in result.stderr
+
+
+# --- T134: import boundaries ----------------------------------------------------------------
+
+
+IMPORT_CTRLRUN = textwrap.dedent(
+    """
+    import sys
+    import ctrlrun
+
+    leaked = sorted(
+        name
+        for name in sys.modules
+        if name in {"ctrlrun.verify", "ctrlrun.conformance", "httpx", "jwt", "pytest"}
+        or name.startswith("opentelemetry")
+        or name.startswith("ctrlrun.conformance.")
+    )
+    assert not leaked, leaked
+    assert "ctrlrun.adapter" in sys.modules, "adapter is core and in the action path"
+    print("ok")
+    """
+)
+
+
+def test_T134_import_ctrlrun_imports_neither_verify_nor_conformance():
+    """`v0.4`'s T125b, extended. `ctrlrun.adapter` **is** imported: it is core and in the action
+    path, and this test is where the line between the two is written down."""
+    result = subprocess.run(
+        [sys.executable, "-c", IMPORT_CTRLRUN],
+        capture_output=True,
+        text=True,
+        env={"PYTHONPATH": str(REPO_ROOT / "src"), "PATH": "/usr/bin:/bin"},
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_T134b_the_kit_is_stdlib_and_needs_no_extra():
+    """SPEC-v0.5 §12.1. It was planned as `ctrlrun[conformance]` on the premise that a kit needs
+    `pytest`; building it showed the premise was wrong, and an extra with no dependency behind
+    it is a `MissingDependency` that can never fire and an install line that installs nothing.
+
+    So the assertion is the honest one: the package declares no `conformance` extra, and nothing
+    the kit imports comes from outside the standard library and `ctrlrun` itself.
+    """
+    import tomllib
+
+    with (REPO_ROOT / "pyproject.toml").open("rb") as handle:
+        pyproject = tomllib.load(handle)
+
+    extras = pyproject["project"]["optional-dependencies"]
+    assert "conformance" not in extras, (
+        "an extra with no dependency behind it installs nothing and can never raise "
+        "MissingDependency"
+    )
+    assert pyproject["project"]["dependencies"] == ["pyyaml>=6.0", "click"]
+
+
+def test_T134b_the_kit_imports_nothing_from_an_extra():
+    import ast
+
+    package = REPO_ROOT / "src" / "ctrlrun" / "conformance"
+    forbidden = {"httpx", "jwt", "opentelemetry", "pytest", "yaml"}
+
+    for module in sorted(package.glob("*.py")):
+        tree = ast.parse(module.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = [alias.name.split(".")[0] for alias in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                names = [(node.module or "").split(".")[0]]
+            else:
+                continue
+            assert not set(names) & forbidden, (module.name, names)
+
+
+# --- the kit is deterministic ----------------------------------------------------------------
+
+
+def test_two_runs_of_the_same_adapter_report_identically():
+    """`v0.4 §3.6`'s discipline: no RNG, and a clock only the kit moves. A kit whose report
+    depended on the wall clock would be one whose failures nobody could reproduce."""
+    first = run(Reference()).to_dict()
+    second = run(Reference()).to_dict()
+
+    assert first == second
+    assert T0.year == 2026


### PR DESCRIPTION
Build-list item 3 for v0.5. **Stacked on #47** → #45. Merge bottom-up.

`ctrlrun.conformance`: the SPEC-v0.1 §7 and SPEC-v0.3 §10 acceptance suites runnable against any adapter through the item-2 surface, **eleven adapters broken in one named way each**, and one that is not.

## The fixtures come first

"Two adapters pass the suites" is this milestone's exit criterion and it means nothing until the suite can fail. Each fixture must fail **the suite named for it**; incidental failures of others are permitted, because "and no other" is false of an adapter broken badly enough. Both directions of the mapping are asserted — a fixture pointed at a renamed suite would pass its own test by never being checked against anything, and a suite no fixture fails would report `pass` for every adapter ever written.

## What building it settled (SPEC-v0.5 §12)

- **§12.1 — the kit is core, not the extra it was planned as.** §5.1's premise was that a kit needs `pytest`. It does not: the suites drive a `Control` and compare exceptions, and an adapter author runs the report *inside* their own pytest. That left an extra installing nothing and a `MissingDependency` that could never fire.
- **§12.2 — the kit found a defect in the surface.** The mandatory binding check applied to every answer, so a human's **no** — which carries no approved arguments — was refused with `ApprovalMismatch` before it could become a denial. Exactly what §2.4 forbids in the other direction.
- **§12.3 — an already-granted request is a hole the provider cannot close.** `GrantsForItself` writes the grant and re-presents, so `wait()` finds the record granted and returns it without calling `interrupt()`. The provider is *right* to return it. The hole is that a suite asserting a refusal cannot tell "the human said no" from "the framework was never asked" — so the kit counts interrupt calls.
- **§12.4, §12.5** — the Protocol exposes its interrupt so the kit can play operator; two acceptance tests are genuinely unreachable through one `invoke`, and a third is not.

## Independent review — three blocking defects

A session that did not write the kit wrote adapters designed to get a green report out of a broken one, and got two.

1. **The kit passed an adapter that put every allowed call to a human.** The fixture failed only because the kit's own double *raises* — a real primitive prompts and returns. And the counting half was **dead code**: the proxy was wired into the provider, which is reached only on `ApprovalRequired`, which an `ALLOW` policy never raises. The proxy is now **swapped in place of the adapter's interrupt attribute**, so every route is counted; `run()` restores the original.
2. **§12.5 said T5 was unreachable "without a hook into the adapter's own primitive"** — and §12.3 had added exactly that hook two subsections earlier, in the same commit. T5 is in the `kernel` suite now.
3. **§8's T134b described a test the same commit made impossible**, and §5.2's code block still carried the `ctrlrun[conformance]` header.

## The mutation table found one the review did not

**A1's interrupt count was subsumed.** `interrupts-on-allow` bumps the count on T4, B2 and B3 too, so deleting A1's own check left the kit still failing it — for a reason unrelated to the case A1 is. `interrupts-only-when-unasked` is the eleventh fixture: correct wherever a human is expected, wrong on exactly the calls where none is, invisible to every other case.

**Ten rows, all red** — `PYTHONDONTWRITEBYTECODE=1`, `__pycache__` cleared, every anchor verified unique.

## Verification

- 2156 tests · `ruff check` · `mypy --strict src/`
- Reference adapter **5/5**; a non-carrier **4/4 (1 not applicable)**, never 5/5
- `import ctrlrun` reaches neither `ctrlrun.verify` nor `ctrlrun.conformance`; `dependencies` unchanged