### PR TITLE
release: publish from a tag with no stored token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,162 @@
+name: Release
+
+# Publishing runs from a tag and from nothing else, and it stores no token.
+#
+# **Trusted publishing (OIDC), not an API token.** PyPI mints a short-lived credential for this
+# exact workflow file in this exact repository, so there is no long-lived secret in the
+# repository, in an environment, or on a maintainer's laptop. The laptop is the reason: v0.5.0
+# was published by hand, and the `~/.pypirc` beside it had never held anything but
+# `<your-api-token-here>` — a credential path nobody could see the state of until it failed.
+#
+# `id-token: write` is granted **per job**, so the only jobs that can mint a PyPI credential are
+# the three that publish. Everything else in this workflow is read-only, which is `ci.yml`'s
+# discipline for `contents: write` applied to the one other privilege this repository uses.
+#
+# One-time setup on PyPI, per project (ctrlrun, ctrlrun-langgraph, ctrlrun-openai-agents):
+#   Publishing → Add a new pending publisher
+#     Owner: CTRLRun   Repository: ctrlrun   Workflow: release.yml   Environment: pypi
+# Until that exists the publish step fails closed with an authentication error, which is the
+# correct behaviour: nothing is uploaded on a half-configured release.
+
+on:
+  push:
+    tags:
+      - "v*"
+      - "adapters-langgraph-*"
+      - "adapters-openai-agents-*"
+  workflow_dispatch:
+    inputs:
+      distribution:
+        description: Which distribution to publish
+        required: true
+        type: choice
+        options: [ctrlrun, ctrlrun-langgraph, ctrlrun-openai-agents]
+
+permissions:
+  contents: read
+
+jobs:
+  # The tag is the input, and the tag has to agree with what it claims to be. A tag whose
+  # `pyproject.toml` says a different version is a release nobody can reproduce from the
+  # repository, which is the whole reason release verification runs from a fresh clone.
+  verify:
+    runs-on: ubuntu-latest
+    outputs:
+      target: ${{ steps.pick.outputs.target }}
+      path: ${{ steps.pick.outputs.path }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Which distribution does this tag name
+        id: pick
+        env:
+          REF: ${{ github.ref_name }}
+          CHOICE: ${{ inputs.distribution }}
+        run: |
+          set -eu
+          case "${CHOICE:-$REF}" in
+            ctrlrun|v*)                             target=ctrlrun;               path=.                        ;;
+            ctrlrun-langgraph|adapters-langgraph-*) target=ctrlrun-langgraph;     path=adapters/langgraph       ;;
+            ctrlrun-openai-agents|adapters-openai-agents-*)
+                                                    target=ctrlrun-openai-agents; path=adapters/openai-agents   ;;
+            *) echo "::error::$REF names no distribution"; exit 1 ;;
+          esac
+          echo "target=$target" >> "$GITHUB_OUTPUT"
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+          echo "publishing $target from $path"
+
+      - name: The tag and the metadata agree
+        # Only for a version-bearing tag; `workflow_dispatch` has no version to check against.
+        if: github.event_name == 'push'
+        env:
+          REF: ${{ github.ref_name }}
+          PATH_: ${{ steps.pick.outputs.path }}
+        run: |
+          python - <<'PY'
+          import os, pathlib, re, sys
+
+          ref = os.environ["REF"]
+          declared = re.search(
+              r'^version = "([^"]+)"',
+              (pathlib.Path(os.environ["PATH_"]) / "pyproject.toml").read_text(encoding="utf-8"),
+              re.M,
+          ).group(1)
+          # v0.5.0 -> 0.5.0   |   adapters-langgraph-1.0 -> 1.0, which 1.0.0 must start with
+          wanted = ref[1:] if ref.startswith("v") else ref.rsplit("-", 1)[-1]
+          ok = declared == wanted or declared.startswith(wanted + ".")
+          print(f"tag {ref} -> wants {wanted}; pyproject declares {declared}: {'ok' if ok else 'MISMATCH'}")
+          sys.exit(0 if ok else 1)
+          PY
+
+  build:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build and check
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build --outdir dist "${{ needs.verify.outputs.path }}"
+          twine check --strict dist/*
+
+      # SPEC-v0.5 §6.1, and T136's assertion carried onto the release path: the kernel's
+      # artifacts never carry an adapter, and an adapter's never carry the kernel.
+      - name: Neither distribution carries the other
+        env:
+          TARGET: ${{ needs.verify.outputs.target }}
+        run: |
+          python - <<'PY'
+          import os, pathlib, tarfile, zipfile
+
+          names = []
+          for path in pathlib.Path("dist").iterdir():
+              if path.suffix == ".whl":
+                  names += zipfile.ZipFile(path).namelist()
+              elif path.name.endswith(".tar.gz"):
+                  with tarfile.open(path) as archive:
+                      names += archive.getnames()
+          assert names, "nothing was built"
+
+          if os.environ["TARGET"] == "ctrlrun":
+              bad = [n for n in names if "adapters/" in n or "ctrlrun_langgraph" in n
+                     or "ctrlrun_openai_agents" in n]
+              assert not bad, bad
+              assert any(n.endswith("ctrlrun/adapter.py") for n in names), "the surface is missing"
+          else:
+              bad = [n for n in names if "/src/ctrlrun/" in n]
+              assert not bad, bad
+          print("ok:", len(names), "entries")
+          PY
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: [verify, build]
+    runs-on: ubuntu-latest
+    # The environment is half of what PyPI's pending publisher is configured against, and it is
+    # where a required reviewer goes if this repository ever wants one on the publish step.
+    environment:
+      name: pypi
+      url: https://pypi.org/project/${{ needs.verify.outputs.target }}/
+    permissions:
+      # The only privilege in this workflow, on the only job that needs it.
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -751,3 +751,48 @@ def test_the_claims_table_line_numbers_point_at_what_they_name():
 
     assert checked, "CLAIMS.md cites no code locations at all"
     assert stale == [], stale
+
+
+def test_every_documented_install_names_a_distribution_this_repository_builds():
+    """`pip install ctrlrun-langgraph` shipped in the README of a release where no such
+    distribution existed, so the line 404s for anyone who follows it.
+
+    The publication state is not knowable offline, so this asserts the half that is: every
+    `pip install <name>` in the documentation names something this repository actually builds —
+    `ctrlrun` itself, one of its extras, or a distribution under `adapters/`. A typo, a rename,
+    or a doc written ahead of the code fails here.
+
+    What it deliberately does **not** claim is that the name is on PyPI. That is a release-time
+    fact and `.github/workflows/release.yml` is what makes it true; saying otherwise would be
+    the kind of loosely-true assertion this suite keeps refusing.
+    """
+    import tomllib
+
+    root = REPO_ROOT
+    with (root / "pyproject.toml").open("rb") as handle:
+        kernel = tomllib.load(handle)["project"]
+    known = {kernel["name"]}
+    known |= {f"{kernel['name']}[{extra}]" for extra in kernel.get("optional-dependencies", {})}
+
+    adapters = root / "adapters"
+    if adapters.is_dir():
+        for path in sorted(adapters.iterdir()):
+            manifest = path / "pyproject.toml"
+            if manifest.is_file():
+                with manifest.open("rb") as handle:
+                    known.add(tomllib.load(handle)["project"]["name"])
+
+    documents = [root / "README.md", root / "docs" / "adapters.md"]
+    documents += sorted((root / "adapters").glob("*/README.md")) if adapters.is_dir() else []
+
+    unknown = []
+    for document in documents:
+        if not document.exists():  # pragma: no cover - not a checkout
+            continue
+        for match in re.findall(r"pip install \"?([A-Za-z0-9_.\[\]-]+)\"?", document.read_text()):
+            if match.startswith(".") or match.startswith("-"):
+                continue
+            if match.split("==")[0] not in known:
+                unknown.append(f"{document.name}: {match}")
+
+    assert unknown == [], unknown

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -775,12 +775,19 @@ def test_every_documented_install_names_a_distribution_this_repository_builds():
     known |= {f"{kernel['name']}[{extra}]" for extra in kernel.get("optional-dependencies", {})}
 
     adapters = root / "adapters"
-    if adapters.is_dir():
-        for path in sorted(adapters.iterdir()):
-            manifest = path / "pyproject.toml"
-            if manifest.is_file():
-                with manifest.open("rb") as handle:
-                    known.add(tomllib.load(handle)["project"]["name"])
+    if not adapters.is_dir():  # pragma: no cover - running from an unpacked sdist
+        # `adapters/` is pruned from the sdist (SPEC-v0.5 §6.1) while the README that names
+        # them ships inside it, so here the invariant is **unverifiable rather than violated**.
+        # Same reasoning as T136's other half, and the same narrowness: it holds in a checkout,
+        # which is where a doc is written, and the `adapters` CI job runs it with the tree
+        # present. Asserting from the sdist would fail every adapter name on principle.
+        pytest.skip("adapters/ is not in this distribution, which SPEC-v0.5 §6.1 requires")
+
+    for path in sorted(adapters.iterdir()):
+        manifest = path / "pyproject.toml"
+        if manifest.is_file():
+            with manifest.open("rb") as handle:
+                known.add(tomllib.load(handle)["project"]["name"])
 
     documents = [root / "README.md", root / "docs" / "adapters.md"]
     documents += sorted((root / "adapters").glob("*/README.md")) if adapters.is_dir() else []


### PR DESCRIPTION
Follow-up to 0.5.0, from two things the release itself exposed.

## The README documents a package that does not exist

`README.md` and `adapters/langgraph/README.md` both say `pip install ctrlrun-langgraph`. Both adapters are tagged `adapters-langgraph-1.0` / `adapters-openai-agents-1.0` and **neither is on PyPI** — the line 404s for anyone who follows it, in a release that is already live.

Publication state is not knowable offline, so `test_every_documented_install_names_a_distribution_this_repository_builds` asserts the half that is: every `pip install <name>` in the docs names something this repository actually builds. Mutation-checked with a typo. It deliberately does **not** claim the name is on PyPI — that is a release-time fact, and the workflow below is what makes it true.

## 0.5.0 was published by hand from a `~/.pypirc` that had never held a token

The file contained the literal `<your-api-token-here>`. A `twine upload` against it fails with a 403, which is how anyone found out — a credential path whose state was invisible until it failed.

`release.yml` uses **PyPI trusted publishing**: no long-lived token in the repository, in an environment, or on a laptop. PyPI mints a short-lived credential for this workflow file in this repository.

- **`id-token: write` on the publish job alone.** The workflow is `contents: read`; nothing else can mint a credential. That is `ci.yml`'s discipline for `contents: write`, applied to the one other privilege this repository uses.
- **Runs from a tag and nothing else**, plus a `workflow_dispatch` for a re-run.
- **The tag and `pyproject.toml` must agree** before anything is built. A tag claiming a version its metadata does not is a release nobody can reproduce from the repository, which is the reason release verification runs from a fresh clone.
- **T136 carried onto the release path**: the kernel's artifacts never carry an adapter, and an adapter's never carry the kernel.

## Both adapters are verified and ready to publish

```
twine check --strict          PASSED (both)
install both wheels           resolves ctrlrun>=0.5,<0.6 against the real PyPI 0.5.0
                              no --no-deps needed — that was only ever because
                              0.5.0.dev0 sorts below 0.5
```

## What this needs from the maintainer

One-time, per project (`ctrlrun`, `ctrlrun-langgraph`, `ctrlrun-openai-agents`), on PyPI:

> Publishing → Add a new pending publisher
> Owner `CTRLRun` · Repository `ctrlrun` · Workflow `release.yml` · Environment `pypi`

Until that exists the publish step fails closed with an authentication error, which is correct: nothing is uploaded on a half-configured release.

## Verification

`ruff format --check` · `ruff check` · `mypy --strict src` · **2261 passed**