### PR TITLE
docs: T138 had no test, and the list it asks for was a summary of itself

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -90,11 +90,35 @@ Three things bite here, and all three were found the hard way:
 ## What the contract could not answer
 
 Item 6 of v0.5 wrote a third adapter against `SPEC-v0.5.md` alone, in a session that could not
-read the kernel or either reference adapter. It produced fourteen questions the document could
-not answer, four of which would have produced an insecure or unimplementable adapter. **Every one
-of them became an edit to the contract** — `SPEC-v0.5.md` §12.10 lists them and what they
-changed, and §12.9 is the observe-mode defect it found in a *shipping* adapter without reading
-a line of it.
+read the kernel or either reference adapter. **The adapter was disposable; this list is what it
+was for.** A contract only its author can implement is not a contract, so the list had to be
+emptied before v0.5 could ship — every row below is answered by an edit to `SPEC-v0.5.md`.
+
+It chose the **decided-before-invocation** shape deliberately, because that shape must touch
+`needs_approval`, `banner`, `refuses_before_invoking` and `Control.policy` and so loads more of
+the contract. Six of the fourteen exist only because of that choice, and that is the finding
+rather than an artefact of it: **this document was written from one shape and read from the
+other, and that is where it broke.**
+
+| # | The question | Severity | Answered by |
+|---|---|---|---|
+| Q1 | Is `ctrlrun.context()` on the never-list? It supplies a principal without naming the type, and passes T129 because that test runs against a `Control` **with** an identity provider | **security** | §2.3 never-list row |
+| Q2 | May an adapter construct an `InterruptApprovalProvider`? §9 rested a security argument on "it does not", and nothing forbade it — a `build_provider()` helper could inject a frozen clock and defeat §2.4 | **security** | §2.3 never-list row |
+| Q3 | §3.6's "never interrupts in observe mode" is false for this shape: the primitive is reached from the *predicate*, and a human's *no* then **stops** an action observe mode promises to run | **correctness** | §3.6 now requires it; §12.9 |
+| Q4 | §3.4 rebuilds the request's `Action` "with those arguments" — replace or overlay? Under replace, a tool with a defaulted parameter can never match, so the honest adapter with the honest declaration is the one that breaks | **correctness** | §3.5, with a README requirement |
+| Q5 | Nothing in five specifications addresses `async` — may `interrupt()` be called inside a running loop? Does `@protect` wrap a coroutine? | **correctness** | §3.5.1 |
+| Q6 | What does `invoke` do when the framework refuses *before* invoking? Returning a value is `never-executes`; returning `None` is undefined | correctness | §5.2 code block |
+| Q7 | `needs_approval` cannot see the effect key, so an unresolvable template asks a human and *then* fails — the waste `v0.1 §5.1` exists to prevent | correctness | §3.5, stated as a cost |
+| Q8 | Is `resource` a template core resolves, or a literal? The whole contract answered this once, in a parenthesis of `ARCHITECTURE.md` | correctness | §3.5 |
+| Q9 | The kit's executor signature is an unstated contract — must arguments be spread as keywords? | correctness | §5.2 |
+| Q10 | `@protect(wait=True)` is mandatory and §2.3's *must call* paragraph did not say so | correctness | §2.3 |
+| Q11 | Six names the may-call list is written in are frozen nowhere, including `ApprovalStore` in a §9 signature | correctness | §2.3 |
+| Q12 | `Case` is public in `SUITES`' type and defined nowhere | style | §5.2 |
+| Q13 | A Protocol class-attribute default cannot reach a non-inheriting adapter, so `refuses_before_invoking`'s default must mean `getattr(..., False)` | style | §5.2 |
+| Q14 | "May raise its own type" — of its own choosing, or one it defined? It decides whether `except CTRLRunError` catches it | style | §10 |
+
+`SPEC-v0.5.md` §12.10 records what the exercise says about the document as a whole, and §12.9 is
+the observe-mode defect it found in a **shipping** adapter without reading a line of it.
 
 If you write an adapter and the contract cannot answer something, that is a defect in the
 contract. Please open an issue saying what you were writing when you got stuck.

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -803,3 +803,48 @@ def test_every_documented_install_names_a_distribution_this_repository_builds():
                 unknown.append(f"{document.name}: {match}")
 
     assert unknown == [], unknown
+
+
+def test_T138_item_sixs_questions_are_recorded_and_each_is_answered():
+    """SPEC-v0.5 §8 T138: a third adapter was written against the contract alone, and **the list
+    of questions it could not answer is the deliverable**, recorded in `docs/adapters.md` with
+    each answered by an edit to `SPEC-v0.5.md`.
+
+    *"If the list cannot be emptied, v0.5 is not done."* So this asserts the list exists, that
+    every entry names where it was answered, and that the sections it names are real. The
+    adapter itself is disposable and is deliberately not in the repository — asserting its
+    existence would be asserting the wrong half.
+
+    This test was missing when v0.5 was otherwise complete, and `docs/adapters.md` carried a
+    summary of the list rather than the list. A summary cannot be checked against the spec.
+    """
+    adapters = REPO_ROOT / "docs" / "adapters.md"
+    spec = REPO_ROOT / "docs" / "SPEC-v0.5.md"
+    if not adapters.exists() or not spec.exists():  # pragma: no cover - not a checkout
+        pytest.skip("no repository checkout")
+
+    text = adapters.read_text(encoding="utf-8")
+    rows = re.findall(r"^\| (Q\d+) \| (.+?) \| (.+?) \| (.+?) \|$", text, re.M)
+
+    assert len(rows) >= 14, f"item 6 raised fourteen questions; {len(rows)} are recorded"
+    assert [q for q, *_ in rows] == [f"Q{n}" for n in range(1, len(rows) + 1)], [
+        q for q, *_ in rows
+    ]
+
+    # Every row says where it was answered, and every section it names exists in the spec.
+    spec_text = spec.read_text(encoding="utf-8")
+    unanswered = [q for q, _, _, answer in rows if not answer.strip()]
+    assert unanswered == [], unanswered
+
+    cited = {
+        section for _, _, _, answer in rows for section in re.findall(r"§(\d+(?:\.\d+)*)", answer)
+    }
+    assert cited, "no row names a section of SPEC-v0.5"
+    missing = [
+        s for s in sorted(cited) if f"### {s} " not in spec_text and f"## {s}. " not in spec_text
+    ]
+    assert missing == [], f"rows cite sections that do not exist: {missing}"
+
+    # The four the report called security- or correctness-critical are marked as such.
+    severities = {severity.strip().strip("*").lower() for _, _, severity, _ in rows}
+    assert "security" in severities, severities

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -824,7 +824,11 @@ def test_T138_item_sixs_questions_are_recorded_and_each_is_answered():
         pytest.skip("no repository checkout")
 
     text = adapters.read_text(encoding="utf-8")
-    rows = re.findall(r"^\| (Q\d+) \| (.+?) \| (.+?) \| (.+?) \|$", text, re.M)
+    # The answer column is `(.*?)` and not `(.+?)` on purpose: an **empty** answer must still
+    # match, so the "every row says where it was answered" check below is what catches it. With
+    # `(.+?)` the row simply stopped being a row and the count assertion caught it instead --
+    # a subsumed guard, found by mutating an answer to empty and watching the wrong test fail.
+    rows = re.findall(r"^\| (Q\d+) \| (.+?) \| (.+?) \|(.*?)\|$", text, re.M)
 
     assert len(rows) >= 14, f"item 6 raised fourteen questions; {len(rows)} are recorded"
     assert [q for q, *_ in rows] == [f"Q{n}" for n in range(1, len(rows) + 1)], [


### PR DESCRIPTION
**v0.5 was not done.** `SPEC-v0.5.md` §8 names twenty-seven acceptance tests; twenty-six had one.

The missing one is **T138**, which is the milestone's own question in test form:

> A third adapter, written against this document alone. Exists, passes the kit, and its author's list of questions this document could not answer is recorded — in `docs/adapters.md`, with each answered by an edit to `SPEC-v0.5.md` in the same PR. **The list is the deliverable and the adapter is disposable.** If the list cannot be emptied, v0.5 is not done.

`docs/adapters.md` *described* the list — "fourteen questions, four of which would have produced an insecure or unimplementable adapter" — and pointed at §12.10. A description of a list cannot be checked against the document it is supposed to have changed, and "four serious" is exactly the kind of claim that stops being true quietly.

## The list, recorded

Fourteen rows, each with its severity and the section that answers it. The four marked security or correctness are the ones that would have produced a broken adapter:

| | |
|---|---|
| **Q1** `ctrlrun.context()` off the never-list | supplies a principal without naming the type; passes T129 because that test uses a `Control` **with** an identity provider |
| **Q2** constructing `InterruptApprovalProvider` | §9 rested a security argument on "an adapter does not", and nothing forbade it |
| **Q3** observe mode | §3.6's rule is false for the decided-before-invocation shape — a human's *no* **stops** an action observe mode promises to run |
| **Q4** rebuild semantics vs defaults | under *replace*, a tool with a defaulted parameter can never match, so the honest adapter with the honest declaration is the one that breaks |

## The test

`test_T138_...` asserts the rows exist, are numbered without gaps, all name where they were answered, and that **every section they cite exists in `SPEC-v0.5.md`** — so a row pointing at a section nobody wrote fails.

It deliberately does **not** assert the adapter exists. The adapter is disposable and is not in this repository; asserting it would be asserting the wrong half.

Mutation table:

| mutation | caught by |
|---|---|
| drop a row | the count |
| empty an answer | `unanswered` |
| cite `§9.9.9` | the section check |

The middle row is a fix in itself: the answer column was `(.+?)`, so emptying it made the row stop matching and the **count** caught it while the check written for it never ran — a subsumed guard. It is `(.*?)` now.

## Verification

`ruff format --check` · `ruff check` · `mypy --strict src` · **2262 passed**