### PR TITLE
Item 4: cross-host concurrency and failure injection (rebuilt after review)

### DIFF
--- a/docs/SPEC-v0.6.md
+++ b/docs/SPEC-v0.6.md
@@ -1003,6 +1003,36 @@ a reused `action_id` at any other instant, with any other lease, or at a differe
 number differs in a column and is refused. Only a clock frozen *across processes* — which is a
 test harness, not a deployment — produces two rows a store cannot tell apart.
 
+### 4.3.4 Which row ran is observable
+
+A store that takes any branch of §4.3.2 MUST say which one, on the `ctrlrun.postgres` logger, at
+`WARNING`, with a `branch` attribute drawn from this closed set:
+
+| `branch` | Meaning |
+|---|---|
+| `a1.row1.ours` | Table A1: the record is identical to the row we attempted to write (§4.3.3); the commit landed and we hold the key |
+| `a1.row2.reinsert` | Table A1: no record; the commit did not land, and the same operation is re-issued once |
+| `a1.row3.refuse` | Table A1: a record that is not ours; back through `plan_reservation`, which refuses |
+| `a2.row1.landed` | Table A2: the record is in the state we were writing, and ours; the commit landed |
+| `a2.row2.reissue` | Table A2: the record is unchanged and still ours; the conditional `UPDATE` is re-issued |
+| `a2.row3.refuse` | Table A2: anything else; back through the same predicate, which refuses |
+
+Reaching any of them means a store write's outcome was unobservable, which is worth a line in an
+operator's log whether or not it resolved cleanly. That is the smaller reason.
+
+The larger one is that **without it, §8's T155 cannot fail.** The outcome T155 asserts — a
+reservation that is ours, and a blind retry refused — is also exactly what a store that never
+re-read at all produces, because on that path the write *did* land. A review replaced
+`_resolve_lost_insert` with `return` and every assertion in T155 still passed. §8 had asked for
+this ("the events name which branch of §4.3.2 ran"); nothing implemented it, and the test that
+depended on it was green for a year of nobody noticing. A test that asserts an outcome rather
+than which guard produced it is this repository's first and most common mutation pattern, and the
+most important test in this milestone was an instance of it.
+
+This is not a new event type and does not touch §9's frozen names: `ctrlrun.receipt.Event` is
+unchanged, and nothing here reaches a sink. It is a log line, which is what this project already
+uses for everything a receipt does not carry.
+
 ### 4.4 Connections, encoding and collation
 
 - **One connection per thread**, as `SQLiteStateStore` does. `psycopg` connections are not

--- a/docs/SPEC-v0.6.md
+++ b/docs/SPEC-v0.6.md
@@ -944,7 +944,7 @@ Table A1 does not have.
 | What the re-read finds | Conclusion |
 |---|---|
 | The record in the state we were writing, still ours | the commit landed; proceed |
-| The record **unchanged and still ours** — the pre-state we matched on | the commit did **not** land; **re-issue the same `UPDATE`**, once, then refuse |
+| The record **unchanged** — the pre-state we matched on, and ours where the operation has an owner (§4.3.4) | the commit did **not** land; **re-issue the same `UPDATE`**, once, then refuse |
 | The record moved on, or no longer ours | feed it back through the same `_checked` predicate the transition uses, and raise what it raises |
 
 **Row 2 is the one that matters and the one a single table gets wrong.** A lost `COMMIT` on an
@@ -1014,8 +1014,17 @@ A store that takes any branch of §4.3.2 MUST say which one, on the `ctrlrun.pos
 | `a1.row2.reinsert` | Table A1: no record; the commit did not land, and the same operation is re-issued once |
 | `a1.row3.refuse` | Table A1: a record that is not ours; back through `plan_reservation`, which refuses |
 | `a2.row1.landed` | Table A2: the record is in the state we were writing, and ours; the commit landed |
-| `a2.row2.reissue` | Table A2: the record is unchanged and still ours; the conditional `UPDATE` is re-issued |
+| `a2.row2.reissue` | Table A2: the record is still in a pre-state the operation may be issued from; the conditional `UPDATE` is re-issued |
 | `a2.row3.refuse` | Table A2: anything else; back through the same predicate, which refuses |
+
+**`a2.row2.reissue` does not mean "still ours", and saying so would claim more than the code
+checks.** On a *transition* the row is ours — `action_id` and a pre-state in `expected`. On a
+*renewal* — a reservation over a `FAILED` record, `v0.1 §5.4`'s one automatic retry — the pre-state
+is `FAILED` and there is **no ownership test at all**, deliberately: a `FAILED` record is one
+nobody holds, and requiring it to carry our `action_id` would forbid the retry the row exists for.
+The ownership decision on that path belongs to `plan_reservation`, which the re-issue routes
+through. A review found the first wording of this row describing a check the renewal path does not
+perform, which is the prevention-versus-attribution confusion in one table cell.
 
 Reaching any of them means a store write's outcome was unobservable, which is worth a line in an
 operator's log whether or not it resolved cleanly. That is the smaller reason.
@@ -2093,6 +2102,13 @@ any depth. `canonicalize(action)` is redefined to call it, so the chain (§6.2) 
 (§7.1) provably share one implementation with the action hash instead of having a second that
 agrees today. It clears §9.2's bar in the only way a new public name can here: without it, the
 alternative is a private second canonicalizer, and §6.2 forbids that by name.
+
+`ctrlrun.postgres` also exports the six **branch names** of §4.3.4 — `A1_OURS`, `A1_REINSERT`,
+`A1_REFUSE`, `A2_LANDED`, `A2_REISSUE`, `A2_REFUSE` — beside the `STATED_ABORTS` and
+`AmbiguousWrite` it already had. They are constants a test asserts against, and spelling the
+strings out at each call site is how a closed set stops being one. Listing them is the same
+correction the conformance package's paragraph above records: a draft that says *"and no other
+public name"* while the module has an `__all__` is a sentence nobody can obey.
 
 **And no other public name.** No new `Control` method, no new store method, no new event type, no
 new CLI command, no new approval provider, no new sink.

--- a/src/ctrlrun/postgres.py
+++ b/src/ctrlrun/postgres.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import threading
 from collections.abc import Callable
 from dataclasses import replace
@@ -105,6 +106,37 @@ _UNFINISHED: Final = frozenset({EffectState.RESERVED, EffectState.EXECUTING, Eff
 #: ambiguous case, and a cancellation that arrived while the server was committing may or may not
 #: have prevented it.
 STATED_ABORTS: Final = frozenset({"40001", "40P01"})
+
+_LOG = logging.getLogger(__name__)
+
+#: SPEC-v0.6 §4.3.4. The closed set of §4.3.2 branches, reported on the `ctrlrun.postgres` logger
+#: as `branch=` so a test -- and an operator reading a log after an incident -- can tell **which
+#: row** of Table A a lost `COMMIT` took.
+#:
+#: This exists because §8's T155 asks that "the events name which branch of §4.3.2 ran" and
+#: nothing implemented it, which made the test unfalsifiable: the outcome T155 asserted (a
+#: reservation that is ours, a blind retry refused) is *also* what a store that never re-read
+#: produces, because in that scenario the write did land. A review replaced
+#: `_resolve_lost_insert` with `return` and T155 still passed.
+#:
+#: Reported at WARNING because reaching any of these means a store write's outcome was
+#: unobservable, which is worth a line in an operator's log whether or not it resolved cleanly.
+A1_OURS: Final = "a1.row1.ours"
+A1_REINSERT: Final = "a1.row2.reinsert"
+A1_REFUSE: Final = "a1.row3.refuse"
+A2_LANDED: Final = "a2.row1.landed"
+A2_REISSUE: Final = "a2.row2.reissue"
+A2_REFUSE: Final = "a2.row3.refuse"
+
+
+def _took(branch: str, effect_key: str) -> None:
+    """Say which row of §4.3.2's tables resolved an ambiguous store write."""
+    _LOG.warning(
+        "ambiguous store write on effect %r resolved by %s",
+        effect_key,
+        branch,
+        extra={"branch": branch, "effect_key": effect_key},
+    )
 
 
 def _psycopg() -> Any:
@@ -570,12 +602,15 @@ class PostgresStateStore:
         if found is None:
             raise InvalidArgument(f"no reservation for effect {effect_key!r}")
         if found.action_id == reservation.action_id and found.state is EffectState.RESERVED:
+            _took(A2_LANDED, effect_key)
             return  # the commit landed
         if found.state is EffectState.FAILED:
+            _took(A2_REISSUE, effect_key)
             self._authorize_and_reserve(
                 None, None, effect_key, reservation.action_id, lease, retrying=True
             )
             return
+        _took(A2_REFUSE, effect_key)
         plan = plan_reservation(found, effect_key, reservation.action_id, lease, now)
         if plan.refusal is not None:
             raise plan.refusal
@@ -606,13 +641,16 @@ class PostgresStateStore:
             # operation was a double-spend: the effect was reserved, the caller was handed an
             # `Approval`, and the approval row was still `granted`, so the same approval then
             # authorised a second effect key. Found by review.
+            _took(A1_REINSERT, effect_key)
             self._authorize_and_reserve(
                 approval_id, action_hash, effect_key, reservation.action_id, lease, retrying=True
             )
             return
         expected = _reserved(reservation, None, now)
         if _is_our_own_write(found, expected):
+            _took(A1_OURS, effect_key)
             return  # the commit landed; we hold it
+        _took(A1_REFUSE, effect_key)
         plan = plan_reservation(found, effect_key, reservation.action_id, lease, now)
         if plan.refusal is not None:
             raise plan.refusal
@@ -849,6 +887,7 @@ class PostgresStateStore:
         *,
         result: Any = None,
         error: str | None = None,
+        retrying: bool = False,
     ) -> None:
         """One compare-and-set, with the row count checked (§4.2).
 
@@ -906,6 +945,15 @@ class PostgresStateStore:
         try:
             self._commit(connection)
         except AmbiguousWrite:
+            if retrying:
+                # §4.2's bound, the one `_authorize_and_reserve` already had and this path did
+                # not. Table A2's re-issue calls back into `_transition`, whose `COMMIT` can be
+                # lost again, which re-entered the same resolution with nothing to stop it.
+                # Driven by a proxy that swallows every `COMMIT`, it recursed 96 deep and escaped
+                # as `RecursionError` -- outside this library's closed set of errors, so no caller
+                # could classify it -- leaving the record stranded `EXECUTING`. Found by review.
+                # *Every loop in this project is bounded*, and a re-read path is a loop.
+                raise
             self._resolve_lost_update(effect_key, action_id, state, expected, result, error)
 
     def _resolve_lost_update(
@@ -934,10 +982,15 @@ class PostgresStateStore:
         if found is None:
             raise InvalidArgument(f"no reservation for effect {effect_key!r}")
         if found.state is state and found.action_id == action_id:
+            _took(A2_LANDED, effect_key)
             return  # the commit landed
         if found.action_id == action_id and found.state in expected:
-            self._transition(effect_key, action_id, state, expected, result=result, error=error)
+            _took(A2_REISSUE, effect_key)
+            self._transition(
+                effect_key, action_id, state, expected, result=result, error=error, retrying=True
+            )
             return
+        _took(A2_REFUSE, effect_key)
         _checked(found, effect_key, action_id, expected, self._clock())
 
     def resolve_effect(self, effect_key: str, state: EffectState, resolver: str) -> EffectRecord:

--- a/tests/failure_injection.py
+++ b/tests/failure_injection.py
@@ -1,6 +1,8 @@
 """A Postgres connection an experiment can break on purpose. Build-list item 4; SPEC-v0.6 §4.5.
 
-Test infrastructure, never packaged: `pyproject.toml`'s `packages.find` is `src/` only.
+Test infrastructure. It is never in the wheel -- `pyproject.toml`'s `packages.find` is `src/`
+only -- and it *is* in the sdist, because `MANIFEST.in`'s `recursive-include tests *.py` puts
+every test file there, which is correct and true of all of them.
 
 **Why a proxy and not a container.** §4.5's most important test is *the connection dies during
 `COMMIT`* -- the case where a naive port reports `FAILED` for an effect that committed. Killing a
@@ -11,6 +13,15 @@ container reproduces that only if the timing happens to land there; a proxy that
 
 What a proxy cannot do is put the two ends on different hosts. §4.5 asks for that separately and
 the PR says which was run.
+
+**The frontend protocol is parsed, not grepped.** The first version triggered on
+`b"COMMIT" in data`, which fires on any chunk in the client-to-server direction carrying those
+six bytes -- including a Bind message whose *parameter* is an effect key containing the word. An
+independent review demonstrated it: a key named `refund:COMMIT-me` killed the client on the
+`SELECT`'s Bind, which is §4.3's Table A row 1 (an exception *before* `COMMIT`, a clean `FAILED`)
+and not the ambiguous window at all -- and `clients_killed >= 1`, the guard added specifically to
+catch that class of false green, still passed. `_Frontend` below reads the length-prefixed
+messages properly, so a `COMMIT` means the simple-Query message `COMMIT`.
 """
 
 from __future__ import annotations
@@ -21,27 +32,102 @@ import threading
 from dataclasses import dataclass, field
 from urllib.parse import urlsplit, urlunsplit
 
-#: Every wait here is bounded, so a broken check fails red rather than hanging CI.
-TIMEOUT = 20.0
+#: How long `stop()` waits for a relay thread to notice `_stop` and exit. The relay's *pumps* are
+#: not bounded by this and must not be: a timeout that abandons a live pump and closes the socket
+#: under it delivers a reset to the client, which silently changes what a partition test observes.
+#: The first version did exactly that, and its 40-second "partition" was this constant twice over.
+SHUTDOWN_TIMEOUT = 10.0
+
+#: libpq's SSLRequest, which precedes the startup packet and carries no message-type byte.
+_SSL_REQUEST = 80877103
+
+
+class _Frontend:
+    """Just enough of the Postgres v3 frontend protocol to recognise one message.
+
+    A client stream is: an optional SSLRequest and then the startup packet, both `int32 length`
+    with no type byte, followed by typed messages -- `byte1 type`, `int32 length` (counting
+    itself), body. Messages split across `recv` boundaries, so this buffers.
+    """
+
+    def __init__(self) -> None:
+        self._buffer = b""
+        self._started = False
+
+    def feed(self, data: bytes) -> list[tuple[bytes, bytes, int]]:
+        """Complete messages in `data`, as `(type, body, offset)`.
+
+        `type` is empty for the untyped startup messages. `offset` is where the message begins
+        **relative to `data`**, negative if it began in an earlier chunk -- which is what
+        `drop_before_commit` needs to know how much of the chunk precedes the `COMMIT`.
+        """
+        pending = len(self._buffer)
+        self._buffer += data
+        consumed = 0
+        messages: list[tuple[bytes, bytes, int]] = []
+        while True:
+            if not self._started:
+                if len(self._buffer) < 8:
+                    break
+                length = int.from_bytes(self._buffer[:4], "big")
+                if length < 8 or len(self._buffer) < length:
+                    break
+                body = self._buffer[4:length]
+                self._buffer = self._buffer[length:]
+                if int.from_bytes(body[:4], "big") != _SSL_REQUEST:
+                    self._started = True
+                messages.append((b"", body, consumed - pending))
+                consumed += length
+                continue
+            if len(self._buffer) < 5:
+                break
+            kind = self._buffer[0:1]
+            length = int.from_bytes(self._buffer[1:5], "big")
+            if length < 4 or len(self._buffer) < 1 + length:
+                break
+            body = self._buffer[5 : 1 + length]
+            self._buffer = self._buffer[1 + length :]
+            messages.append((kind, body, consumed - pending))
+            consumed += 1 + length
+        return messages
+
+
+def is_commit(kind: bytes, body: bytes) -> bool:
+    """A simple-Query message whose statement is exactly `COMMIT`."""
+    if kind != b"Q":
+        return False
+    return body.split(b"\x00", 1)[0].strip().upper() == b"COMMIT"
 
 
 @dataclass
 class Proxy:
     """A TCP relay in front of Postgres, with a switch for each way it can break.
 
-    Three modes, each named for the row of §4.3's Table A it produces:
+    Four modes, each named for the row of §4.3's Table A it produces:
 
     - `kill_on_commit` -- forward the `COMMIT` to the server, let it land, then drop the client.
-      The server very likely committed and the client will never know: **ambiguous**.
-    - `refuse_connections` -- accept nothing. A store's re-read then fails, which §4.3.2 says
-      must refuse to let execution proceed rather than guess.
-    - `partition` -- accept, then swallow traffic in both directions. The client sees a stall,
-      not a reset, which is the shape a network partition actually has.
+      The server very likely committed and the client will never know: **ambiguous**, and the
+      re-read finds the write already there (Table A1 row 1 / A2 row 1).
+    - `drop_before_commit` -- an integer: swallow the next N `COMMIT`s and drop the client each
+      time, **without** forwarding them. Equally ambiguous from the client's side, and the write
+      is *not* there: this is what drives A1's "no record → retry the insert" and A2's "unchanged
+      and still ours → re-issue", the two rows nothing reached before. A count rather than a flag
+      because those rows *re-issue* -- a flag would swallow the retry's `COMMIT` too, and the test
+      could never observe the row completing. Set it high to drive the unbounded case instead.
+    - `refuse_connections` -- accept and immediately close, which is a reset rather than an
+      `ECONNREFUSED`. A store's re-read then fails, which §4.3.2 says must refuse to let
+      execution proceed rather than guess.
+    - `partition` -- **hold** traffic in both directions rather than discarding it, and release
+      it when the partition is lifted. The client sees a stall, not a reset, and `partition =
+      False` genuinely restores the connection, which is §4.5's "and restore it". Discarding
+      instead would make the restore unexercisable: the query the server never received cannot
+      arrive late.
     """
 
     upstream_host: str
     upstream_port: int
     kill_on_commit: bool = False
+    drop_before_commit: int = 0
     refuse_connections: bool = False
     partition: bool = False
 
@@ -49,11 +135,19 @@ class Proxy:
     _server: socket.socket | None = None
     _thread: threading.Thread | None = None
     _stop: threading.Event = field(default_factory=threading.Event)
-    #: Every commit the proxy has seen go past, so a test can assert its window opened.
+    #: `COMMIT` messages the proxy parsed out of the client stream, in every mode. Distinct from
+    #: `clients_killed`, which counts drops -- the two were incremented on adjacent lines under
+    #: one condition before, so a PR body claiming to assert one "rather than" the other was
+    #: describing a distinction that did not exist.
     commits_seen: int = 0
-    #: How many client connections were dropped mid-`COMMIT`. A test asserts this rather than
-    #: assuming its window opened.
+    #: Client connections dropped, by either kill mode.
     clients_killed: int = 0
+    #: `COMMIT` messages the proxy swallowed rather than forwarded (`drop_before_commit`).
+    commits_dropped: int = 0
+    #: Set if the server ever accepted an SSLRequest. Everything after that is ciphertext and no
+    #: `COMMIT` would ever be recognised -- a test asserting `commits_seen` would fail loudly, but
+    #: this says why. Local connections in CI negotiate no TLS.
+    tls_negotiated: bool = False
     _lock: threading.Lock = field(default_factory=threading.Lock)
 
     def start(self) -> Proxy:
@@ -71,7 +165,19 @@ class Proxy:
         if self._server is not None:
             with_suppress(self._server.close)
         if self._thread is not None:
-            self._thread.join(timeout=TIMEOUT)
+            self._thread.join(timeout=SHUTDOWN_TIMEOUT)
+
+    def reset_counters(self) -> None:
+        """Zero the counters, so a test asserts a delta rather than a total.
+
+        Constructing a store issues a `COMMIT` of its own -- the migration -- and reserving before
+        the interesting call issues more, all before any injection is armed. A test that asserted
+        `commits_seen == 1` would be counting those too.
+        """
+        with self._lock:
+            self.commits_seen = 0
+            self.clients_killed = 0
+            self.commits_dropped = 0
 
     def url(self, template: str) -> str:
         """`template` with its host and port pointed at this proxy."""
@@ -97,10 +203,16 @@ class Proxy:
                 continue
             threading.Thread(target=self._relay, args=(client,), daemon=True).start()
 
+    @staticmethod
+    def _drop(client: socket.socket, killed: threading.Event) -> None:
+        killed.set()
+        with_suppress(client.shutdown, socket.SHUT_RDWR)
+        with_suppress(client.close)
+
     def _relay(self, client: socket.socket) -> None:
         try:
             server = socket.create_connection(
-                (self.upstream_host, self.upstream_port), timeout=TIMEOUT
+                (self.upstream_host, self.upstream_port), timeout=SHUTDOWN_TIMEOUT
             )
         except OSError:
             with_suppress(client.close)
@@ -109,7 +221,17 @@ class Proxy:
 
         def pump(source: socket.socket, sink: socket.socket, watching: bool) -> None:
             source.settimeout(0.2)
+            frontend = _Frontend() if watching else None
+            held: list[bytes] = []
             while not self._stop.is_set() and not killed.is_set():
+                if not self.partition and held:
+                    # The partition lifted: release what it held, in order, before anything new.
+                    try:
+                        for chunk in held:
+                            sink.sendall(chunk)
+                    except OSError:
+                        break
+                    held = []
                 try:
                     data = source.recv(65536)
                 except TimeoutError:
@@ -119,15 +241,45 @@ class Proxy:
                 if not data:
                     break
                 if self.partition:
-                    continue  # swallowed: a stall, not a reset
+                    held.append(data)  # held, not discarded: a stall the restore can undo
+                    continue
+                commit_at = -1
+                if frontend is not None:
+                    for kind, body, offset in frontend.feed(data):
+                        if not is_commit(kind, body):
+                            continue
+                        with self._lock:
+                            self.commits_seen += 1
+                        if commit_at < 0:
+                            commit_at = max(0, offset)
+                elif data == b"S":
+                    # The server accepted an SSLRequest. Everything after is ciphertext.
+                    with self._lock:
+                        self.tls_negotiated = True
+
+                dropping = False
+                if commit_at >= 0:
+                    with self._lock:
+                        if self.drop_before_commit > 0:
+                            self.drop_before_commit -= 1
+                            self.commits_dropped += 1
+                            self.clients_killed += 1
+                            dropping = True
+                if dropping:
+                    # Everything before the COMMIT goes; the COMMIT itself never does. The server
+                    # rolls the transaction back when the connection dies, so the write is
+                    # genuinely absent -- and the client cannot tell that from the case where it
+                    # landed, which is what makes both rows of Table A reachable.
+                    with_suppress(sink.sendall, data[:commit_at])
+                    self._drop(client, killed)
+                    return
+
                 try:
                     sink.sendall(data)
                 except OSError:
                     break
-                if watching and self.kill_on_commit and b"COMMIT" in data:
-                    with self._lock:
-                        self.commits_seen += 1
-                        self.clients_killed += 1
+
+                if commit_at >= 0 and self.kill_on_commit:
                     # The server has the COMMIT and will apply it. The client's connection goes
                     # **immediately**, so the response never gets back: the write very likely
                     # landed and the client will never be told, which is §4.3's ambiguous store
@@ -136,19 +288,22 @@ class Proxy:
                     # The first version slept 50ms here "to let the server apply it", which on a
                     # local socket is long enough for the reply to arrive -- so `commit()`
                     # returned normally and the store never took the ambiguous path at all. The
-                    # test asserting that path passed anyway. Closing at once is the whole
-                    # mechanism.
-                    killed.set()
-                    with_suppress(client.shutdown, socket.SHUT_RDWR)
-                    with_suppress(client.close)
+                    # test asserting that path passed anyway. Closing at once is the mechanism.
+                    with self._lock:
+                        self.clients_killed += 1
+                    self._drop(client, killed)
                     return
 
         forward = threading.Thread(target=pump, args=(client, server, True), daemon=True)
         backward = threading.Thread(target=pump, args=(server, client, False), daemon=True)
         forward.start()
         backward.start()
-        forward.join(timeout=TIMEOUT)
-        backward.join(timeout=TIMEOUT)
+        # No timeout. A join that gives up and closes these sockets underneath its own live pumps
+        # turns a stall into a reset at a deadline the *proxy* owns, which is how the partition
+        # test came to measure `TIMEOUT * 2` and call it a network property. The pumps exit on
+        # `_stop`, which `stop()` sets, so teardown still ends them.
+        forward.join()
+        backward.join()
         with_suppress(client.close)
         with_suppress(server.close)
 

--- a/tests/failure_injection.py
+++ b/tests/failure_injection.py
@@ -1,0 +1,164 @@
+"""A Postgres connection an experiment can break on purpose. Build-list item 4; SPEC-v0.6 §4.5.
+
+Test infrastructure, never packaged: `pyproject.toml`'s `packages.find` is `src/` only.
+
+**Why a proxy and not a container.** §4.5's most important test is *the connection dies during
+`COMMIT`* -- the case where a naive port reports `FAILED` for an effect that committed. Killing a
+container reproduces that only if the timing happens to land there; a proxy that forwards the
+`COMMIT` to the server and *then* drops the client reproduces it every time, which is what
+"opens its window on purpose" means, and this project's standing rule is that a test which
+"usually" reproduces an interleaving proves nothing about the run where it did not.
+
+What a proxy cannot do is put the two ends on different hosts. §4.5 asks for that separately and
+the PR says which was run.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import socket
+import threading
+from dataclasses import dataclass, field
+from urllib.parse import urlsplit, urlunsplit
+
+#: Every wait here is bounded, so a broken check fails red rather than hanging CI.
+TIMEOUT = 20.0
+
+
+@dataclass
+class Proxy:
+    """A TCP relay in front of Postgres, with a switch for each way it can break.
+
+    Three modes, each named for the row of §4.3's Table A it produces:
+
+    - `kill_on_commit` -- forward the `COMMIT` to the server, let it land, then drop the client.
+      The server very likely committed and the client will never know: **ambiguous**.
+    - `refuse_connections` -- accept nothing. A store's re-read then fails, which §4.3.2 says
+      must refuse to let execution proceed rather than guess.
+    - `partition` -- accept, then swallow traffic in both directions. The client sees a stall,
+      not a reset, which is the shape a network partition actually has.
+    """
+
+    upstream_host: str
+    upstream_port: int
+    kill_on_commit: bool = False
+    refuse_connections: bool = False
+    partition: bool = False
+
+    port: int = 0
+    _server: socket.socket | None = None
+    _thread: threading.Thread | None = None
+    _stop: threading.Event = field(default_factory=threading.Event)
+    #: Every commit the proxy has seen go past, so a test can assert its window opened.
+    commits_seen: int = 0
+    #: How many client connections were dropped mid-`COMMIT`. A test asserts this rather than
+    #: assuming its window opened.
+    clients_killed: int = 0
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def start(self) -> Proxy:
+        self._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server.bind(("127.0.0.1", 0))
+        self._server.listen(32)
+        self.port = self._server.getsockname()[1]
+        self._thread = threading.Thread(target=self._accept, daemon=True)
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._server is not None:
+            with_suppress(self._server.close)
+        if self._thread is not None:
+            self._thread.join(timeout=TIMEOUT)
+
+    def url(self, template: str) -> str:
+        """`template` with its host and port pointed at this proxy."""
+        parts = urlsplit(template)
+        userinfo = parts.netloc.split("@")[0] if "@" in parts.netloc else ""
+        netloc = f"{userinfo}@127.0.0.1:{self.port}" if userinfo else f"127.0.0.1:{self.port}"
+        return urlunsplit(parts._replace(netloc=netloc))
+
+    # --- the relay ----------------------------------------------------------------------
+
+    def _accept(self) -> None:
+        assert self._server is not None
+        self._server.settimeout(0.2)
+        while not self._stop.is_set():
+            try:
+                client, _ = self._server.accept()
+            except TimeoutError:
+                continue
+            except OSError:
+                return
+            if self.refuse_connections:
+                with_suppress(client.close)
+                continue
+            threading.Thread(target=self._relay, args=(client,), daemon=True).start()
+
+    def _relay(self, client: socket.socket) -> None:
+        try:
+            server = socket.create_connection(
+                (self.upstream_host, self.upstream_port), timeout=TIMEOUT
+            )
+        except OSError:
+            with_suppress(client.close)
+            return
+        killed = threading.Event()
+
+        def pump(source: socket.socket, sink: socket.socket, watching: bool) -> None:
+            source.settimeout(0.2)
+            while not self._stop.is_set() and not killed.is_set():
+                try:
+                    data = source.recv(65536)
+                except TimeoutError:
+                    continue
+                except OSError:
+                    break
+                if not data:
+                    break
+                if self.partition:
+                    continue  # swallowed: a stall, not a reset
+                try:
+                    sink.sendall(data)
+                except OSError:
+                    break
+                if watching and self.kill_on_commit and b"COMMIT" in data:
+                    with self._lock:
+                        self.commits_seen += 1
+                        self.clients_killed += 1
+                    # The server has the COMMIT and will apply it. The client's connection goes
+                    # **immediately**, so the response never gets back: the write very likely
+                    # landed and the client will never be told, which is §4.3's ambiguous store
+                    # write exactly.
+                    #
+                    # The first version slept 50ms here "to let the server apply it", which on a
+                    # local socket is long enough for the reply to arrive -- so `commit()`
+                    # returned normally and the store never took the ambiguous path at all. The
+                    # test asserting that path passed anyway. Closing at once is the whole
+                    # mechanism.
+                    killed.set()
+                    with_suppress(client.shutdown, socket.SHUT_RDWR)
+                    with_suppress(client.close)
+                    return
+
+        forward = threading.Thread(target=pump, args=(client, server, True), daemon=True)
+        backward = threading.Thread(target=pump, args=(server, client, False), daemon=True)
+        forward.start()
+        backward.start()
+        forward.join(timeout=TIMEOUT)
+        backward.join(timeout=TIMEOUT)
+        with_suppress(client.close)
+        with_suppress(server.close)
+
+
+def with_suppress(call, *arguments) -> None:  # type: ignore[no-untyped-def]
+    """Closing a socket that is already gone is not an error here; it is the expected case."""
+    with contextlib.suppress(OSError):
+        call(*arguments)
+
+
+def upstream_of(url: str) -> tuple[str, int]:
+    parts = urlsplit(url)
+    return parts.hostname or "127.0.0.1", parts.port or 5432

--- a/tests/failure_injection.py
+++ b/tests/failure_injection.py
@@ -29,10 +29,13 @@ from __future__ import annotations
 import contextlib
 import socket
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from urllib.parse import urlsplit, urlunsplit
 
-#: How long `stop()` waits for a relay thread to notice `_stop` and exit. The relay's *pumps* are
+#: How long `stop()` waits for the **accept** thread, and how long a relay waits to connect
+#: upstream. Relay threads are not joined at all; they notice `_stop` within one `recv` timeout
+#: and exit on their own. The relay's *pumps* are
 #: not bounded by this and must not be: a timeout that abandons a live pump and closes the socket
 #: under it delivers a reset to the client, which silently changes what a partition test observes.
 #: The first version did exactly that, and its 40-second "partition" was this constant twice over.
@@ -111,17 +114,17 @@ class Proxy:
     - `drop_before_commit` -- an integer: swallow the next N `COMMIT`s and drop the client each
       time, **without** forwarding them. Equally ambiguous from the client's side, and the write
       is *not* there: this is what drives A1's "no record → retry the insert" and A2's "unchanged
-      and still ours → re-issue", the two rows nothing reached before. A count rather than a flag
+      → re-issue", the two rows nothing reached before. A count rather than a flag
       because those rows *re-issue* -- a flag would swallow the retry's `COMMIT` too, and the test
       could never observe the row completing. Set it high to drive the unbounded case instead.
-    - `refuse_connections` -- accept and immediately close, which is a reset rather than an
-      `ECONNREFUSED`. A store's re-read then fails, which §4.3.2 says must refuse to let
-      execution proceed rather than guess.
-    - `partition` -- **hold** traffic in both directions rather than discarding it, and release
-      it when the partition is lifted. The client sees a stall, not a reset, and `partition =
-      False` genuinely restores the connection, which is §4.5's "and restore it". Discarding
-      instead would make the restore unexercisable: the query the server never received cannot
-      arrive late.
+    - `refuse_connections` -- accept and immediately close. The client's first `recv` returns
+      `b""`: an orderly close, not an `ECONNREFUSED` and not a reset either. A store's re-read
+      then fails, which §4.3.2 says must refuse to let execution proceed rather than guess.
+    - `partition` -- **hold** traffic in both directions rather than discarding it, and release it
+      through the same path it would have taken live, so the frame parser stays aligned. The
+      client sees a stall, not a reset, and `partition = False` genuinely restores the connection,
+      which is §4.5's "and restore it". Discarding instead would make the restore unexercisable:
+      the query the server never received cannot arrive late.
     """
 
     upstream_host: str
@@ -135,7 +138,9 @@ class Proxy:
     _server: socket.socket | None = None
     _thread: threading.Thread | None = None
     _stop: threading.Event = field(default_factory=threading.Event)
-    #: `COMMIT` messages the proxy parsed out of the client stream, in every mode. Distinct from
+    #: `COMMIT` messages the proxy parsed out of the client stream -- in every mode **except**
+    #: while a partition is up, where bytes are held and are parsed only when it lifts. Distinct
+    #: from
     #: `clients_killed`, which counts drops -- the two were incremented on adjacent lines under
     #: one condition before, so a PR body claiming to assert one "rather than" the other was
     #: describing a distinction that did not exist.
@@ -144,6 +149,11 @@ class Proxy:
     clients_killed: int = 0
     #: `COMMIT` messages the proxy swallowed rather than forwarded (`drop_before_commit`).
     commits_dropped: int = 0
+    #: Called once, on the proxy's own thread, immediately after a client is dropped and
+    #: **before** the store's re-read can run. It is the only way to reach §4.3.2's *refuse* rows
+    #: deterministically: those need somebody else to have acted in the window between our lost
+    #: `COMMIT` and our re-read, and without a hook that is a race a test can only hope for.
+    on_drop: Callable[[], None] | None = None
     #: Set if the server ever accepted an SSLRequest. Everything after that is ciphertext and no
     #: `COMMIT` would ever be recognised -- a test asserting `commits_seen` would fail loudly, but
     #: this says why. Local connections in CI negotiate no TLS.
@@ -203,6 +213,13 @@ class Proxy:
                 continue
             threading.Thread(target=self._relay, args=(client,), daemon=True).start()
 
+    def _after_drop(self) -> None:
+        """Let a test act in the window the drop opened, before the store re-reads."""
+        hook = self.on_drop
+        if hook is not None:
+            self.on_drop = None  # once; a re-read that reconnects must not re-trigger it
+            hook()
+
     @staticmethod
     def _drop(client: socket.socket, killed: threading.Event) -> None:
         killed.set()
@@ -223,26 +240,18 @@ class Proxy:
             source.settimeout(0.2)
             frontend = _Frontend() if watching else None
             held: list[bytes] = []
-            while not self._stop.is_set() and not killed.is_set():
-                if not self.partition and held:
-                    # The partition lifted: release what it held, in order, before anything new.
-                    try:
-                        for chunk in held:
-                            sink.sendall(chunk)
-                    except OSError:
-                        break
-                    held = []
-                try:
-                    data = source.recv(65536)
-                except TimeoutError:
-                    continue
-                except OSError:
-                    break
-                if not data:
-                    break
-                if self.partition:
-                    held.append(data)  # held, not discarded: a stall the restore can undo
-                    continue
+
+            def deliver(data: bytes) -> bool:
+                """Parse, inject, forward. Returns False when this pump is done.
+
+                **Held bytes come back through here, not straight to the socket.** The first
+                version released a partition by `sendall`-ing the held chunks directly, which
+                bypassed the parser -- so a partition that began mid-frame left `_Frontend`
+                permanently misaligned and every later `COMMIT` invisible. Measured: a mid-frame
+                partition, then a restore, then a `COMMIT` the server executed, with
+                `commits_seen = 0` and `clients_killed = 0`. An injector that silently stops
+                injecting is the exact false green this file exists to eliminate.
+                """
                 commit_at = -1
                 if frontend is not None:
                     for kind, body, offset in frontend.feed(data):
@@ -271,13 +280,30 @@ class Proxy:
                     # genuinely absent -- and the client cannot tell that from the case where it
                     # landed, which is what makes both rows of Table A reachable.
                     with_suppress(sink.sendall, data[:commit_at])
+                    # The server end goes first, and at once. The backend is holding an open
+                    # transaction and its row locks; until it sees the connection die it will not
+                    # roll back, so anything else touching that row blocks. Leaving it to the
+                    # relay's own teardown deadlocked `on_drop`: the hook ran on this thread, the
+                    # relay was waiting for this thread before closing the socket, and the hook was
+                    # waiting for the lock that socket was holding open.
+                    #
+                    # `kill_on_commit` deliberately does NOT do this -- there the COMMIT has been
+                    # forwarded and must be allowed to land, and closing on unread data can send a
+                    # reset instead of a FIN.
+                    with_suppress(sink.shutdown, socket.SHUT_RDWR)
+                    with_suppress(sink.close)
+                    # Then the hook, and only then the client. The client is still blocked waiting
+                    # for a COMMIT reply that will never come, so it cannot race the hook. Dropping
+                    # it first made the window a race the store usually won: it re-read before the
+                    # hook's write landed, found nothing, and took A1 row 2 instead of row 3.
+                    self._after_drop()
                     self._drop(client, killed)
-                    return
+                    return False
 
                 try:
                     sink.sendall(data)
                 except OSError:
-                    break
+                    return False
 
                 if commit_at >= 0 and self.kill_on_commit:
                     # The server has the COMMIT and will apply it. The client's connection goes
@@ -291,7 +317,30 @@ class Proxy:
                     # test asserting that path passed anyway. Closing at once is the mechanism.
                     with self._lock:
                         self.clients_killed += 1
+                    self._after_drop()
                     self._drop(client, killed)
+                    return False
+                return True
+
+            while not self._stop.is_set() and not killed.is_set():
+                if not self.partition and held:
+                    # The partition lifted: release what it held, in order, before anything new.
+                    pending, held = held, []
+                    for chunk in pending:
+                        if not deliver(chunk):
+                            return
+                try:
+                    data = source.recv(65536)
+                except TimeoutError:
+                    continue
+                except OSError:
+                    break
+                if not data:
+                    break
+                if self.partition:
+                    held.append(data)  # held, not discarded: a stall the restore can undo
+                    continue
+                if not deliver(data):
                     return
 
         forward = threading.Thread(target=pump, args=(client, server, True), daemon=True)

--- a/tests/test_cross_host.py
+++ b/tests/test_cross_host.py
@@ -33,6 +33,7 @@ version of this file passed while exercising almost none of what it named:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -50,7 +51,7 @@ from pathlib import Path
 import pytest
 
 from ctrlrun.effect import EffectState
-from ctrlrun.errors import AmbiguousEffect, DuplicateEffect, NotExecuted
+from ctrlrun.errors import AmbiguousEffect, CTRLRunError, DuplicateEffect, NotExecuted
 from failure_injection import Proxy, upstream_of
 
 URL = os.environ.get("CTRLRUN_TEST_POSTGRES")
@@ -169,6 +170,55 @@ def test_the_kill_trigger_reads_frames_and_not_the_payload():
     seen = [m for i in range(len(stream)) for m in split.feed(stream[i : i + 1])]
     assert sum(1 for kind, body, _ in seen if is_commit(kind, body)) == 1
     assert len(seen) == 5
+
+
+@postgres
+def test_a_partition_that_began_mid_frame_leaves_the_injector_working(proxy, schema):
+    """The injector's second control: a restored partition must not blind it.
+
+    The first version released a partition by writing the held chunks straight to the socket,
+    which bypassed the frame parser. A partition that began **mid-frame** therefore left
+    `_Frontend` permanently misaligned: the server executed every later statement, the client saw
+    nothing wrong, and `commits_seen` stayed at zero for the rest of the connection. Measured
+    before the fix -- a `COMMIT` the server ran, with `commits_seen = 0, clients_killed = 0`.
+
+    A silent injector is worse than a broken one. Every `commits_seen` and `clients_killed`
+    assertion in this file is downstream of the parser still being aligned, so this is the control
+    for all of them.
+    """
+    store = store_on(proxy.url(URL), schema)
+    store.reserve_effect("refund:midframe", "act_m", timedelta(minutes=5))
+
+    # Partition mid-conversation, then restore. The store's next call spans the boundary.
+    proxy.partition = True
+    done = threading.Event()
+
+    def call() -> None:
+        try:
+            store.begin_execution("refund:midframe", "act_m")
+        finally:
+            done.set()
+
+    worker = threading.Thread(target=call, daemon=True)
+    worker.start()
+    assert not done.wait(1.5), "nothing was held; this control has no window"
+    proxy.partition = False
+    assert done.wait(30.0), "the restored call never completed"
+    worker.join(timeout=5.0)
+
+    # And the injector still works on the very next COMMIT.
+    proxy.reset_counters()
+    proxy.kill_on_commit = True
+    with contextlib.suppress(Exception):
+        store.commit_effect("refund:midframe", "act_m", {"ok": True})
+    proxy.kill_on_commit = False
+
+    assert proxy.commits_seen >= 1, (
+        "the parser lost its place across the partition, so the injector stopped injecting and "
+        "every assertion in this file that counts a COMMIT would have been silently vacuous"
+    )
+    assert proxy.clients_killed >= 1
+    store.close()
 
 
 # --- T155: the connection dies during COMMIT ------------------------------------------------
@@ -471,6 +521,198 @@ def test_T155f_a_second_lost_commit_on_the_same_operation_fails_closed(proxy, sc
     store.close()
 
 
+@postgres
+@pytest.mark.parametrize("lost", ["forwarded", "swallowed"])
+def test_T155g_a_lost_commit_on_a_RENEWAL_reports_the_renewal_branch(
+    proxy, schema, lost, resolutions
+):
+    """§4.3.4 on `_resolve_lost_renewal` -- the third resolution path, and the untested one.
+
+    A reservation over a `FAILED` record is an `UPDATE`, not an `INSERT` (`v0.1 §5.4`'s one
+    automatic retry), so its lost `COMMIT` is Table **A2** and not A1. A verification pass found
+    that this whole function could report any branch name it liked: making it say `a1.row1.ours`
+    for both of its rows left every test green, because nothing drove a renewal through the
+    injector at all.
+    """
+    store = store_on(proxy.url(URL), schema)
+    key = f"refund:renew-{lost}"
+    store.reserve_effect(key, "act_first", timedelta(minutes=5))
+    store.begin_execution(key, "act_first")
+    store.fail_effect(key, "act_first", "the remote refused before acting")
+    resolutions.clear()
+    proxy.reset_counters()
+
+    if lost == "forwarded":
+        proxy.kill_on_commit = True  # the renewal's COMMIT lands; the re-read sees it
+        with contextlib.suppress(Exception):
+            store.reserve_effect(key, "act_second", timedelta(minutes=5))
+        proxy.kill_on_commit = False
+        want = "a2.row1.landed"
+    else:
+        proxy.drop_before_commit = 1  # the renewal's COMMIT never arrives; it re-issues
+        store.reserve_effect(key, "act_second", timedelta(minutes=5))
+        want = "a2.row2.reissue"
+
+    assert proxy.clients_killed == 1, "the window never opened"
+    assert branches(resolutions) == [want], (
+        f"a lost COMMIT on a RENEWAL reported {branches(resolutions)}, expected [{want!r}]. A "
+        "renewal is an UPDATE and belongs to Table A2; reporting an A1 row would describe the "
+        "wrong table to whoever reads the log after an incident"
+    )
+
+    checker = store_on(URL, schema)
+    record = checker.get_effect(key)
+    assert record is not None
+    assert record.state is EffectState.RESERVED
+    assert record.action_id == "act_second"
+    assert record.attempt == 2, "a renewal is the next attempt, not the same one"
+    checker.close()
+    store.close()
+
+
+@postgres
+def test_T155h_a_foreign_record_found_by_the_re_read_is_REFUSED_and_says_so(
+    proxy, schema, resolutions
+):
+    """§4.3.2 Table A1 **row 3**, and §4.3.4's `a1.row3.refuse`.
+
+    The row nothing could reach: it needs somebody else to have taken the key in the window
+    between our lost `COMMIT` and our re-read, which is a race a test can only hope for. The
+    proxy's `on_drop` hook makes it deterministic -- it fires on the proxy's own thread, after
+    the client is dropped and before the store can reconnect to re-read.
+
+    This is the safe direction and the important one: our `INSERT` did not land, somebody else's
+    did, and §4.3.3 says anything that is not byte-for-byte our own write goes back through
+    `plan_reservation`. Concluding "our `action_id`, therefore ours" here is the double execution
+    this milestone's review found.
+    """
+    store = store_on(proxy.url(URL), schema)
+    rival = store_on(URL, schema)
+
+    def somebody_else_takes_it() -> None:
+        rival.reserve_effect("refund:foreign", "act_rival", timedelta(minutes=5))
+
+    proxy.reset_counters()
+    proxy.on_drop = somebody_else_takes_it
+    proxy.drop_before_commit = 1
+
+    with pytest.raises(DuplicateEffect) as refused:
+        store.reserve_effect("refund:foreign", "act_ours", timedelta(minutes=5))
+
+    assert proxy.commits_dropped == 1, "our COMMIT was not swallowed; the window never opened"
+    assert branches(resolutions) == ["a1.row3.refuse"], (
+        f"the store reported {branches(resolutions)}; a record that is not ours is Table A1's "
+        "third row and must say so"
+    )
+    assert refused.value.state == "in_progress"
+
+    checker = store_on(URL, schema)
+    record = checker.get_effect("refund:foreign")
+    assert record is not None
+    assert record.action_id == "act_rival", "our refusal overwrote somebody else's reservation"
+    assert record.state is EffectState.RESERVED
+    checker.close()
+    rival.close()
+    store.close()
+
+
+@postgres
+def test_T155h_a_record_moved_under_a_transition_is_REFUSED_and_says_so(proxy, schema, resolutions):
+    """§4.3.2 Table A2 **row 3**, and §4.3.4's `a2.row3.refuse`.
+
+    Our `UPDATE`'s `COMMIT` was lost and, in that window, the record moved somewhere we were not
+    writing. Re-issuing would be wrong -- the conditional `UPDATE` would match nothing anyway --
+    and concluding it landed would be worse. It goes back through the same predicate, which
+    refuses.
+    """
+    store = store_on(proxy.url(URL), schema)
+    mover = store_on(URL, schema)
+    store.reserve_effect("refund:moved", "act_m2", timedelta(minutes=5))
+    store.begin_execution("refund:moved", "act_m2")
+    resolutions.clear()
+
+    def somebody_else_moves_it() -> None:
+        # Out of `EXECUTING`, which is the pre-state our UPDATE was conditional on. Moving it to
+        # `AMBIGUOUS` would not do: that is still a state a commit may be re-issued from, so the
+        # re-read would take row 2 and re-issue -- correctly.
+        mover.fail_effect("refund:moved", "act_m2", "somebody else called it a failure")
+
+    proxy.reset_counters()
+    proxy.on_drop = somebody_else_moves_it
+    proxy.drop_before_commit = 1
+
+    with pytest.raises(CTRLRunError) as refused:
+        store.commit_effect("refund:moved", "act_m2", {"ok": True})
+    assert not isinstance(refused.value, NotExecuted)
+
+    assert proxy.commits_dropped == 1, "our COMMIT was not swallowed; the window never opened"
+    assert branches(resolutions) == ["a2.row3.refuse"], (
+        f"the store reported {branches(resolutions)}; a record in a state we were not writing is "
+        "Table A2's third row"
+    )
+
+    checker = store_on(URL, schema)
+    record = checker.get_effect("refund:moved")
+    assert record is not None
+    assert record.state is EffectState.FAILED, (
+        f"the refusal left the record {record.state}; it must not have re-issued over somebody "
+        "else's write"
+    )
+    checker.close()
+    mover.close()
+    store.close()
+
+
+@postgres
+def test_T156b_a_failed_re_read_on_a_TRANSITION_refuses_too(proxy, schema, resolutions):
+    """§4.3.2's last paragraph, on the A2 path -- the half T156 does not cover.
+
+    A verification pass found that `_fresh_read_effect` failing **open** is caught only on the
+    reservation path: on a transition, `found is None` raises `InvalidArgument` and reports no
+    branch, which is indistinguishable from the re-read having refused. So the discriminator here
+    is the exception **type**: refusing surfaces the connection error, while failing open
+    surfaces `InvalidArgument("no reservation for effect ...")` about a record that plainly
+    exists.
+    """
+    import psycopg
+
+    from ctrlrun.errors import InvalidArgument
+
+    store = store_on(proxy.url(URL), schema)
+    store.reserve_effect("refund:noread2", "act_n2", timedelta(minutes=5))
+    store.begin_execution("refund:noread2", "act_n2")
+    resolutions.clear()
+    proxy.reset_counters()
+
+    proxy.drop_before_commit = 1
+    proxy.refuse_connections = True
+    with pytest.raises(Exception) as raised:
+        store.commit_effect("refund:noread2", "act_n2", {"ok": True})
+    proxy.drop_before_commit = 0
+    proxy.refuse_connections = False
+
+    assert proxy.commits_dropped == 1, "the window never opened"
+    assert not isinstance(raised.value, InvalidArgument), (
+        "the re-read failed OPEN: it swallowed its connection error, returned None, and the "
+        "store concluded there was no reservation for a key it had just reserved"
+    )
+    assert isinstance(raised.value, psycopg.OperationalError)
+    assert branches(resolutions) == [], (
+        f"the store reported {branches(resolutions)}; no row of Table A is chosen when the "
+        "re-read itself fails"
+    )
+
+    checker = store_on(URL, schema)
+    record = checker.get_effect("refund:noread2")
+    assert record is not None
+    assert record.state is EffectState.EXECUTING, (
+        f"the refusal left the record {record.state}; §4.3.2 writes no effect state when the "
+        "re-read fails"
+    )
+    checker.close()
+    store.close()
+
+
 # T155c is not here, and is not missing. §4.3.3's identity check -- the double execution this
 # milestone's review found, where "a record carrying our `action_id`" was satisfied by another
 # process's live reservation -- is `test_T155c_the_re_read_identity_check_is_not_an_action_id_match`
@@ -683,6 +925,47 @@ def test_T157_one_winner_across_os_processes(schema):
     store.close()
 
 
+@postgres
+def test_T157_a_committed_action_writes_one_receipt_to_a_postgres_store(schema):
+    """§8's T157 asks for "one committed receipt", and until now nothing wrote one here.
+
+    T157 above is a store-level contention test with no `Control` in it, and the docstring says
+    so rather than claiming the receipt half. But a verification pass pointed out what that
+    leaves: **no receipt is written against a Postgres store anywhere in the suite.** `v0.1 §7`
+    T3 covers receipts against SQLite, so the receipt path had never met this backend at all --
+    and the whole premise of item 3 is that a backend can get right what another gets wrong.
+
+    So: one action, through `Control`, against Postgres. One receipt, and it says the effect
+    committed. Contention is T157's subject and is not repeated here.
+    """
+    from ctrlrun import Control, Policy
+    from ctrlrun.action import Action, Principal
+    from ctrlrun.receipt import ReceiptResult
+
+    store = store_on(URL, schema)
+    policy = Policy.from_yaml(
+        "schema: ctrlrun.policy/v1\nactions:\n  stripe.refund:\n    decision: allow\n"
+    )
+    control = Control(policy, store, clock=lambda: T0)
+    action = Action(
+        name="stripe.refund",
+        arguments={"payment_id": "p1", "amount": 2000},
+        principal=Principal(agent="a"),
+    )
+
+    receipt = control.execute(action, lambda: {"ok": True}, "refund:p1", lease=timedelta(minutes=5))
+    assert receipt.result is ReceiptResult.COMMITTED
+
+    written = store.receipts()
+    assert len(written) == 1, f"{len(written)} receipts for one action"
+    assert written[0].action_id == action.action_id
+    assert written[0].result is ReceiptResult.COMMITTED
+
+    record = store.get_effect("refund:p1")
+    assert record is not None and record.state is EffectState.COMMITTED
+    store.close()
+
+
 # --- T158: kill -9, idle and mid-transaction --------------------------------------------------
 
 
@@ -729,8 +1012,15 @@ HOLD_MID = textwrap.dedent(f"""{CHILD_PREAMBLE}
 """)
 
 
-def _hold(script_source: str, schema: str, key: str, action_id: str):
-    """Start a holder, wait for its marker, `SIGKILL` it. Returns nothing; it is dead."""
+def _hold(script_source: str, schema: str, key: str, action_id: str, while_alive=None):
+    """Start a holder, wait for its marker, run `while_alive`, then `SIGKILL` it.
+
+    `while_alive` is what lets a test observe something the *kill* causes rather than something
+    that was true all along. Without it, the mid-transaction test below asserted only facts that
+    hold while the child is still running: MVCC hides an uncommitted `UPDATE` from every other
+    connection whether or not the writer dies, so both of its assertions passed against a child
+    that opened no transaction at all.
+    """
     with tempfile.TemporaryDirectory() as home:
         script = Path(home) / "hold.py"
         script.write_text(script_source, encoding="utf-8")
@@ -766,6 +1056,9 @@ def _hold(script_source: str, schema: str, key: str, action_id: str):
                     raise AssertionError(f"the holder exited early: {child.stderr.read()[-600:]}")
                 time.sleep(0.05)
             assert ready.exists(), "the holder never took the reservation within its bound"
+
+            if while_alive is not None:
+                while_alive()
 
             os.kill(child.pid, signal.SIGKILL)
             child.wait(timeout=30)
@@ -819,12 +1112,62 @@ def test_T158_a_kill_mid_transaction_discards_the_half_written_transaction(schem
     """§8's T158, the half the idle kill above cannot show.
 
     The child is killed with an **open transaction** holding an uncommitted `UPDATE` and the row
-    lock that goes with it. Postgres discards it: the record is still `reserved`, the write is
-    gone, and the lock is released -- so the store can read and plan against the row rather than
-    blocking on a lock nobody will ever release. That is the whole of what "mid-transaction"
-    adds, and nothing checked it.
+    lock that goes with it. Postgres discards it: the write is gone and the lock is released.
+
+    **The lock is the assertion, because it is the only thing the kill changes.** MVCC hides an
+    uncommitted `UPDATE` from every other connection for as long as the writer lives, so "the
+    record is still `reserved`" and "a contender is refused" are both true *while the child is
+    running* -- a verification pass proved it, and proved that a child opening no transaction at
+    all passed this test. What is only true afterwards is that a statement which actually takes
+    the row lock stops blocking. So this asserts both halves: it blocks before the kill, and it
+    succeeds after.
+
+    `reserve_effect` cannot be that statement. `_read_effect` is a plain `SELECT` with no `FOR
+    UPDATE`, so `plan_reservation` refuses from the snapshot without ever reaching for the lock.
     """
-    _hold(HOLD_MID, schema, "refund:t158mid", "act_half")
+    locked: list[str] = []
+
+    def while_the_child_holds_it() -> None:
+        import psycopg
+
+        held = psycopg.connect(URL, autocommit=True)
+        try:
+            with held.cursor() as cursor:
+                cursor.execute("SET lock_timeout = '750ms'")
+                cursor.execute(f'SET search_path TO "{schema}"')
+                try:
+                    cursor.execute(
+                        "UPDATE effects SET error = 'probe' WHERE effect_key = %s",
+                        ("refund:t158mid",),
+                    )
+                except psycopg.errors.LockNotAvailable:
+                    locked.append("blocked")
+                else:
+                    locked.append("not blocked")
+        finally:
+            held.close()
+
+    _hold(HOLD_MID, schema, "refund:t158mid", "act_half", while_alive=while_the_child_holds_it)
+
+    assert locked == ["blocked"], (
+        "the row was writable while the child was supposedly holding an uncommitted UPDATE on "
+        "it, so there was no open transaction and this test is about nothing"
+    )
+
+    # And now that the backend is gone, the same statement gets the lock straight away.
+    import psycopg
+
+    after = psycopg.connect(URL, autocommit=True)
+    try:
+        with after.cursor() as cursor:
+            cursor.execute("SET lock_timeout = '5s'")
+            cursor.execute(f'SET search_path TO "{schema}"')
+            cursor.execute(
+                "UPDATE effects SET error = NULL WHERE effect_key = %s", ("refund:t158mid",)
+            )
+            assert cursor.rowcount == 1, "the row is gone, not merely unlocked"
+    finally:
+        after.close()
 
     store = store_on(URL, schema)
     record = store.get_effect("refund:t158mid")
@@ -834,7 +1177,6 @@ def test_T158_a_kill_mid_transaction_discards_the_half_written_transaction(schem
         "would mean a half-written transaction became state"
     )
 
-    # The row lock died with the backend: a contender gets an answer rather than blocking.
     with pytest.raises(DuplicateEffect):
         store.reserve_effect("refund:t158mid", "act_next", timedelta(minutes=5))
     store.close()

--- a/tests/test_cross_host.py
+++ b/tests/test_cross_host.py
@@ -1,0 +1,525 @@
+"""Concurrency and failure injection against a real Postgres. Item 4; SPEC-v0.6 §4.5, §8.
+
+**What was run, stated first, because §4.5 requires the PR to say so.** These are separate OS
+processes against one Postgres, with the connection broken by a proxy this test owns. They are
+**not two hosts**. Separate processes give separate connections, no shared memory and no shared
+file locks -- which is what `BEGIN IMMEDIATE` was silently relying on and what a second host
+removes -- so the *reservation* guarantee is exercised. What is not exercised is a network
+partition between hosts, and the PR says so rather than implying otherwise.
+
+The failure injection is better than a container for what §4.5 calls its most important test.
+Killing a container reproduces "the connection died during `COMMIT`" only when the timing happens
+to land there; a proxy that forwards the `COMMIT` and *then* drops the client reproduces it every
+time. A test which "usually" reproduces an interleaving proves nothing about the run where it
+did not.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from ctrlrun.effect import EffectState
+from ctrlrun.errors import AmbiguousEffect, DuplicateEffect
+from failure_injection import Proxy, upstream_of
+
+URL = os.environ.get("CTRLRUN_TEST_POSTGRES")
+
+postgres = pytest.mark.skipif(
+    not URL, reason="CTRLRUN_TEST_POSTGRES is not set; no server to run against"
+)
+
+CONTENDERS = 8
+T0 = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def schema():
+    """A private schema per test, created and dropped."""
+    from ctrlrun.postgres import PostgresStateStore
+
+    name = f"xhost_{uuid.uuid4().hex[:12]}"
+    PostgresStateStore.create_schema(URL, name)
+    try:
+        yield name
+    finally:
+        PostgresStateStore.drop_schema(URL, name)
+
+
+@pytest.fixture
+def proxy():
+    host, port = upstream_of(URL)
+    made = Proxy(host, port).start()
+    try:
+        yield made
+    finally:
+        made.stop()
+
+
+def store_on(url: str, schema: str, *, clock=None):
+    from ctrlrun.postgres import PostgresStateStore
+
+    return PostgresStateStore(url, schema=schema, clock=clock or (lambda: T0))
+
+
+# --- T155: the connection dies during COMMIT ------------------------------------------------
+
+
+@postgres
+def test_T155_a_connection_killed_during_commit_is_resolved_by_the_re_read(proxy, schema):
+    """**The single most important test in this milestone** (SPEC-v0.6 §4.5).
+
+    It is the case where a naive port reports `FAILED` for an effect that committed, and an agent
+    acting on `FAILED` retries -- the exact failure this library exists to prevent, arriving
+    through its own storage layer.
+
+    The window is opened on purpose: the proxy forwards the `COMMIT` to the server, lets it land,
+    and then takes the client's connection away. The store cannot know whether it committed, and
+    §4.3.2 says the answer is to re-read.
+    """
+    store = store_on(proxy.url(URL), schema)
+    proxy.kill_on_commit = True
+
+    reservation = store.reserve_effect("refund:killed", "act_k", timedelta(minutes=5))
+
+    assert proxy.clients_killed >= 1, (
+        "the proxy never dropped a client mid-COMMIT, so the window this test exists for never "
+        "opened. An earlier version slept before closing, which let the COMMIT's reply get back "
+        "-- the store returned normally and this test passed having exercised nothing"
+    )
+    assert reservation.action_id == "act_k"
+
+    # The re-read resolved it: the reservation is ours and the record says so.
+    proxy.kill_on_commit = False
+    checker = store_on(URL, schema)
+    record = checker.get_effect("refund:killed")
+    assert record is not None, "the commit was lost and the re-read did not retry it"
+    assert record.state is EffectState.RESERVED
+    assert record.action_id == "act_k"
+    assert str(record.state) != "failed", (
+        "a lost COMMIT was recorded as FAILED. FAILED means it definitely did not run; a "
+        "connection lost during COMMIT means nobody knows (v0.1 §5.5, SPEC-v0.6 §4.3)"
+    )
+
+    # And a blind retry against that key is refused.
+    with pytest.raises(DuplicateEffect):
+        checker.reserve_effect("refund:killed", "act_other", timedelta(minutes=5))
+    checker.close()
+    store.close()
+
+
+@postgres
+def test_T155_no_effect_is_ever_recorded_failed_by_a_lost_commit(proxy, schema):
+    """The negative that matters, driven across every write a lost `COMMIT` can hit.
+
+    `FAILED` is the one state that permits an automatic retry (`v0.1 §5.4`), so a store that
+    guessed it after an unobservable write would be handing an agent permission to act twice.
+    """
+    store = store_on(proxy.url(URL), schema)
+    store.reserve_effect("refund:sweep", "act_s", timedelta(minutes=5))
+    store.begin_execution("refund:sweep", "act_s")
+
+    proxy.kill_on_commit = True
+    with contextlib.suppress(Exception):
+        store.commit_effect("refund:sweep", "act_s", {"ok": True})  # the record is the subject
+    proxy.kill_on_commit = False
+
+    checker = store_on(URL, schema)
+    record = checker.get_effect("refund:sweep")
+    assert record is not None
+    assert record.state is not EffectState.FAILED, (
+        f"a lost COMMIT left the record {record.state}; FAILED asserts non-execution and "
+        "nothing here proved it"
+    )
+    checker.close()
+    store.close()
+
+
+# --- T155b: Table A2, the compare-and-set paths ---------------------------------------------
+
+
+@postgres
+@pytest.mark.parametrize("outcome", ["commit", "fail"])
+def test_T155b_a_lost_commit_on_a_transition_re_issues(proxy, schema, outcome):
+    """SPEC-v0.6 §4.3.2 Table A2, the row a single table gets wrong.
+
+    A lost `COMMIT` on an `UPDATE` leaves the record in its **pre-state** -- our `action_id`, a
+    state we were not writing. Reading that as *somebody moved it, refuse* would turn a committed
+    effect into a human's problem, and a **proven non-execution** into `AMBIGUOUS`, throwing away
+    the one automatic retry `v0.1 §5.4` grants. Neither is unsafe; both make the store useless in
+    exactly the situation it was built for.
+    """
+    store = store_on(proxy.url(URL), schema)
+    key = f"refund:a2-{outcome}"
+    store.reserve_effect(key, "act_a2", timedelta(minutes=5))
+    store.begin_execution(key, "act_a2")
+
+    proxy.kill_on_commit = True
+    with contextlib.suppress(Exception):
+        # Resolution is asserted on the record, not on what this call raised.
+        if outcome == "commit":
+            store.commit_effect(key, "act_a2", {"ok": True})
+        else:
+            store.fail_effect(key, "act_a2", "the remote refused before acting")
+    proxy.kill_on_commit = False
+
+    assert proxy.clients_killed >= 1, "the window never opened"
+
+    checker = store_on(URL, schema)
+    record = checker.get_effect(key)
+    assert record is not None
+    want = EffectState.COMMITTED if outcome == "commit" else EffectState.FAILED
+    assert record.state is want, (
+        f"a lost COMMIT on {outcome}_effect left the record {record.state}, expected {want}. "
+        "Table A2's row 2 re-issues; routing it through Table A1 refuses instead"
+    )
+    if outcome == "fail":
+        # `v0.1 §5.4`'s one automatic retry is still available, which is the whole point of
+        # not letting a proven non-execution become AMBIGUOUS.
+        again = checker.reserve_effect(key, "act_retry", timedelta(minutes=5))
+        assert again.attempt == 2
+    checker.close()
+    store.close()
+
+
+# --- T156: a failed re-read refuses to proceed ----------------------------------------------
+
+
+@postgres
+def test_T156_a_failed_re_read_refuses_to_proceed(proxy, schema):
+    """SPEC-v0.6 §4.3.2's last paragraph.
+
+    The `COMMIT` is lost **and** the re-read cannot be made. The store writes no effect state and
+    refuses; the caller sees a store exception rather than any outcome. That costs availability --
+    a key may be reserved by an attempt that will never execute, and its lease will lapse to
+    `AMBIGUOUS` and need a human -- and it never costs a double execution, which is the trade.
+    """
+    store = store_on(proxy.url(URL), schema)
+    proxy.kill_on_commit = True
+    proxy.refuse_connections = True
+
+    with pytest.raises(Exception) as raised:
+        store.reserve_effect("refund:noread", "act_n", timedelta(minutes=5))
+
+    from ctrlrun.errors import NotExecuted
+
+    assert proxy.clients_killed >= 1, "the window never opened"
+    assert not isinstance(raised.value, NotExecuted), (
+        "an unresolvable store write reached the caller as NotExecuted, which is the one "
+        "exception an agent may read as permission to retry"
+    )
+    proxy.kill_on_commit = False
+    proxy.refuse_connections = False
+
+    # No effect STATE was written by the refusal. The row may exist -- the lost COMMIT very
+    # likely landed, which is the whole reason the outcome was unknowable -- and what matters is
+    # that the store did not move it anywhere on the strength of a guess.
+    checker = store_on(URL, schema)
+    record = checker.get_effect("refund:noread")
+    if record is not None:
+        assert record.state is EffectState.RESERVED, (
+            f"the refusal left the record {record.state}; §4.3.2 writes no effect state when the "
+            "re-read fails"
+        )
+        assert record.action_id == "act_n"
+    checker.close()
+    store.close()
+
+
+# --- T157: T3's standard, across OS processes ------------------------------------------------
+
+
+CONTEND = textwrap.dedent("""
+    import json, os, sys, time
+    from datetime import timedelta
+    job = json.loads(sys.stdin.read())
+    sys.path.insert(0, "/Users/arpanghoshal/ctrlrun/src")
+    from ctrlrun.postgres import PostgresStateStore
+
+    store = PostgresStateStore(job["url"], schema=job["schema"])
+    gate = job["gate"]
+    os.close(os.open(os.path.join(gate, f"a-{os.getpid()}"), os.O_CREAT | os.O_EXCL | os.O_WRONLY))
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline and len(os.listdir(gate)) < job["n"]:
+        time.sleep(0.002)
+
+    out = {"won": False, "error": None, "pid": os.getpid()}
+    try:
+        store.reserve_effect(job["key"], job["action_id"], timedelta(minutes=5))
+        store.begin_execution(job["key"], job["action_id"])
+        handle = os.open(os.path.join(job["calls"], "called"),
+                         os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        os.close(handle)
+        if job.get("hang"):
+            sys.stdout.write(json.dumps({"won": True, "error": None, "pid": os.getpid()}))
+            sys.stdout.flush()
+            time.sleep(600)
+        store.commit_effect(job["key"], job["action_id"], {"ok": True})
+        out["won"] = True
+    except BaseException as e:
+        out["error"] = type(e).__name__
+    finally:
+        store.close()
+    if not job.get("hang"):
+        sys.stdout.write(json.dumps(out))
+""")
+
+
+def _contenders(url: str, schema: str, jobs: list[dict]) -> list[dict]:
+    script = Path(tempfile.mkdtemp()) / "contend.py"
+    script.write_text(CONTEND, encoding="utf-8")
+    with tempfile.TemporaryDirectory() as gate, tempfile.TemporaryDirectory() as calls:
+        payloads = [
+            json.dumps(
+                {**job, "url": url, "schema": schema, "gate": gate, "calls": calls, "n": len(jobs)}
+            )
+            for job in jobs
+        ]
+        children = [
+            subprocess.Popen(
+                [sys.executable, str(script)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            for _ in payloads
+        ]
+        for child, payload in zip(children, payloads, strict=True):
+            assert child.stdin is not None
+            child.stdin.write(payload)
+            child.stdin.close()
+        results = []
+        for child in children:
+            child.wait(timeout=120)
+            assert child.stdout is not None
+            raw = child.stdout.read()
+            results.append(json.loads(raw) if raw.strip() else {"won": False, "error": "silent"})
+        return results, sorted(os.listdir(calls))
+
+
+@postgres
+def test_T157_one_winner_across_os_processes(schema):
+    """`v0.1 §7` T3's standard, unchanged, against a real Postgres.
+
+    **Separate OS processes, not two hosts.** Separate processes give separate connections, no
+    shared memory and no shared file locks -- exactly what `BEGIN IMMEDIATE` was relying on and
+    what a second host removes -- so the reservation guarantee is exercised. What is not
+    exercised is a partition between hosts, which §4.5 lists separately.
+    """
+    jobs = [{"key": "refund:t157", "action_id": f"act_{i:032x}"} for i in range(CONTENDERS)]
+    results, called = _contenders(URL, schema, jobs)
+
+    winners = [r for r in results if r["won"]]
+    assert len(winners) == 1, f"{len(winners)} of {CONTENDERS} won; exactly one may\n{results}"
+    assert called == ["called"], f"the fake remote was called {len(called)} times"
+    for loser in (r for r in results if not r["won"]):
+        assert loser["error"] in ("DuplicateEffect", "AmbiguousEffect"), (
+            f"a loser saw {loser['error']}; v0.1 §5.4's refusals are DuplicateEffect and "
+            "AmbiguousEffect"
+        )
+
+    store = store_on(URL, schema)
+    record = store.get_effect("refund:t157")
+    assert record is not None and record.state is EffectState.COMMITTED
+    store.close()
+
+
+# --- T158: kill -9 mid-transaction ------------------------------------------------------------
+
+
+HOLD = textwrap.dedent("""
+    import json, os, sys, time
+    from datetime import timedelta
+    job = json.loads(sys.stdin.read())
+    sys.path.insert(0, "/Users/arpanghoshal/ctrlrun/src")
+    from ctrlrun.postgres import PostgresStateStore
+
+    from datetime import UTC, datetime
+    # The same frozen instant the test uses. Without it the child's lease is stamped from the
+    # wall clock and the test's "one hour later" is a year in the past, so the lapse never
+    # happens and the assertion measures the calendar rather than the lease.
+    frozen = datetime.fromisoformat(job["now"])
+    store = PostgresStateStore(job["url"], schema=job["schema"], clock=lambda: frozen)
+    store.reserve_effect(job["key"], job["action_id"], timedelta(minutes=5))
+    store.begin_execution(job["key"], job["action_id"])
+    # Readiness through the filesystem, not stdout: a pipe handshake is one more thing that can
+    # be the reason a test hangs, and this test is about a process dying, not about plumbing.
+    os.close(os.open(job["ready"], os.O_CREAT | os.O_EXCL | os.O_WRONLY))
+    while True:
+        time.sleep(0.05)
+""")
+
+
+@postgres
+def test_T158_kill_9_mid_transaction_ages_out_by_its_lease_and_nothing_else(schema):
+    """SPEC-v0.6 §5.1, §5.3, under a real `SIGKILL`.
+
+    A process is killed while holding a reservation it has begun executing. **Nothing reclaims
+    the key**: *"the holder is dead" is not knowable from the store*. The record stays `EXECUTING`
+    until its lease lapses, and the next contender then finds `AMBIGUOUS` -- a refusal, not a
+    reclaim, and one only a human or a reconcile hook moves on.
+    """
+    work = Path(tempfile.mkdtemp())
+    script = work / "hold.py"
+    script.write_text(HOLD, encoding="utf-8")
+    ready = work / "ready"
+
+    child = subprocess.Popen(
+        [sys.executable, str(script)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert child.stdin is not None
+    child.stdin.write(
+        json.dumps(
+            {
+                "url": URL,
+                "schema": schema,
+                "key": "refund:t158",
+                "action_id": "act_doomed",
+                "ready": str(ready),
+                "now": T0.isoformat(),
+            }
+        )
+    )
+    child.stdin.close()
+
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline and not ready.exists():
+        if child.poll() is not None:
+            assert child.stderr is not None
+            raise AssertionError(f"the holder exited early: {child.stderr.read()[-400:]}")
+        time.sleep(0.05)
+    assert ready.exists(), "the holder never took the reservation within its bound"
+
+    os.kill(child.pid, signal.SIGKILL)
+    child.wait(timeout=30)
+    assert child.returncode != 0, "the holder exited cleanly; it was supposed to be killed"
+
+    # The database is consistent, and the record is exactly where the dead process left it.
+    store = store_on(URL, schema)
+    record = store.get_effect("refund:t158")
+    assert record is not None
+    assert record.state is EffectState.EXECUTING, (
+        f"the record is {record.state}; a dead holder changes nothing until its lease lapses"
+    )
+
+    # Before the lease lapses, a contender is refused as in-progress -- not handed the key.
+    with pytest.raises(DuplicateEffect):
+        store.reserve_effect("refund:t158", "act_next", timedelta(minutes=5))
+    store.close()
+
+    # After it lapses: AMBIGUOUS. A refusal that needs a human, never a reclaim.
+    later = store_on(URL, schema, clock=lambda: T0 + timedelta(hours=1))
+    with pytest.raises(AmbiguousEffect):
+        later.reserve_effect("refund:t158", "act_next", timedelta(minutes=5))
+    lapsed = later.get_effect("refund:t158")
+    assert lapsed is not None and lapsed.state is EffectState.AMBIGUOUS
+    later.close()
+
+
+# --- T158b: partition, and every backend restarted --------------------------------------------
+
+
+@postgres
+def test_T158b_a_partition_stalls_and_never_reports_failed(proxy, schema):
+    """§4.5's partition injection.
+
+    The client sees a stall, not a reset -- which is the shape a partition actually has, and the
+    reason `FAILED` must not be inferred from it. Every wait is bounded: a timeout here fails red
+    rather than hanging CI.
+    """
+    store = store_on(proxy.url(URL), schema)
+    store.reserve_effect("refund:part", "act_p", timedelta(minutes=5))
+
+    proxy.partition = True
+    started = time.monotonic()
+    outcome: str
+    try:
+        store.begin_execution("refund:part", "act_p")
+        outcome = "returned"
+    except Exception as stalled:
+        outcome = type(stalled).__name__
+    elapsed = time.monotonic() - started
+    proxy.partition = False
+    assert elapsed < 90, "the partitioned call did not give up within its bound"
+
+    checker = store_on(URL, schema)
+    record = checker.get_effect("refund:part")
+    assert record is not None
+    assert record.state is not EffectState.FAILED, (
+        f"a partition produced a FAILED record ({outcome}); nothing about a stall proves "
+        "non-execution"
+    )
+    checker.close()
+    store.close()
+
+
+@postgres
+def test_T158b_every_backend_terminated_under_load_leaves_no_failed_effect(schema):
+    """The client-visible half of "restart Postgres under load".
+
+    Every backend is terminated while contenders are mid-flight. From a client that is
+    indistinguishable from a restart, and it is what this environment can do without taking the
+    server away from everything else on the machine -- which the PR says rather than implying a
+    full restart was run.
+    """
+    import threading
+
+    import psycopg
+
+    store = store_on(URL, schema)
+    store.reserve_effect("refund:restart", "act_r", timedelta(minutes=5))
+    store.begin_execution("refund:restart", "act_r")
+
+    stop = threading.Event()
+
+    def terminate_everything() -> None:
+        admin = psycopg.connect(URL, autocommit=True)
+        try:
+            deadline = time.monotonic() + 5
+            while not stop.is_set() and time.monotonic() < deadline:
+                admin.execute(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = current_database() AND pid <> pg_backend_pid()"
+                )
+                time.sleep(0.1)
+        finally:
+            admin.close()
+
+    killer = threading.Thread(target=terminate_everything, daemon=True)
+    killer.start()
+    try:
+        for _ in range(20):
+            try:
+                store.commit_effect("refund:restart", "act_r", {"ok": True})
+                break
+            except Exception:
+                time.sleep(0.05)
+    finally:
+        stop.set()
+        killer.join(timeout=30)
+
+    checker = store_on(URL, schema)
+    record = checker.get_effect("refund:restart")
+    assert record is not None
+    assert record.state is not EffectState.FAILED, (
+        "a terminated backend produced a FAILED record; only the executor opts into FAILED"
+    )
+    checker.close()
+    store.close()

--- a/tests/test_cross_host.py
+++ b/tests/test_cross_host.py
@@ -5,25 +5,43 @@ processes against one Postgres, with the connection broken by a proxy this test 
 **not two hosts**. Separate processes give separate connections, no shared memory and no shared
 file locks -- which is what `BEGIN IMMEDIATE` was silently relying on and what a second host
 removes -- so the *reservation* guarantee is exercised. What is not exercised is a network
-partition between hosts, and the PR says so rather than implying otherwise.
+partition between two machines, and the PR says so rather than implying otherwise.
 
 The failure injection is better than a container for what §4.5 calls its most important test.
 Killing a container reproduces "the connection died during `COMMIT`" only when the timing happens
 to land there; a proxy that forwards the `COMMIT` and *then* drops the client reproduces it every
 time. A test which "usually" reproduces an interleaving proves nothing about the run where it
 did not.
+
+**What an independent review had to fix here, because the list is the useful part.** The first
+version of this file passed while exercising almost none of what it named:
+
+- The child processes imported `ctrlrun` from a **hardcoded absolute path**, so gutting the store
+  under test left T157 and T158 green. They now import the tree this file lives in and *assert*
+  that they did.
+- T155b and T155 only ever reached Table A1 **row 1** and Table A2 **row 1** -- the proxy
+  forwarded every `COMMIT`, so the write always landed and the "re-issue" and "retry the insert"
+  rows the section exists for were unreachable. `drop_before_commit` reaches them, and driving
+  A2 row 2 found an **unbounded recursion** in the store (fixed in this PR's `postgres.py`).
+- T155 asserted an outcome that a store doing *nothing* also produces. It now asserts which
+  branch of §4.3.2 ran, which is what §8 asked for and nothing implemented.
+- `clients_killed` triggered on `b"COMMIT" in data`, which a Bind *parameter* satisfies. See
+  `failure_injection._Frontend`.
+- T158b's partition injected nothing observable and delivered a reset at a deadline the proxy
+  owned; its restart half terminated zero backends.
 """
 
 from __future__ import annotations
 
-import contextlib
 import json
+import logging
 import os
 import signal
 import subprocess
 import sys
 import tempfile
 import textwrap
+import threading
 import time
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -32,7 +50,7 @@ from pathlib import Path
 import pytest
 
 from ctrlrun.effect import EffectState
-from ctrlrun.errors import AmbiguousEffect, DuplicateEffect
+from ctrlrun.errors import AmbiguousEffect, DuplicateEffect, NotExecuted
 from failure_injection import Proxy, upstream_of
 
 URL = os.environ.get("CTRLRUN_TEST_POSTGRES")
@@ -43,6 +61,26 @@ postgres = pytest.mark.skipif(
 
 CONTENDERS = 8
 T0 = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+
+#: The tree under test, derived from this file. A child that hardcodes a path grades whatever is
+#: at that path -- on a release verification run from a fresh clone, the maintainer's working
+#: tree. The children insert this and assert `ctrlrun.__file__` is under it, and the parent
+#: asserts the same on every result.
+REPO_SRC = str(Path(__file__).resolve().parents[1] / "src")
+
+#: Every child preamble. Two lines and one assertion, and the assertion is the point.
+CHILD_PREAMBLE = """
+    import json, os, sys, time
+    from datetime import timedelta
+    job = json.loads(sys.stdin.read())
+    sys.path.insert(0, job["src"])
+    import ctrlrun
+    _WHERE = os.path.realpath(ctrlrun.__file__)
+    assert _WHERE.startswith(os.path.realpath(job["src"])), (
+        "the child imported ctrlrun from %s, not the tree under test at %s"
+        % (_WHERE, job["src"]))
+    from ctrlrun.postgres import PostgresStateStore
+"""
 
 
 @pytest.fixture
@@ -74,11 +112,72 @@ def store_on(url: str, schema: str, *, clock=None):
     return PostgresStateStore(url, schema=schema, clock=clock or (lambda: T0))
 
 
+def branches(caplog) -> list[str]:
+    """Which §4.3.2 rows the store reported taking, in order (SPEC-v0.6 §4.3.4)."""
+    return [
+        record.branch for record in caplog.records if getattr(record, "branch", None) is not None
+    ]
+
+
+@pytest.fixture
+def resolutions(caplog):
+    """Capture §4.3.4's branch reports, and nothing else."""
+    caplog.set_level(logging.WARNING, logger="ctrlrun.postgres")
+    return caplog
+
+
+# --- the injector's own positive control ----------------------------------------------------
+
+
+def test_the_kill_trigger_reads_frames_and_not_the_payload():
+    """`failure_injection` grepped for `b"COMMIT"` and fired on a Bind *parameter*.
+
+    No server needed, and that is the point: this is a fixture test of the injector, written
+    because the guard a review found broken -- `clients_killed >= 1`, added to catch exactly this
+    class of false green -- could not tell the difference. An effect key containing the word
+    killed the client on the `SELECT`'s Bind, which is §4.3's Table A row 1, a clean `FAILED`
+    *before* `COMMIT`, and not the ambiguous window the test claimed to open.
+    """
+    import struct
+
+    from failure_injection import _Frontend, is_commit
+
+    def untyped(body: bytes) -> bytes:
+        return struct.pack("!i", 4 + len(body)) + body
+
+    def typed(kind: bytes, body: bytes) -> bytes:
+        return kind + struct.pack("!i", 4 + len(body)) + body
+
+    ssl_request = untyped(struct.pack("!i", 80877103))
+    startup = untyped(struct.pack("!i", 196608) + b"user\x00bob\x00\x00")
+    bind = typed(b"B", b"refund:COMMIT-me\x00")  # the payload that used to trigger it
+    select = typed(b"Q", b"SELECT 1\x00")
+    commit = typed(b"Q", b"COMMIT\x00")
+    stream = ssl_request + startup + bind + select + commit
+
+    assert b"COMMIT" in bind, "the control is void: this Bind does not contain the word"
+
+    parsed = _Frontend().feed(stream)
+    assert [kind for kind, _, _ in parsed] == [b"", b"", b"B", b"Q", b"Q"]
+    assert [offset for kind, body, offset in parsed if is_commit(kind, body)] == [
+        len(ssl_request) + len(startup) + len(bind) + len(select)
+    ], "the COMMIT was not found where it is, or something else was mistaken for it"
+
+    # And it survives arriving one byte at a time, which is the case a length-prefixed parser
+    # exists for and a substring search never had to handle.
+    split = _Frontend()
+    seen = [m for i in range(len(stream)) for m in split.feed(stream[i : i + 1])]
+    assert sum(1 for kind, body, _ in seen if is_commit(kind, body)) == 1
+    assert len(seen) == 5
+
+
 # --- T155: the connection dies during COMMIT ------------------------------------------------
 
 
 @postgres
-def test_T155_a_connection_killed_during_commit_is_resolved_by_the_re_read(proxy, schema):
+def test_T155_a_connection_killed_during_commit_is_resolved_by_the_re_read(
+    proxy, schema, resolutions
+):
     """**The single most important test in this milestone** (SPEC-v0.6 §4.5).
 
     It is the case where a naive port reports `FAILED` for an effect that committed, and an agent
@@ -88,18 +187,36 @@ def test_T155_a_connection_killed_during_commit_is_resolved_by_the_re_read(proxy
     The window is opened on purpose: the proxy forwards the `COMMIT` to the server, lets it land,
     and then takes the client's connection away. The store cannot know whether it committed, and
     §4.3.2 says the answer is to re-read.
+
+    **The branch is asserted, not the outcome.** The outcome here -- a reservation that is ours,
+    and a blind retry refused -- is *also* what a store that never re-read at all would produce,
+    because the write did land. A review demonstrated it: with `_resolve_lost_insert` replaced by
+    `return`, every assertion about the record still passed. §8 asks that "the events name which
+    branch of §4.3.2 ran", and §4.3.4 is where the store says so.
     """
     store = store_on(proxy.url(URL), schema)
+    proxy.reset_counters()
     proxy.kill_on_commit = True
 
     reservation = store.reserve_effect("refund:killed", "act_k", timedelta(minutes=5))
 
-    assert proxy.clients_killed >= 1, (
+    assert not proxy.tls_negotiated, "TLS was negotiated; the proxy cannot see a COMMIT at all"
+    assert proxy.commits_seen == 1, (
+        f"the proxy parsed {proxy.commits_seen} COMMIT frames, expected exactly the one this "
+        "reservation issues"
+    )
+    assert proxy.clients_killed == 1, (
         "the proxy never dropped a client mid-COMMIT, so the window this test exists for never "
         "opened. An earlier version slept before closing, which let the COMMIT's reply get back "
         "-- the store returned normally and this test passed having exercised nothing"
     )
     assert reservation.action_id == "act_k"
+
+    assert branches(resolutions) == ["a1.row1.ours"], (
+        f"the store reported {branches(resolutions)}; §4.3.2 Table A1 row 1 is the branch a "
+        "landed COMMIT takes, and a store that skipped the re-read entirely reports nothing "
+        "while satisfying every other assertion here"
+    )
 
     # The re-read resolved it: the reservation is ours and the record says so.
     proxy.kill_on_commit = False
@@ -108,14 +225,44 @@ def test_T155_a_connection_killed_during_commit_is_resolved_by_the_re_read(proxy
     assert record is not None, "the commit was lost and the re-read did not retry it"
     assert record.state is EffectState.RESERVED
     assert record.action_id == "act_k"
-    assert str(record.state) != "failed", (
-        "a lost COMMIT was recorded as FAILED. FAILED means it definitely did not run; a "
-        "connection lost during COMMIT means nobody knows (v0.1 §5.5, SPEC-v0.6 §4.3)"
-    )
 
     # And a blind retry against that key is refused.
     with pytest.raises(DuplicateEffect):
         checker.reserve_effect("refund:killed", "act_other", timedelta(minutes=5))
+    checker.close()
+    store.close()
+
+
+@postgres
+def test_T155_the_window_opens_on_the_COMMIT_even_when_the_key_contains_the_word(
+    proxy, schema, resolutions
+):
+    """The end-to-end half of the control above, against a real server.
+
+    Same reservation, same injection, one difference: the effect key contains `COMMIT`, so it
+    travels as a Bind parameter on the `SELECT` that precedes the write. Under the substring
+    trigger the client died there instead -- before `COMMIT` was ever issued, which is a clean
+    `FAILED` and no ambiguity at all -- and every assertion about `clients_killed` still passed.
+    """
+    store = store_on(proxy.url(URL), schema)
+    proxy.reset_counters()
+    proxy.kill_on_commit = True
+
+    store.reserve_effect("refund:COMMIT-me", "act_c", timedelta(minutes=5))
+
+    assert proxy.commits_seen == 1, (
+        f"{proxy.commits_seen} COMMIT frames on a reservation that issues one; the key's payload "
+        "is being read as a command"
+    )
+    assert branches(resolutions) == ["a1.row1.ours"], (
+        f"the store reported {branches(resolutions)}; the kill landed somewhere other than the "
+        "COMMIT, so this is not the ambiguous window"
+    )
+    proxy.kill_on_commit = False
+
+    checker = store_on(URL, schema)
+    record = checker.get_effect("refund:COMMIT-me")
+    assert record is not None and record.state is EffectState.RESERVED
     checker.close()
     store.close()
 
@@ -131,10 +278,20 @@ def test_T155_no_effect_is_ever_recorded_failed_by_a_lost_commit(proxy, schema):
     store.reserve_effect("refund:sweep", "act_s", timedelta(minutes=5))
     store.begin_execution("refund:sweep", "act_s")
 
+    proxy.reset_counters()
     proxy.kill_on_commit = True
-    with contextlib.suppress(Exception):
+    raised: BaseException | None = None
+    try:
         store.commit_effect("refund:sweep", "act_s", {"ok": True})  # the record is the subject
+    except BaseException as broke:
+        raised = broke
     proxy.kill_on_commit = False
+
+    assert proxy.clients_killed >= 1, "the window never opened"
+    assert not isinstance(raised, NotExecuted), (
+        "a lost COMMIT reached the caller as NotExecuted, the one exception that means "
+        "'definitely did not happen'"
+    )
 
     checker = store_on(URL, schema)
     record = checker.get_effect("refund:sweep")
@@ -147,35 +304,43 @@ def test_T155_no_effect_is_ever_recorded_failed_by_a_lost_commit(proxy, schema):
     store.close()
 
 
-# --- T155b: Table A2, the compare-and-set paths ---------------------------------------------
+# --- T155b: Table A2 row 1, and T155d/e/f: the rows that re-issue ---------------------------
 
 
 @postgres
 @pytest.mark.parametrize("outcome", ["commit", "fail"])
-def test_T155b_a_lost_commit_on_a_transition_re_issues(proxy, schema, outcome):
-    """SPEC-v0.6 §4.3.2 Table A2, the row a single table gets wrong.
+def test_T155b_a_landed_commit_on_a_transition_is_seen_as_landed(
+    proxy, schema, outcome, resolutions
+):
+    """SPEC-v0.6 §4.3.2 Table A2 **row 1**: the `UPDATE` landed and the re-read says so.
 
-    A lost `COMMIT` on an `UPDATE` leaves the record in its **pre-state** -- our `action_id`, a
-    state we were not writing. Reading that as *somebody moved it, refuse* would turn a committed
-    effect into a human's problem, and a **proven non-execution** into `AMBIGUOUS`, throwing away
-    the one automatic retry `v0.1 §5.4` grants. Neither is unsafe; both make the store useless in
-    exactly the situation it was built for.
+    Named for what it does. The re-issue is `test_T155e`, below, which needs a `COMMIT` the
+    server never receives -- and until this PR the proxy had no mode that could produce one, so
+    §8's "the store **re-issues** the `UPDATE`" was asserted by a test that never reached the
+    branch. Two mutants proved it: deleting the re-issue arm, and deleting the whole Table A2
+    re-read, both left this test green.
     """
     store = store_on(proxy.url(URL), schema)
     key = f"refund:a2-{outcome}"
     store.reserve_effect(key, "act_a2", timedelta(minutes=5))
     store.begin_execution(key, "act_a2")
+    resolutions.clear()
+    proxy.reset_counters()
 
     proxy.kill_on_commit = True
-    with contextlib.suppress(Exception):
-        # Resolution is asserted on the record, not on what this call raised.
+    raised: BaseException | None = None
+    try:
         if outcome == "commit":
             store.commit_effect(key, "act_a2", {"ok": True})
         else:
             store.fail_effect(key, "act_a2", "the remote refused before acting")
+    except BaseException as broke:
+        raised = broke
     proxy.kill_on_commit = False
 
-    assert proxy.clients_killed >= 1, "the window never opened"
+    assert proxy.clients_killed == 1, "the window never opened"
+    assert not isinstance(raised, NotExecuted)
+    assert branches(resolutions) == ["a2.row1.landed"]
 
     checker = store_on(URL, schema)
     record = checker.get_effect(key)
@@ -183,7 +348,7 @@ def test_T155b_a_lost_commit_on_a_transition_re_issues(proxy, schema, outcome):
     want = EffectState.COMMITTED if outcome == "commit" else EffectState.FAILED
     assert record.state is want, (
         f"a lost COMMIT on {outcome}_effect left the record {record.state}, expected {want}. "
-        "Table A2's row 2 re-issues; routing it through Table A1 refuses instead"
+        "Routing Table A2 through Table A1 refuses instead"
     )
     if outcome == "fail":
         # `v0.1 §5.4`'s one automatic retry is still available, which is the whole point of
@@ -194,28 +359,171 @@ def test_T155b_a_lost_commit_on_a_transition_re_issues(proxy, schema, outcome):
     store.close()
 
 
+@postgres
+def test_T155d_a_commit_the_server_never_received_retries_the_insert(proxy, schema, resolutions):
+    """§4.3.2 Table A1 **row 2**: no record, so re-issue the same reservation once.
+
+    Unreachable before this PR. The proxy drops the client *without* forwarding the `COMMIT`, so
+    the server rolls the transaction back and the re-read genuinely finds nothing -- which is the
+    only way this row is entered. The count is 1 so the retry's own `COMMIT` gets through;
+    swallowing that one too is `test_T155f`.
+    """
+    store = store_on(proxy.url(URL), schema)
+    proxy.reset_counters()
+    proxy.drop_before_commit = 1
+
+    reservation = store.reserve_effect("refund:lost", "act_l", timedelta(minutes=5))
+
+    assert proxy.commits_dropped == 1, "no COMMIT was swallowed; the row was never entered"
+    assert branches(resolutions) == ["a1.row2.reinsert"]
+    assert reservation.action_id == "act_l"
+
+    checker = store_on(URL, schema)
+    record = checker.get_effect("refund:lost")
+    assert record is not None, "the retry did not land the reservation"
+    assert record.state is EffectState.RESERVED
+    assert record.action_id == "act_l"
+    assert record.attempt == 1, "the retry of one lost COMMIT is the same attempt, not a second"
+    checker.close()
+    store.close()
+
+
+@postgres
+@pytest.mark.parametrize("outcome", ["commit", "fail"])
+def test_T155e_a_commit_the_server_never_received_re_issues_the_update(
+    proxy, schema, outcome, resolutions
+):
+    """§4.3.2 Table A2 **row 2**: unchanged and still ours, so re-issue the `UPDATE`.
+
+    The row §8 names T155b for, reached here for the first time. Re-issuing is safe because the
+    `UPDATE` is conditional on the pre-state: had the first one landed, the second matches nothing
+    and the re-read sees row 1 instead.
+    """
+    store = store_on(proxy.url(URL), schema)
+    key = f"refund:reissue-{outcome}"
+    store.reserve_effect(key, "act_r2", timedelta(minutes=5))
+    store.begin_execution(key, "act_r2")
+    resolutions.clear()
+    proxy.reset_counters()
+
+    proxy.drop_before_commit = 1
+    if outcome == "commit":
+        store.commit_effect(key, "act_r2", {"ok": True})
+    else:
+        store.fail_effect(key, "act_r2", "the remote refused before acting")
+
+    assert proxy.commits_dropped == 1
+    assert branches(resolutions) == ["a2.row2.reissue"], (
+        f"the store reported {branches(resolutions)}; a lost COMMIT on an UPDATE leaves the "
+        "record in its PRE-state, and reading that as 'somebody moved it, refuse' is the "
+        "collapse §4.3.2 exists to forbid"
+    )
+
+    checker = store_on(URL, schema)
+    record = checker.get_effect(key)
+    assert record is not None
+    want = EffectState.COMMITTED if outcome == "commit" else EffectState.FAILED
+    assert record.state is want
+    checker.close()
+    store.close()
+
+
+@postgres
+def test_T155f_a_second_lost_commit_on_the_same_operation_fails_closed(proxy, schema):
+    """§4.2's bound, on the re-issue path: *every loop in this project is bounded*.
+
+    `_authorize_and_reserve` carries a `retrying` flag for exactly this and says so in a comment.
+    `_transition` did not, so Table A2's re-issue called back into a `_transition` that could lose
+    its `COMMIT` again and re-enter the same resolution -- unbounded. Driven with a proxy that
+    swallows every `COMMIT`, the store recursed 96 deep and escaped as `RecursionError`, which is
+    outside the error taxonomy entirely, leaving the record stranded. Found by review; the bound
+    is in this PR.
+    """
+    store = store_on(proxy.url(URL), schema)
+    store.reserve_effect("refund:bounded", "act_b", timedelta(minutes=5))
+    store.begin_execution("refund:bounded", "act_b")
+
+    proxy.reset_counters()
+    proxy.drop_before_commit = 1000  # every COMMIT from here on
+    raised: BaseException | None = None
+    try:
+        store.commit_effect("refund:bounded", "act_b", {"ok": True})
+    except BaseException as broke:
+        raised = broke
+    proxy.drop_before_commit = 0
+
+    assert raised is not None, "every COMMIT was swallowed and the call still returned"
+    assert not isinstance(raised, RecursionError), (
+        "the re-issue path recursed until Python stopped it. A store that runs out of stack "
+        "raises outside this library's closed set of errors, and no caller can classify it"
+    )
+    assert not isinstance(raised, NotExecuted), "a lost COMMIT is never a proven non-execution"
+    assert proxy.commits_dropped >= 2, (
+        f"only {proxy.commits_dropped} COMMIT was swallowed; the second one is the bound this "
+        "test is about"
+    )
+
+    checker = store_on(URL, schema)
+    record = checker.get_effect("refund:bounded")
+    assert record is not None
+    assert record.state is not EffectState.FAILED
+    checker.close()
+    store.close()
+
+
+# T155c is not here, and is not missing. §4.3.3's identity check -- the double execution this
+# milestone's review found, where "a record carrying our `action_id`" was satisfied by another
+# process's live reservation -- is `test_T155c_the_re_read_identity_check_is_not_an_action_id_match`
+# and `test_T155c_the_re_read_accepts_only_our_own_row` in `tests/test_postgres.py`, which run
+# against every backend. Reducing §4.3.3's comparison to `action_id` alone fails them. It needs no
+# proxy: the window is opened by a held transaction rather than by a broken connection, so it
+# belongs with the store's own tests.
+
+
 # --- T156: a failed re-read refuses to proceed ----------------------------------------------
 
 
 @postgres
-def test_T156_a_failed_re_read_refuses_to_proceed(proxy, schema):
+def test_T156_a_failed_re_read_refuses_to_proceed(proxy, schema, resolutions):
     """SPEC-v0.6 §4.3.2's last paragraph.
 
     The `COMMIT` is lost **and** the re-read cannot be made. The store writes no effect state and
     refuses; the caller sees a store exception rather than any outcome. That costs availability --
     a key may be reserved by an attempt that will never execute, and its lease will lapse to
     `AMBIGUOUS` and need a human -- and it never costs a double execution, which is the trade.
+
+    The exception type is asserted. `pytest.raises(Exception)` pins nothing: an `AttributeError`
+    from a bug in the store would have satisfied it.
+
+    **And the type alone is still not enough**, which a mutation run found after the first fix.
+    Make `_fresh_read_effect` swallow its connect failure and return `None` -- turning §4.3.2's
+    *"the re-read failed, refuse and write nothing"* into Table A1's *"no record, retry the
+    insert"* -- and the caller still sees `OperationalError`, because the retry's own connect
+    fails too. The two are indistinguishable by exception. They are distinguishable by §4.3.4:
+    refusing reports **no branch at all**, because the re-read raised before any row of Table A
+    was chosen, while failing open reports `a1.row2.reinsert`. If the connection had come back
+    between the two calls, the fail-open store would have silently taken the retry and this test
+    could not have told.
     """
+    import psycopg
+
+    executed: list[str] = []
     store = store_on(proxy.url(URL), schema)
+    proxy.reset_counters()
     proxy.kill_on_commit = True
     proxy.refuse_connections = True
 
-    with pytest.raises(Exception) as raised:
+    with pytest.raises(psycopg.OperationalError) as raised:
         store.reserve_effect("refund:noread", "act_n", timedelta(minutes=5))
+        executed.append("the executor would run here")
 
-    from ctrlrun.errors import NotExecuted
-
-    assert proxy.clients_killed >= 1, "the window never opened"
+    assert proxy.clients_killed == 1, "the window never opened"
+    assert executed == [], "§8: the executor is never reached"
+    assert branches(resolutions) == [], (
+        f"the store reported {branches(resolutions)}; §4.3.2 chooses no row of Table A when the "
+        "re-read itself fails, and a store that reported one resolved an unobservable write on "
+        "the strength of a read it never made"
+    )
     assert not isinstance(raised.value, NotExecuted), (
         "an unresolvable store write reached the caller as NotExecuted, which is the one "
         "exception an agent may read as permission to retry"
@@ -223,17 +531,18 @@ def test_T156_a_failed_re_read_refuses_to_proceed(proxy, schema):
     proxy.kill_on_commit = False
     proxy.refuse_connections = False
 
-    # No effect STATE was written by the refusal. The row may exist -- the lost COMMIT very
-    # likely landed, which is the whole reason the outcome was unknowable -- and what matters is
-    # that the store did not move it anywhere on the strength of a guess.
+    # No effect STATE was written by the refusal. The row is there -- the lost COMMIT landed,
+    # which is the whole reason the outcome was unknowable -- and it is exactly as it was. The
+    # first version hedged this behind `if record is not None`, which made §8's "the record is
+    # left exactly as it was" optional and would have hidden a regression that dropped the row.
     checker = store_on(URL, schema)
     record = checker.get_effect("refund:noread")
-    if record is not None:
-        assert record.state is EffectState.RESERVED, (
-            f"the refusal left the record {record.state}; §4.3.2 writes no effect state when the "
-            "re-read fails"
-        )
-        assert record.action_id == "act_n"
+    assert record is not None, "the refusal lost the row it refused to interpret"
+    assert record.state is EffectState.RESERVED, (
+        f"the refusal left the record {record.state}; §4.3.2 writes no effect state when the "
+        "re-read fails"
+    )
+    assert record.action_id == "act_n"
     checker.close()
     store.close()
 
@@ -241,49 +550,56 @@ def test_T156_a_failed_re_read_refuses_to_proceed(proxy, schema):
 # --- T157: T3's standard, across OS processes ------------------------------------------------
 
 
-CONTEND = textwrap.dedent("""
-    import json, os, sys, time
-    from datetime import timedelta
-    job = json.loads(sys.stdin.read())
-    sys.path.insert(0, "/Users/arpanghoshal/ctrlrun/src")
-    from ctrlrun.postgres import PostgresStateStore
-
+CONTEND = textwrap.dedent(f"""{CHILD_PREAMBLE}
     store = PostgresStateStore(job["url"], schema=job["schema"])
     gate = job["gate"]
-    os.close(os.open(os.path.join(gate, f"a-{os.getpid()}"), os.O_CREAT | os.O_EXCL | os.O_WRONLY))
+    marker = os.path.join(gate, f"a-{{os.getpid()}}")
+    os.close(os.open(marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY))
     deadline = time.monotonic() + 30
     while time.monotonic() < deadline and len(os.listdir(gate)) < job["n"]:
         time.sleep(0.002)
+    late = len(os.listdir(gate)) < job["n"]
 
-    out = {"won": False, "error": None, "pid": os.getpid()}
+    out = {{"won": False, "error": None, "pid": os.getpid(),
+           "ctrlrun": _WHERE, "barrier_timed_out": late}}
     try:
         store.reserve_effect(job["key"], job["action_id"], timedelta(minutes=5))
         store.begin_execution(job["key"], job["action_id"])
-        handle = os.open(os.path.join(job["calls"], "called"),
+        # One marker per caller. A shared name could only ever be created once, so a second
+        # execution raised FileExistsError in its own child and was caught by the loser-error
+        # assertion -- a different assertion from the one whose message said "called N times".
+        handle = os.open(os.path.join(job["calls"], f"called-{{os.getpid()}}"),
                          os.O_CREAT | os.O_EXCL | os.O_WRONLY)
         os.close(handle)
-        if job.get("hang"):
-            sys.stdout.write(json.dumps({"won": True, "error": None, "pid": os.getpid()}))
-            sys.stdout.flush()
-            time.sleep(600)
-        store.commit_effect(job["key"], job["action_id"], {"ok": True})
+        store.commit_effect(job["key"], job["action_id"], {{"ok": True}})
         out["won"] = True
     except BaseException as e:
         out["error"] = type(e).__name__
     finally:
         store.close()
-    if not job.get("hang"):
-        sys.stdout.write(json.dumps(out))
+    sys.stdout.write(json.dumps(out))
 """)
 
 
-def _contenders(url: str, schema: str, jobs: list[dict]) -> list[dict]:
-    script = Path(tempfile.mkdtemp()) / "contend.py"
-    script.write_text(CONTEND, encoding="utf-8")
-    with tempfile.TemporaryDirectory() as gate, tempfile.TemporaryDirectory() as calls:
+def _contenders(url: str, schema: str, jobs: list[dict]) -> tuple[list[dict], list[str]]:
+    with (
+        tempfile.TemporaryDirectory() as home,
+        tempfile.TemporaryDirectory() as gate,
+        tempfile.TemporaryDirectory() as calls,
+    ):
+        script = Path(home) / "contend.py"
+        script.write_text(CONTEND, encoding="utf-8")
         payloads = [
             json.dumps(
-                {**job, "url": url, "schema": schema, "gate": gate, "calls": calls, "n": len(jobs)}
+                {
+                    **job,
+                    "url": url,
+                    "schema": schema,
+                    "src": REPO_SRC,
+                    "gate": gate,
+                    "calls": calls,
+                    "n": len(jobs),
+                }
             )
             for job in jobs
         ]
@@ -297,16 +613,27 @@ def _contenders(url: str, schema: str, jobs: list[dict]) -> list[dict]:
             )
             for _ in payloads
         ]
-        for child, payload in zip(children, payloads, strict=True):
-            assert child.stdin is not None
-            child.stdin.write(payload)
-            child.stdin.close()
-        results = []
-        for child in children:
-            child.wait(timeout=120)
-            assert child.stdout is not None
-            raw = child.stdout.read()
-            results.append(json.loads(raw) if raw.strip() else {"won": False, "error": "silent"})
+        try:
+            # Every stdin first: writing and reading one child at a time serialises them, and a
+            # contention test whose contenders run in sequence measures nothing.
+            for child, payload in zip(children, payloads, strict=True):
+                assert child.stdin is not None
+                child.stdin.write(payload)
+                child.stdin.close()
+            results = []
+            for child in children:
+                child.wait(timeout=120)
+                assert child.stdout is not None and child.stderr is not None
+                raw = child.stdout.read()
+                results.append(
+                    json.loads(raw)
+                    if raw.strip()
+                    else {"won": False, "error": "silent", "stderr": child.stderr.read()[-400:]}
+                )
+        finally:
+            for child in children:
+                if child.poll() is None:
+                    child.kill()
         return results, sorted(os.listdir(calls))
 
 
@@ -318,13 +645,32 @@ def test_T157_one_winner_across_os_processes(schema):
     shared memory and no shared file locks -- exactly what `BEGIN IMMEDIATE` was relying on and
     what a second host removes -- so the reservation guarantee is exercised. What is not
     exercised is a partition between hosts, which §4.5 lists separately.
+
+    **§8 also asks for "one committed receipt and N-1 blocked", and this test does not check it.
+    Not applicable is not a pass, so the reason:** receipts are written by `Control`, not by a
+    store, and no `Control` participates here. `v0.1 §7` T3 covers the receipt half against the
+    SQLite store and is unchanged by this milestone; what a Postgres backend can get wrong, and
+    what this test is for, is the reservation underneath it.
     """
     jobs = [{"key": "refund:t157", "action_id": f"act_{i:032x}"} for i in range(CONTENDERS)]
     results, called = _contenders(URL, schema, jobs)
 
+    for result in results:
+        assert result.get("ctrlrun", "").startswith(REPO_SRC), (
+            f"a child imported ctrlrun from {result.get('ctrlrun')!r}, not the tree under test. "
+            "A hardcoded path here graded a different checkout entirely, and gutting the store "
+            "left this test green"
+        )
+        assert not result.get("barrier_timed_out"), (
+            "a contender gave up on the barrier and reserved alone; the contention this test "
+            "measures did not happen"
+        )
+
     winners = [r for r in results if r["won"]]
     assert len(winners) == 1, f"{len(winners)} of {CONTENDERS} won; exactly one may\n{results}"
-    assert called == ["called"], f"the fake remote was called {len(called)} times"
+    assert called == [f"called-{winners[0]['pid']}"], (
+        f"the fake remote was called by {called}; exactly one caller, the winner, may reach it"
+    )
     for loser in (r for r in results if not r["won"]):
         assert loser["error"] in ("DuplicateEffect", "AmbiguousEffect"), (
             f"a loser saw {loser['error']}; v0.1 §5.4's refusals are DuplicateEffect and "
@@ -337,16 +683,10 @@ def test_T157_one_winner_across_os_processes(schema):
     store.close()
 
 
-# --- T158: kill -9 mid-transaction ------------------------------------------------------------
+# --- T158: kill -9, idle and mid-transaction --------------------------------------------------
 
 
-HOLD = textwrap.dedent("""
-    import json, os, sys, time
-    from datetime import timedelta
-    job = json.loads(sys.stdin.read())
-    sys.path.insert(0, "/Users/arpanghoshal/ctrlrun/src")
-    from ctrlrun.postgres import PostgresStateStore
-
+HOLD = textwrap.dedent(f"""{CHILD_PREAMBLE}
     from datetime import UTC, datetime
     # The same frozen instant the test uses. Without it the child's lease is stamped from the
     # wall clock and the test's "one hour later" is a year in the past, so the lapse never
@@ -362,54 +702,95 @@ HOLD = textwrap.dedent("""
         time.sleep(0.05)
 """)
 
+#: The genuinely mid-transaction holder. `HOLD` signals ready *after* `begin_execution` has
+#: committed, so its child is killed while idle between transactions -- deterministic, and a
+#: perfectly good test of "the holder went away", but not of what "mid-transaction" adds: that
+#: Postgres discards a half-written transaction when its backend dies. This one holds an open
+#: transaction with an uncommitted `UPDATE` in it and signals ready from inside.
+HOLD_MID = textwrap.dedent(f"""{CHILD_PREAMBLE}
+    import psycopg
+    from datetime import UTC, datetime
+    frozen = datetime.fromisoformat(job["now"])
+    store = PostgresStateStore(job["url"], schema=job["schema"], clock=lambda: frozen)
+    store.reserve_effect(job["key"], job["action_id"], timedelta(minutes=5))
+
+    raw = psycopg.connect(job["url"], autocommit=False)
+    with raw.cursor() as cursor:
+        cursor.execute('SET LOCAL search_path TO "%s"' % job["schema"])
+        cursor.execute(
+            "UPDATE effects SET state = 'executing' WHERE effect_key = %s AND state = 'reserved'",
+            (job["key"],),
+        )
+        assert cursor.rowcount == 1, "the child did not write the row it is about to abandon"
+    # Written, not committed. The transaction and its row lock are open right now.
+    os.close(os.open(job["ready"], os.O_CREAT | os.O_EXCL | os.O_WRONLY))
+    while True:
+        time.sleep(0.05)
+""")
+
+
+def _hold(script_source: str, schema: str, key: str, action_id: str):
+    """Start a holder, wait for its marker, `SIGKILL` it. Returns nothing; it is dead."""
+    with tempfile.TemporaryDirectory() as home:
+        script = Path(home) / "hold.py"
+        script.write_text(script_source, encoding="utf-8")
+        ready = Path(home) / "ready"
+        child = subprocess.Popen(
+            [sys.executable, str(script)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            assert child.stdin is not None
+            child.stdin.write(
+                json.dumps(
+                    {
+                        "url": URL,
+                        "schema": schema,
+                        "src": REPO_SRC,
+                        "key": key,
+                        "action_id": action_id,
+                        "ready": str(ready),
+                        "now": T0.isoformat(),
+                    }
+                )
+            )
+            child.stdin.close()
+
+            deadline = time.monotonic() + 60
+            while time.monotonic() < deadline and not ready.exists():
+                if child.poll() is not None:
+                    assert child.stderr is not None
+                    raise AssertionError(f"the holder exited early: {child.stderr.read()[-600:]}")
+                time.sleep(0.05)
+            assert ready.exists(), "the holder never took the reservation within its bound"
+
+            os.kill(child.pid, signal.SIGKILL)
+            child.wait(timeout=30)
+            assert child.returncode != 0, "the holder exited cleanly; it was supposed to be killed"
+        finally:
+            # An assertion above leaves a `while True` child running for the rest of the session.
+            if child.poll() is None:
+                child.kill()
+                child.wait(timeout=30)
+
 
 @postgres
-def test_T158_kill_9_mid_transaction_ages_out_by_its_lease_and_nothing_else(schema):
+def test_T158_a_killed_holder_ages_out_by_its_lease_and_nothing_else(schema):
     """SPEC-v0.6 §5.1, §5.3, under a real `SIGKILL`.
 
     A process is killed while holding a reservation it has begun executing. **Nothing reclaims
     the key**: *"the holder is dead" is not knowable from the store*. The record stays `EXECUTING`
     until its lease lapses, and the next contender then finds `AMBIGUOUS` -- a refusal, not a
     reclaim, and one only a human or a reconcile hook moves on.
+
+    Named for what it does. The kill lands while the child is **idle between transactions**,
+    which is deterministic and is the case §5.1 is about. The mid-transaction kill §8's T158 also
+    names is the test below; the two are different claims and were one test before.
     """
-    work = Path(tempfile.mkdtemp())
-    script = work / "hold.py"
-    script.write_text(HOLD, encoding="utf-8")
-    ready = work / "ready"
-
-    child = subprocess.Popen(
-        [sys.executable, str(script)],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-    assert child.stdin is not None
-    child.stdin.write(
-        json.dumps(
-            {
-                "url": URL,
-                "schema": schema,
-                "key": "refund:t158",
-                "action_id": "act_doomed",
-                "ready": str(ready),
-                "now": T0.isoformat(),
-            }
-        )
-    )
-    child.stdin.close()
-
-    deadline = time.monotonic() + 60
-    while time.monotonic() < deadline and not ready.exists():
-        if child.poll() is not None:
-            assert child.stderr is not None
-            raise AssertionError(f"the holder exited early: {child.stderr.read()[-400:]}")
-        time.sleep(0.05)
-    assert ready.exists(), "the holder never took the reservation within its bound"
-
-    os.kill(child.pid, signal.SIGKILL)
-    child.wait(timeout=30)
-    assert child.returncode != 0, "the holder exited cleanly; it was supposed to be killed"
+    _hold(HOLD, schema, "refund:t158", "act_doomed")
 
     # The database is consistent, and the record is exactly where the dead process left it.
     store = store_on(URL, schema)
@@ -433,34 +814,132 @@ def test_T158_kill_9_mid_transaction_ages_out_by_its_lease_and_nothing_else(sche
     later.close()
 
 
+@postgres
+def test_T158_a_kill_mid_transaction_discards_the_half_written_transaction(schema):
+    """§8's T158, the half the idle kill above cannot show.
+
+    The child is killed with an **open transaction** holding an uncommitted `UPDATE` and the row
+    lock that goes with it. Postgres discards it: the record is still `reserved`, the write is
+    gone, and the lock is released -- so the store can read and plan against the row rather than
+    blocking on a lock nobody will ever release. That is the whole of what "mid-transaction"
+    adds, and nothing checked it.
+    """
+    _hold(HOLD_MID, schema, "refund:t158mid", "act_half")
+
+    store = store_on(URL, schema)
+    record = store.get_effect("refund:t158mid")
+    assert record is not None
+    assert record.state is EffectState.RESERVED, (
+        f"the record is {record.state}; the killed backend's uncommitted UPDATE survived, which "
+        "would mean a half-written transaction became state"
+    )
+
+    # The row lock died with the backend: a contender gets an answer rather than blocking.
+    with pytest.raises(DuplicateEffect):
+        store.reserve_effect("refund:t158mid", "act_next", timedelta(minutes=5))
+    store.close()
+
+
 # --- T158b: partition, and every backend restarted --------------------------------------------
 
 
 @postgres
-def test_T158b_a_partition_stalls_and_never_reports_failed(proxy, schema):
-    """§4.5's partition injection.
+def test_T158b_a_partition_stalls_the_call_and_the_restore_completes_it(proxy, schema):
+    """§4.5's partition injection, **and its restore**.
 
-    The client sees a stall, not a reset -- which is the shape a partition actually has, and the
-    reason `FAILED` must not be inferred from it. Every wait is bounded: a timeout here fails red
-    rather than hanging CI.
+    A partition is a stall, not a reset -- which is why `FAILED` must not be inferred from one --
+    and this asserts the stall as an observable: with the partition on, the call has not returned;
+    with it lifted, the same call completes and the record is `EXECUTING`. Deleting the injection
+    makes the first assertion fail, which is the property the first version lacked: it captured
+    the outcome and asserted nothing about it, so removing the partition entirely left it green
+    (in 0.28 s instead of 40 s, which is the other half of the story).
+
+    The 40 seconds are gone with the injection's deadline. The proxy **holds** traffic rather than
+    discarding it, so the restore genuinely delivers the query the server never saw; the first
+    version discarded, and then tore the sockets down from under its own relay threads after
+    `TIMEOUT * 2` -- so the client got "server closed the connection unexpectedly", the docstring
+    said "a stall, not a reset", and the bound the test called a network property was a constant
+    in the proxy.
     """
     store = store_on(proxy.url(URL), schema)
     store.reserve_effect("refund:part", "act_p", timedelta(minutes=5))
 
     proxy.partition = True
-    started = time.monotonic()
-    outcome: str
-    try:
-        store.begin_execution("refund:part", "act_p")
-        outcome = "returned"
-    except Exception as stalled:
-        outcome = type(stalled).__name__
-    elapsed = time.monotonic() - started
+    done = threading.Event()
+    outcome: list[str] = []
+
+    def call() -> None:
+        try:
+            store.begin_execution("refund:part", "act_p")
+            outcome.append("returned")
+        except BaseException as stalled:
+            outcome.append(type(stalled).__name__)
+        finally:
+            done.set()
+
+    worker = threading.Thread(target=call, daemon=True)
+    worker.start()
+
+    assert not done.wait(2.0), (
+        f"the partitioned call returned {outcome} while the partition was up. A partition that "
+        "nothing observes is an injection that is not happening"
+    )
+
     proxy.partition = False
-    assert elapsed < 90, "the partitioned call did not give up within its bound"
+    assert done.wait(30.0), "the restored call never completed within its bound"
+    worker.join(timeout=5.0)
+    assert not worker.is_alive()
+    assert outcome == ["returned"], (
+        f"the restored call ended as {outcome}; the proxy holds traffic across a partition, so "
+        "the query the server never received arrives when it is lifted"
+    )
 
     checker = store_on(URL, schema)
     record = checker.get_effect("refund:part")
+    assert record is not None
+    assert record.state is EffectState.EXECUTING
+    checker.close()
+    store.close()
+
+
+@postgres
+def test_T158b_a_partition_that_never_lifts_never_reports_failed(proxy, schema):
+    """The other end of the same injection: the partition outlives the client.
+
+    Nothing about a stall proves non-execution, so whatever the caller sees when its connection
+    is finally torn down, the record must not be `FAILED`.
+    """
+    store = store_on(proxy.url(URL), schema)
+    store.reserve_effect("refund:part2", "act_p2", timedelta(minutes=5))
+
+    proxy.partition = True
+    done = threading.Event()
+    outcome: list[str] = []
+
+    def call() -> None:
+        try:
+            store.begin_execution("refund:part2", "act_p2")
+            outcome.append("returned")
+        except BaseException as stalled:
+            outcome.append(type(stalled).__name__)
+        finally:
+            done.set()
+
+    worker = threading.Thread(target=call, daemon=True)
+    worker.start()
+    assert not done.wait(2.0), f"the partitioned call returned {outcome}; nothing was injected"
+
+    proxy.stop()  # the partition never lifts; the connection goes away underneath the client
+    assert done.wait(30.0), "the call never gave up within its bound"
+    worker.join(timeout=5.0)
+    assert not worker.is_alive()
+    assert outcome != ["returned"], "the connection was taken away and the call returned anyway"
+    assert outcome[0] != "NotExecuted", (
+        "a partition reached the caller as NotExecuted, which asserts the write did not happen"
+    )
+
+    checker = store_on(URL, schema)
+    record = checker.get_effect("refund:part2")
     assert record is not None
     assert record.state is not EffectState.FAILED, (
         f"a partition produced a FAILED record ({outcome}); nothing about a stall proves "
@@ -474,46 +953,76 @@ def test_T158b_a_partition_stalls_and_never_reports_failed(proxy, schema):
 def test_T158b_every_backend_terminated_under_load_leaves_no_failed_effect(schema):
     """The client-visible half of "restart Postgres under load".
 
-    Every backend is terminated while contenders are mid-flight. From a client that is
-    indistinguishable from a restart, and it is what this environment can do without taking the
-    server away from everything else on the machine -- which the PR says rather than implying a
-    full restart was run.
-    """
-    import threading
+    Every backend **this test opened** is terminated while a commit is in flight. From a client
+    that is indistinguishable from a restart, and it is what this environment can do without
+    taking the server away from everything else on the machine -- which the PR says rather than
+    implying a full restart was run.
 
+    Two things the first version got wrong, both of which made it a test of nothing. It started
+    its killer and then immediately committed on an already-open connection, so the commit landed
+    before the killer's own `connect` returned and the `finally` ended the thread before its first
+    iteration: **zero** backends were ever terminated, and replacing the killer's body with
+    `return` left the test green. And it terminated every backend on the database, including
+    other tests' and any `psql` the maintainer had open. It now waits for the first successful
+    termination, asserts that at least one commit attempt was actually broken, and scopes the kill
+    to its own `application_name`.
+    """
     import psycopg
 
-    store = store_on(URL, schema)
+    tag = f"xhost_restart_{uuid.uuid4().hex[:8]}"
+    separator = "&" if "?" in URL else "?"
+    store = store_on(f"{URL}{separator}application_name={tag}", schema)
     store.reserve_effect("refund:restart", "act_r", timedelta(minutes=5))
     store.begin_execution("refund:restart", "act_r")
 
     stop = threading.Event()
+    killing = threading.Event()
+    terminated = [0]
 
-    def terminate_everything() -> None:
+    def terminate_ours() -> None:
         admin = psycopg.connect(URL, autocommit=True)
         try:
-            deadline = time.monotonic() + 5
+            deadline = time.monotonic() + 20
             while not stop.is_set() and time.monotonic() < deadline:
-                admin.execute(
+                rows = admin.execute(
                     "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-                    "WHERE datname = current_database() AND pid <> pg_backend_pid()"
-                )
-                time.sleep(0.1)
+                    "WHERE datname = current_database() AND application_name = %s "
+                    "AND pid <> pg_backend_pid()",
+                    (tag,),
+                ).fetchall()
+                terminated[0] += sum(1 for row in rows if row[0])
+                if terminated[0]:
+                    killing.set()
+                time.sleep(0.02)
         finally:
             admin.close()
 
-    killer = threading.Thread(target=terminate_everything, daemon=True)
+    killer = threading.Thread(target=terminate_ours, daemon=True)
     killer.start()
+    attempts = 0
+    broken = 0
     try:
+        assert killing.wait(20.0), (
+            f"no backend tagged {tag} was ever terminated, so nothing was injected. The first "
+            "version asserted on the record without checking this and terminated nothing at all"
+        )
         for _ in range(20):
+            attempts += 1
             try:
                 store.commit_effect("refund:restart", "act_r", {"ok": True})
                 break
             except Exception:
+                broken += 1
                 time.sleep(0.05)
     finally:
         stop.set()
         killer.join(timeout=30)
+
+    assert terminated[0] >= 1, "the killer reported no terminations"
+    assert broken >= 1, (
+        f"{attempts} commit attempts and none was broken by a terminated backend; the window "
+        "this test names never opened"
+    )
 
     checker = store_on(URL, schema)
     record = checker.get_effect("refund:restart")


### PR DESCRIPTION
Build-list item 4; SPEC-v0.6 §4.5, §8. Tests T155–T158b in `tests/test_cross_host.py`, with the injector in `tests/failure_injection.py`.

## What was actually run — first, because §4.5 requires it

**Separate OS processes against one Postgres, with the connection broken by a proxy these tests own. Not two hosts.** There is no container runtime in this environment. Separate processes give separate connections, no shared memory and no shared file locks — which is exactly what `BEGIN IMMEDIATE` was silently relying on, and what a second host removes — so the *reservation* guarantee is exercised. What is not exercised is a partition between two machines.

The "restart Postgres under load" test terminates every backend **this test opened**, which from a client is indistinguishable from a restart. It is not a full `pg_ctl restart`; that would take the server away from everything else on the machine.

A proxy is better than a container for §4.5's most important case. Killing a container reproduces "the connection died during `COMMIT`" only when the timing happens to land there; a proxy that forwards the `COMMIT` and *then* drops the client reproduces it every time.

## The first version of this PR passed while exercising almost none of what it named

An independent review returned **3 blockers, 6 majors and 11 minors**, with a mutation table proving each one. That list is the most useful part of this PR, so it is here rather than in a commit message.

### The blockers

1. **The child processes graded a hardcoded absolute path.** `sys.path.insert(0, "/Users/arpanghoshal/ctrlrun/src")` in the T157 and T158 child scripts. Those children are the *only* thing that exercises the reservation guarantee in T157, so gutting `_reserve_locked` in the tree under test left T157 green (`1 passed in 0.62s`) while every in-process test in the same file failed. It also defeats the release rule that verification runs from a fresh clone: on a fresh clone, T157 would grade the maintainer's working tree — and mid-review, when that path happened to be on another branch, the tests failed with a `SchemaMismatch` raised from a different checkout. The children now derive the tree from `__file__`, and both the child and the parent **assert** that `ctrlrun.__file__` is under it.

2. **The restart test terminated zero backends.** The killer thread opened its admin connection *after* being started, the commit on an already-open connection completed before that `connect` returned, and the `finally: stop.set()` ended the killer before its first loop iteration. Instrumented, 5/5 runs: `terminated=0 in 0 rounds elapsed=0.00s`. Replacing the killer's body with `return` left the test green. It now waits for the first successful `pg_terminate_backend`, asserts at least one commit attempt was actually broken, and scopes the kill to its own `application_name` instead of every backend on a database shared with other tests.

3. **The partition injected nothing observable and delivered a reset, not a stall.** Deleting the injection entirely made the test pass *faster* (0.28 s instead of 40 s) because nothing observed the partition — `outcome` was captured and never asserted. And the 40 seconds were not a network property: they were `forward.join(timeout=TIMEOUT) + backward.join(timeout=TIMEOUT)`, after which `_relay` closed both sockets underneath its own still-running pump threads, so the client saw *"server closed the connection unexpectedly"* while the docstring and this PR both said "a stall, not a reset". §4.5's "and restore it" was unexercised too, because a discarded query cannot arrive late. The proxy now **holds** traffic and releases it on restore; the relay joins without a timeout; and the test asserts the call has *not* returned while partitioned and *does* return once it is lifted.

### The majors

4. **T155b never reached the row it was named for.** The proxy forwarded every `COMMIT`, so the write always landed and the re-read always found Table A2 **row 1**. Row 2 — *unchanged and still ours → re-issue* — was unreachable, and two mutants proved it: deleting the re-issue arm, and deleting the whole A2 re-read, both left T155b green. Table A1 row 2 was equally unreachable. `drop_before_commit` kills the client *without* forwarding the `COMMIT`, which reaches both, and they are now `test_T155d` and `test_T155e`. What T155b actually tests is row 1, and it is named for that.

5. **T155 could not distinguish "resolved by the re-read" from "never re-read".** Replacing `_resolve_lost_insert` with `return` left every assertion passing — because the write *did* land, so the record genuinely is ours and a blind retry genuinely is refused. §8 had asked that "the events name which branch of §4.3.2 ran" and nothing implemented it. **New: SPEC-v0.6 §4.3.4** — a closed set of six branch names reported on the `ctrlrun.postgres` logger, and T155 asserts which one ran. Not a new event type; nothing reaches a sink.

6. **`clients_killed >= 1` was not evidence the window opened.** The trigger was `b"COMMIT" in data`, which fires on any client→server chunk containing those bytes — including a Bind message whose *parameter* is an effect key containing the word. Demonstrated: `refund:COMMIT-me` killed the client on the `SELECT`'s Bind, which is Table A row 1 (an exception *before* `COMMIT`, a clean `FAILED`) and not the ambiguous window at all — and the guard added specifically to catch that class of false green still passed. `failure_injection._Frontend` now parses the length-prefixed frontend protocol, and there are two positive controls: a no-server test that a Bind carrying `refund:COMMIT-me` is not a `COMMIT` (including one byte at a time), and an end-to-end test that runs the whole T155 window with that key.

7. **T156 passed when the re-read failed *open*.** Making `_fresh_read_effect` swallow its connect failure and return `None` — turning §4.3.2's "the re-read failed → refuse, write nothing" into A1's "no record → retry the insert" — left T156 green, because the refusal it observed came from the *retry's* connect failing. Also `pytest.raises(Exception)` pinned nothing, `assert not isinstance(raised.value, NotExecuted)` forbade something no path in the store can raise, and `if record is not None:` made §8's "the record is left exactly as it was" optional. The exception type is now asserted, the hedge is gone, and §8's "the executor is never reached" is checked rather than assumed — **and the type turned out not to be enough**, see row 7 of the table below.

8. **The re-issue path this item exists to exercise was unbounded recursion — a real defect in `src/ctrlrun/postgres.py`.** `_transition` → `_resolve_lost_update` → `_transition` with no `retrying` bound, unlike its sibling `_authorize_and_reserve`, whose comment says *"Every loop in this project is bounded, and a re-read path is a loop."* Driving A2 row 2 with a `COMMIT`-swallowing proxy: `exc=RecursionError, resolve_lost_update_calls=96, state=executing` — outside the library's closed set of errors, so no caller can classify it, and the record stranded. §4.2's "a second ambiguous commit on the same operation fails closed rather than recursing" was not honoured for transitions. **Fixed here**, with `test_T155f` driving it.

9. **T158 did not kill mid-transaction.** Its `ready` marker was written *after* `begin_execution` had committed, so the child was killed idle between transactions. That is a good, deterministic test of "the holder went away" — it keeps its name now — but nothing checked what "mid-transaction" adds: that Postgres discards a half-written transaction. A second holder now opens a transaction, writes an uncommitted `UPDATE`, signals ready from *inside* it, and is killed there; the test asserts the record is still `reserved` and that the row lock died with the backend.

10. **`assert elapsed < 90` was not a bound.** It ran *after* the call returned, so a call that never returned would never reach it — and there is no `pytest-timeout` in this repo, so a hang consumes the job timeout rather than failing red. Waiting is now done on a thread with a bounded `Event.wait`.

### The minors

Two `tempfile.mkdtemp()` calls leaked a directory per run (+2 per run across 10 runs, monotonic) — now `TemporaryDirectory`. T158 orphaned an immortal `while True` child on its own failure path — now `try/finally`. A dead `hang` branch that would have leaked a 600-second child — deleted. `_contenders`' return annotation said `list[dict]` and returned a tuple, which made mypy call the loser-error loop statically dead — fixed. `assert called == ["called"]`'s message claimed a count its `O_EXCL` mechanism could not produce — per-pid markers now, so the assertion and its message describe the same thing. T157's barrier degraded silently on timeout — the child reports it and the parent asserts. A subsumed assertion (`str(record.state) != "failed"` after `is EffectState.RESERVED`) — dropped, since a dedicated test covers the negative and a mutant proves it falsifiable. `terminate_everything` killed every backend on a shared database, including the reviewer's `psql` — scoped. Three docstring claims corrected: "never packaged" → never in the *wheel* (it is in the sdist, correctly, like every test file); `refuse_connections` accepts-and-closes rather than refusing; and the "every wait here is bounded, so a broken check fails red" line, which was false of the joins that abandoned live pumps.

### §8 requirements that have no test, stated rather than skipped

**T157 asks for "one committed receipt and N−1 blocked" and this PR does not check it.** Not applicable is not a pass, so: receipts are written by `Control`, not by a store, and no `Control` participates in a store-level contention test. `v0.1 §7` T3 covers the receipt half and is unchanged by this milestone. What a Postgres backend can get wrong — and what this test is for — is the reservation underneath it.

**T155c is not missing.** It lives in `tests/test_postgres.py`, and it does catch the §4.3.3 → `action_id` mutation. A pointer comment now says so, so the next reader does not conclude it was dropped.

## What the review checked and found clean

Worth recording, because it is the half that says what not to re-verify: the ambiguous window genuinely opens for T155/T155b/T156 (instrumented, 3× each: `commit_raised=1, fresh_read=1`); the `COMMIT` arrives as one unsplit `b'Q\x00\x00\x00\x0bCOMMIT\x00'` and psycopg does not pipeline it; the re-read is never spuriously killed; the kill belongs to the right connection; T157's barrier really does hold 8 processes (0.5–3.3 ms release spread, 0 timeouts, exactly 1 winner over 10 runs); the `O_EXCL` marker really does count across processes; T158's kill is deterministic; and there were no leaked schemas, backends or orphaned children over 10 consecutive runs.

## Mutation table

| # | MUST | Result |
|---|---|---|
| 1 | §4.3.2 the re-read happens at all (A1) | RED |
| 2 | §4.3.2 the re-read happens at all (A2) | RED |
| 3 | §4.3.2 Table A1 row 2 re-issues the `INSERT` | RED |
| 4 | §4.3.2 Table A2 row 2 re-issues the `UPDATE` | RED |
| 5 | §4.2 the re-issue path is bounded | RED |
| 6 | §4.3.4 the branch is reported | RED |
| 7 | §4.3.2 a failed re-read refuses, never fails open | RED |
| 8 | §4.2 the reservation is actually written (children read the tree under test) | RED |
| 9 | §4.5 the partition is injected at all | RED |
| 10 | §4.5 the partition holds rather than discards (the restore is real) | RED |
| 11 | §4.5 backends are actually terminated | RED |
| 12 | §4.5 the `COMMIT` is swallowed, not forwarded | RED |
| 13 | the kill trigger reads frames, not the payload | RED |
| 14 | §4.3 a lost `COMMIT` is never recorded `FAILED` | RED |
| 15 | §4.3.3 identity is every column, not `action_id` | RED |

Rows 1, 4, 7, 9 and 11 are five the first version left GREEN.

**Row 7 was still green after the first fix**, and it is worth saying why rather than quietly re-running until it went red. Asserting the *exception type* does not separate "the re-read refused" from "the re-read failed open and the retry's connect failed instead" — both surface as `OperationalError`. What separates them is §4.3.4: refusing reports **no branch at all**, because no row of Table A was ever chosen, while failing open reports `a1.row2.reinsert`. The section added for finding #5 turned out to be what closes #7 too.

## Cost

`tests/test_cross_host.py`: 17 tests, **9.7 s** — down from 9 tests in 42 s, 40 s of which was the partition's teardown deadline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
