### PR TITLE
Item 8: the soak, and the exit criterion it does not meet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,8 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "ANN", "SIM", "RUF"]
 # skipped row and not an import error at module scope.
 "research/framework-probe/*.py" = ["ANN401", "N818", "PLC0415"]
 "research/framework-probe/**/*.py" = ["ANN401", "N818", "PLC0415"]
+"research/soak/*.py" = ["ANN401", "N818", "PLC0415"]
+"research/soak/**/*.py" = ["ANN401", "N818", "PLC0415"]
 # Type hints are a src/ constraint; tests stay cheap to write. N802 lets acceptance
 # tests carry the SPEC §7 identifier verbatim (test_T7_...).
 "tests/*" = ["ANN", "N802"]

--- a/research/soak/README.md
+++ b/research/soak/README.md
@@ -1,0 +1,62 @@
+# The v0.6 soak
+
+Build-list item 8; `SPEC-v0.6.md` §8.1. Outside `src/`, never packaged, on
+`research/framework-probe/`'s precedent (`v0.4 §7.1`).
+
+```
+python research/soak/run.py --minutes 600 --postgres "$CTRLRUN_TEST_POSTGRES" --out soak.json
+```
+
+## The one question
+
+*Does an `AMBIGUOUS` ever appear that the harness did not cause?*
+
+`ROADMAP.md`'s exit criterion is a week with **no** unexplained `AMBIGUOUS`, and that is the one
+number nobody can produce by reasoning about the code. Everything here exists to make an
+unexplained ambiguity **visible** rather than rare.
+
+## "Unexplained" is defined before the run starts
+
+Or the criterion is unfalsifiable.
+
+- An `AMBIGUOUS` whose **attempt** has a recorded injection is *explained*.
+- One with no corresponding injection is *unexplained*, and is what the criterion counts.
+
+Keyed on the attempt — `(effect_key, action_id)` — and never on the effect key alone. One key may
+be attempted more than once, `v0.1 §5.4`'s retry being the ordinary way, and an injection against
+attempt 1 says nothing about attempt 2. Keying on the key would let one recorded injection absorb
+every later ambiguity on it, which is how a real finding disappears.
+
+**Injections are recorded before they are caused.** A crash in between leaves an injection with no
+ambiguity, which is harmless. Recording afterwards would leave an ambiguity with no injection —
+a false finding, manufactured by the harness, in the exact number it exists to report.
+
+## The positive control runs first, in its own store
+
+A harness that reports "zero unexplained" without being able to *see* one is reporting that it
+looked, not that there was nothing to find (`v0.4 §1.3`).
+
+So a short control phase injects an ambiguity it deliberately does not record and requires the
+classifier to report it. It runs in its own store and its own ledger, because a first version ran
+the control inside the measured phase and made `exit_criterion_met` unreachable — the run could
+prove it could see, or report zero, never both.
+
+A table whose control did not fire says so, in words, and is not evidence.
+
+## The duration is measured, never asserted
+
+§8.1's week is calendar time and "does not compress". The table prints how long the run **actually
+lasted** and `exit_criterion_met` is about the ambiguity count alone. A harness that decided for
+itself whether the duration was met would be making the one claim §8.1 says would be exactly as
+false as it looks.
+
+Whoever writes the changelog reads the measured duration and says that. `tests/test_soak.py`
+asserts the rendered table never contains the word "week".
+
+## What it does not do
+
+- It is **not a load test**. The throughput numbers are a by-product; nothing here is tuned for
+  them and none is published as a performance claim.
+- It does not exercise a network partition or a second host. That is item 4's
+  `tests/test_cross_host.py`, and §4.5 says which of those were actually run.
+- It says nothing about the receipt chain. `ctrlrun receipts --verify-chain` is that.

--- a/research/soak/README.md
+++ b/research/soak/README.md
@@ -4,7 +4,7 @@ Build-list item 8; `SPEC-v0.6.md` §8.1. Outside `src/`, never packaged, on
 `research/framework-probe/`'s precedent (`v0.4 §7.1`).
 
 ```
-python research/soak/run.py --minutes 600 --postgres "$CTRLRUN_TEST_POSTGRES" --out soak.json
+python research/soak/run.py --minutes 20 --postgres "$CTRLRUN_TEST_POSTGRES" --out soak.json
 ```
 
 ## The one question
@@ -52,6 +52,45 @@ false as it looks.
 
 Whoever writes the changelog reads the measured duration and says that. `tests/test_soak.py`
 asserts the rendered table never contains the word "week".
+
+## What was run
+
+One measured run, and the numbers are the numbers:
+
+```
+CTRLRun soak — postgres (schema soak_968eae6651)
+  ran            20m 0s (2026-09-05T19:05:37Z → 2026-09-05T19:25:37Z)
+  actions        889735
+  ambiguous      133393  (133393 explained, 0 unexplained)
+  control fired  yes
+
+  no unexplained ambiguity
+```
+
+The JSON table is `results/2026-09-05-postgres-20m.json`.
+
+Four worker threads, one `PostgresStateStore` each, against PostgreSQL on the same host, into a
+schema created for the run and dropped after it. The injection mix is `soak/runner.py`'s
+`INJECTIONS`: 70% clean, 10% executor timeout, 10% unknown exception from the executor, 8%
+`NotExecuted`, 2% a lease short enough to lapse mid-execution.
+
+**What that is evidence of.** Across 889,735 attempts, every `AMBIGUOUS` the store held at the end
+had a ledger entry recorded before the failure that produced it. Nothing became ambiguous that the
+harness did not make ambiguous, and the positive control fired, so the run was capable of saying
+otherwise.
+
+**What it is not evidence of, stated plainly: `ROADMAP.md`'s exit criterion.** That criterion is a
+soak of at least **one week** with no unexplained `AMBIGUOUS`, and this ran for twenty minutes. A
+week of calendar time does not compress, and a bigger action count is not a substitute for it — a
+ten-hour run would meet the criterion no better than this one does, it would just put a larger
+number next to something still unmet. `exit_criterion_met: true` in the JSON is about the
+**ambiguity count**, which is all the harness is allowed to decide; the clock is reported and left
+to a human, and `docs/ROADMAP.md` records the criterion as **not met**.
+
+The throughput figure is a by-product and is not a performance claim. Note in particular what it
+does **not** measure: most of these actions are denied or refused by policy before any receipt is
+written, so it says very little about the one-row head that `SPEC-v0.6.md` §6.3 serializes every
+receipt write on. `docs/postgres.md` describes that ceiling; this run does not size it.
 
 ## What it does not do
 

--- a/research/soak/results/2026-09-05-postgres-20m.json
+++ b/research/soak/results/2026-09-05-postgres-20m.json
@@ -1,0 +1,15 @@
+{
+  "actions": 889735,
+  "ambiguous": 133393,
+  "backend": "postgres (schema soak_968eae6651)",
+  "elapsed_human": "20m 0s",
+  "elapsed_seconds": 1200.004,
+  "ended_at": "2026-09-05T19:25:37.573689+00:00",
+  "exit_criterion_met": true,
+  "explained": 133393,
+  "findings": [],
+  "positive_control_fired": true,
+  "schema": "ctrlrun.soak/v1",
+  "started_at": "2026-09-05T19:05:37.569371+00:00",
+  "unexplained": 0
+}

--- a/research/soak/run.py
+++ b/research/soak/run.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+"""Run the v0.6 soak and print its table. SPEC-v0.6 §8.1.
+
+    python research/soak/run.py --minutes 30 --postgres "$CTRLRUN_TEST_POSTGRES"
+    python research/soak/run.py --minutes 5                      # SQLite, for a smoke run
+
+**The duration is measured and printed, never asserted.** `ROADMAP.md`'s exit criterion is a week
+with no unexplained `AMBIGUOUS`, and a run shorter than that does not meet it — the table says how
+long it actually ran and `exit_criterion_met` is about the ambiguity count, not the clock. A
+harness that reported "criterion met" after thirty minutes would be making the one claim §8.1
+says would be exactly as false as it looks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from soak.ledger import Ledger, classify, render, report, to_json
+from soak.runner import (
+    Runner,
+    ambiguities_in,
+    postgres_store,
+    sqlite_store,
+)
+
+
+def _control_sees_an_unrecorded_ambiguity(work: Path, seed: int) -> bool:
+    """Prove the harness can detect an unexplained ambiguity, in its own store (§8.1).
+
+    Without this, "zero unexplained" is a report that the harness looked, not that there was
+    nothing to find -- `v0.4 §1.3`'s rule, and the reason it is required rather than encouraged.
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory(dir=work) as scratch:
+        room = Path(scratch)
+        ledger = Ledger(room / "control-ledger.db")
+        runner = Runner(
+            open_store=sqlite_store(room / "control-state.db"),
+            ledger=ledger,
+            seed=seed,
+            control=True,
+        )
+        runner.run(until=datetime.now(UTC) + timedelta(seconds=5), workers=2)
+        store = sqlite_store(room / "control-state.db")()
+        found = ambiguities_in(store)
+        close = getattr(store, "close", None)
+        if close is not None:
+            close()
+        return bool(classify(found, ledger))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="The v0.6 soak (SPEC-v0.6 §8.1).")
+    parser.add_argument("--minutes", type=float, default=5.0, help="How long to run.")
+    parser.add_argument("--workers", type=int, default=4)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--postgres", default=None, help="A Postgres URL. Default: SQLite.")
+    parser.add_argument("--out", type=Path, default=None, help="Write the JSON table here.")
+    parser.add_argument(
+        "--no-control",
+        action="store_true",
+        help="Disable the positive control. The table then says so and is not evidence.",
+    )
+    arguments = parser.parse_args(argv)
+
+    work = Path(arguments.out).parent if arguments.out else Path.cwd()
+    work.mkdir(parents=True, exist_ok=True)
+    ledger = Ledger(work / "soak-ledger.db")
+
+    schema = None
+    if arguments.postgres:
+        from ctrlrun.postgres import PostgresStateStore
+
+        schema = f"soak_{uuid.uuid4().hex[:10]}"
+        PostgresStateStore.create_schema(arguments.postgres, schema)
+        opened = postgres_store(arguments.postgres, schema)
+        backend = f"postgres (schema {schema})"
+    else:
+        opened = sqlite_store(work / "soak-state.db")
+        backend = "sqlite"
+
+    # **Two phases, and the control comes first** (`v0.4 §1.3`).
+    #
+    # The control injects an ambiguity it deliberately does not record, and the harness must
+    # report it. It runs in its own store and its own ledger, so the thing it proves -- that an
+    # unexplained ambiguity is *visible* -- does not become an unexplained ambiguity in the
+    # measured run. A first version ran the control inside the measured phase, which made
+    # `exit_criterion_met` unreachable: the run could prove it could see, or report zero, never
+    # both.
+    control_fired = False
+    if not arguments.no_control:
+        control_fired = _control_sees_an_unrecorded_ambiguity(work, arguments.seed)
+        if not control_fired:
+            print(
+                "the positive control did not fire: this harness cannot see an unexplained "
+                "ambiguity, so nothing it reports about one is evidence (SPEC-v0.6 §8.1)",
+                file=sys.stderr,
+            )
+
+    started = datetime.now(UTC)
+    runner = Runner(open_store=opened, ledger=ledger, seed=arguments.seed, control=False)
+    try:
+        runner.run(until=started + timedelta(minutes=arguments.minutes), workers=arguments.workers)
+        ended = datetime.now(UTC)
+        store = opened()
+        found = ambiguities_in(store)
+        close = getattr(store, "close", None)
+        if close is not None:
+            close()
+    finally:
+        if schema:
+            from ctrlrun.postgres import PostgresStateStore
+
+            PostgresStateStore.drop_schema(arguments.postgres, schema)
+
+    findings = classify(found, ledger)
+    document = report(
+        started=started,
+        ended=ended,
+        actions=runner.progress.actions,
+        ambiguities=found,
+        findings=findings,
+        control_fired=control_fired,
+        backend=backend,
+    )
+    print(render(document))
+    if arguments.out:
+        Path(arguments.out).write_text(to_json(document) + "\n", encoding="utf-8")
+
+    # Non-zero when the run found something or could not have found anything. Not when the run
+    # was short: the clock is the maintainer's call, and §8.1 says item 9 does not tag until
+    # item 8 reports.
+    return 0 if document["exit_criterion_met"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/soak/soak/__init__.py
+++ b/research/soak/soak/__init__.py
@@ -1,0 +1,21 @@
+"""The v0.6 soak. Build-list item 8; SPEC-v0.6 §8.1.
+
+Outside `src/`, never packaged, on `research/framework-probe/`'s precedent (`v0.4 §7.1`).
+
+**"Unexplained" is defined before the run starts**, or the exit criterion is unfalsifiable. The
+harness is the definition:
+
+- an `AMBIGUOUS` whose effect key has a **recorded injection** for that attempt is *explained*;
+- one with no corresponding injection is *unexplained*, and is the thing `ROADMAP.md`'s exit
+  criterion counts.
+
+The injector records what it did **before** it does it, so a crash between the injection and the
+record cannot turn an explained ambiguity into an unexplained one by losing the note. The
+alternative -- recording afterwards -- makes the harness optimistic in exactly the direction that
+would hide a real finding.
+
+**The positive control is not optional** (`v0.4 §1.3`). A harness that reports "zero unexplained"
+without being able to *see* one is reporting that it looked, not that there were none. `--control`
+injects an ambiguity it deliberately does not record, and the run MUST report it. `soak.py`
+refuses to publish a table from a run whose control did not fire.
+"""

--- a/research/soak/soak/ledger.py
+++ b/research/soak/soak/ledger.py
@@ -1,0 +1,226 @@
+"""What the harness injected, and what it found. SPEC-v0.6 §8.1.
+
+The ledger is the whole of the definition of "unexplained", so it is a separate module with its
+own tests rather than a dictionary inside the runner: a criterion that lives in a comprehension
+is a criterion nobody can check.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+#: Every way this harness knows how to produce an `AMBIGUOUS` outcome. A cause not in this set is
+#: a defect in the harness, not a finding about the kernel -- so `classify` refuses one rather
+#: than counting it as explained.
+CAUSES: tuple[str, ...] = (
+    "executor_timeout",
+    "executor_unknown_exception",
+    "lease_expired",
+    "store_connection_lost",
+    #: The positive control. Injected and **deliberately not recorded**, so the run must report
+    #: it as unexplained. See `soak.__doc__`.
+    "uncontrolled",
+)
+
+EXPLAINED: frozenset[str] = frozenset(CAUSES) - {"uncontrolled"}
+
+
+@dataclass(frozen=True)
+class Injection:
+    """One failure the harness caused, recorded **before** it was caused."""
+
+    at: datetime
+    effect_key: str
+    action_id: str
+    cause: str
+
+
+@dataclass(frozen=True)
+class Ambiguity:
+    """One `AMBIGUOUS` record the run found, and what the store says about it."""
+
+    effect_key: str
+    action_id: str
+    error: str | None
+    resolved_by: str | None
+
+
+@dataclass(frozen=True)
+class Finding:
+    """An `AMBIGUOUS` with no injection behind it. This is what the exit criterion counts."""
+
+    effect_key: str
+    action_id: str
+    error: str | None
+    resolved_by: str | None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "effect_key": self.effect_key,
+            "action_id": self.action_id,
+            "error": self.error,
+            "resolved_by": self.resolved_by,
+        }
+
+
+class Ledger:
+    """A SQLite file of what was injected. Separate from the store under test, on purpose.
+
+    Writing the ledger into the store the soak is exercising would make the harness a participant
+    in the thing it measures -- its rows would contend for the same locks, and a store failure
+    would take the evidence of that failure with it.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        with self._connect() as connection:
+            connection.execute(
+                "CREATE TABLE IF NOT EXISTS injections("
+                "  at TEXT NOT NULL,"
+                "  effect_key TEXT NOT NULL,"
+                "  action_id TEXT NOT NULL,"
+                "  cause TEXT NOT NULL"
+                ")"
+            )
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS injections_by_key ON injections(effect_key)"
+            )
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self._path, timeout=30)
+        connection.execute("PRAGMA journal_mode=WAL")
+        return connection
+
+    def record(self, injection: Injection) -> None:
+        """Note an injection. Called **before** the failure is caused (§8.1)."""
+        if injection.cause not in CAUSES:
+            raise ValueError(f"unknown cause {injection.cause!r}; add it to CAUSES or fix the call")
+        with self._connect() as connection:
+            connection.execute(
+                "INSERT INTO injections(at, effect_key, action_id, cause) VALUES(?,?,?,?)",
+                (
+                    injection.at.isoformat(),
+                    injection.effect_key,
+                    injection.action_id,
+                    injection.cause,
+                ),
+            )
+
+    def injections(self) -> Iterator[Injection]:
+        with self._connect() as connection:
+            for row in connection.execute(
+                "SELECT at, effect_key, action_id, cause FROM injections ORDER BY at"
+            ):
+                yield Injection(
+                    at=datetime.fromisoformat(row[0]),
+                    effect_key=row[1],
+                    action_id=row[2],
+                    cause=row[3],
+                )
+
+    def explained_keys(self) -> set[tuple[str, str]]:
+        """`(effect_key, action_id)` pairs with a recorded, explaining injection.
+
+        Keyed on the **attempt** and not on the effect key alone: one key may be attempted more
+        than once, and an injection against attempt 1 explains nothing about attempt 2.
+        """
+        return {
+            (injection.effect_key, injection.action_id)
+            for injection in self.injections()
+            if injection.cause in EXPLAINED
+        }
+
+
+def classify(ambiguities: list[Ambiguity], ledger: Ledger) -> list[Finding]:
+    """Every `AMBIGUOUS` with no recorded injection behind it (§8.1).
+
+    This is the exit criterion, and it is deliberately the whole of it: `ROADMAP.md` asks for a
+    week with **no** unexplained `AMBIGUOUS`, so a non-empty return is a finding to investigate
+    and not a number to publish beside a green tick.
+    """
+    explained = ledger.explained_keys()
+    return [
+        Finding(
+            effect_key=item.effect_key,
+            action_id=item.action_id,
+            error=item.error,
+            resolved_by=item.resolved_by,
+        )
+        for item in ambiguities
+        if (item.effect_key, item.action_id) not in explained
+    ]
+
+
+def report(
+    *,
+    started: datetime,
+    ended: datetime,
+    actions: int,
+    ambiguities: list[Ambiguity],
+    findings: list[Finding],
+    control_fired: bool,
+    backend: str,
+) -> dict[str, object]:
+    """The published table (§8.1). The duration is measured, never asserted."""
+    elapsed = ended - started
+    return {
+        "schema": "ctrlrun.soak/v1",
+        "backend": backend,
+        "started_at": started.astimezone(UTC).isoformat(),
+        "ended_at": ended.astimezone(UTC).isoformat(),
+        "elapsed_seconds": round(elapsed.total_seconds(), 3),
+        "elapsed_human": _human(elapsed.total_seconds()),
+        "actions": actions,
+        "ambiguous": len(ambiguities),
+        "explained": len(ambiguities) - len(findings),
+        "unexplained": len(findings),
+        "findings": [finding.to_dict() for finding in findings],
+        # §8.1: *"a harness that reports zero without being able to see one is reporting that it
+        # looked."* A table whose control did not fire is not evidence and says so in itself.
+        "positive_control_fired": control_fired,
+        "exit_criterion_met": control_fired and not findings,
+    }
+
+
+def _human(seconds: float) -> str:
+    minutes, second = divmod(int(seconds), 60)
+    hours, minute = divmod(minutes, 60)
+    days, hour = divmod(hours, 24)
+    if days:
+        return f"{days}d {hour}h {minute}m"
+    if hour:
+        return f"{hour}h {minute}m {second}s"
+    return f"{minute}m {second}s"
+
+
+def render(document: dict[str, object]) -> str:
+    """The table a human reads, and the one the maintainer reads before it goes in a PR."""
+    lines = [
+        f"CTRLRun soak — {document['backend']}",
+        f"  ran            {document['elapsed_human']} "
+        f"({document['started_at']} → {document['ended_at']})",
+        f"  actions        {document['actions']}",
+        f"  ambiguous      {document['ambiguous']}"
+        f"  ({document['explained']} explained, {document['unexplained']} unexplained)",
+        f"  control fired  {'yes' if document['positive_control_fired'] else 'NO'}",
+        "",
+    ]
+    if not document["positive_control_fired"]:
+        lines.append(
+            "  The positive control did not fire. This run cannot see an unexplained ambiguity, "
+            "so its count of zero would mean nothing (SPEC-v0.6 §8.1)."
+        )
+    for finding in document["findings"]:  # type: ignore[union-attr]
+        lines.append(f"  UNEXPLAINED  {finding['effect_key']}  {finding['error']}")
+    if document["exit_criterion_met"]:
+        lines.append("  no unexplained ambiguity")
+    return "\n".join(lines)
+
+
+def to_json(document: dict[str, object]) -> str:
+    return json.dumps(document, indent=2, sort_keys=True)

--- a/research/soak/soak/runner.py
+++ b/research/soak/soak/runner.py
@@ -1,0 +1,225 @@
+"""Drive real actions through a real `Control` and injure them on purpose. SPEC-v0.6 §8.1.
+
+The soak is not a load test. It exists to answer one question — *does an `AMBIGUOUS` ever appear
+that the harness did not cause?* — because that is `ROADMAP.md`'s exit criterion and the one
+number nobody can produce by reasoning about the code.
+
+So every failure is **recorded before it is caused**, and everything else about the run is
+arranged to make an unexplained ambiguity visible rather than rare: concurrency across threads,
+leases short enough to lapse, and a mixture of outcomes so the store is never in one state long
+enough to be quiet.
+"""
+
+from __future__ import annotations
+
+import random
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from ctrlrun import Control, Policy
+from ctrlrun.action import Action, Principal
+from ctrlrun.effect import EffectState
+from ctrlrun.errors import CTRLRunError, NotExecuted
+
+from .ledger import Ambiguity, Injection, Ledger
+
+POLICY = """
+schema: ctrlrun.policy/v4
+version: "soak"
+actions:
+  soak.transfer:
+    effect: "soak:{reference}"
+    rules:
+      - when: {amount_gt: 100000}
+        decision: deny
+      - decision: allow
+"""
+
+#: How the harness injures an attempt, and how often. Weighted so most actions commit: a soak in
+#: which everything fails exercises the failure paths and never the quiet ones, and an unexplained
+#: ambiguity is likeliest to appear where the store is doing ordinary work.
+INJECTIONS: tuple[tuple[str, int], ...] = (
+    ("", 70),
+    ("executor_timeout", 10),
+    ("executor_unknown_exception", 10),
+    ("not_executed", 8),
+    ("lease_expired", 2),
+)
+
+
+@dataclass
+class Progress:
+    """What the run has done so far. Read by the reporter; written only by `Runner`."""
+
+    actions: int = 0
+    committed: int = 0
+    failed: int = 0
+    ambiguous: int = 0
+    denied: int = 0
+    refused: int = 0
+
+
+class Runner:
+    """One soak run against one store."""
+
+    def __init__(
+        self,
+        *,
+        open_store: Callable[[], object],
+        ledger: Ledger,
+        seed: int = 0,
+        control: bool = True,
+    ) -> None:
+        self._open_store = open_store
+        self._ledger = ledger
+        self._random = random.Random(seed)
+        self._control = control
+        self._control_fired = False
+        self._lock = threading.Lock()
+        self.progress = Progress()
+
+    @property
+    def control_fired(self) -> bool:
+        return self._control_fired
+
+    def run(self, *, until: datetime, workers: int = 4) -> None:
+        """Drive actions until `until`, on `workers` threads."""
+        threads = [
+            threading.Thread(target=self._work, args=(index, until), daemon=True)
+            for index in range(workers)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            # No timeout: the workers stop at `until` by themselves, and a join that gave up
+            # would leave them writing into a store the reporter is reading.
+            thread.join()
+
+    def _work(self, worker: int, until: datetime) -> None:
+        store = self._open_store()
+        control = Control(Policy.from_yaml(POLICY), store, clock=_now)  # type: ignore[arg-type]
+        counter = 0
+        while datetime.now(UTC) < until:
+            counter += 1
+            self._one(control, f"w{worker}-{counter}")
+        close = getattr(store, "close", None)
+        if close is not None:
+            close()
+
+    def _one(self, control: Control, reference: str) -> None:
+        amount = self._random.choice([500, 2500, 90000, 250000])
+        action = Action(
+            name="soak.transfer",
+            arguments={"reference": reference, "amount": amount},
+            principal=Principal(agent="soak-agent"),
+        )
+        key = f"soak:{reference}"
+        injury = self._pick()
+
+        # **Recorded before it is caused** (§8.1). A crash in between leaves an injection with no
+        # ambiguity, which is harmless; recording afterwards would leave an ambiguity with no
+        # injection, which is a false finding -- and the harness must not manufacture the very
+        # thing it is counting.
+        if injury in {"executor_timeout", "executor_unknown_exception", "lease_expired"}:
+            self._ledger.record(
+                Injection(
+                    at=datetime.now(UTC),
+                    effect_key=key,
+                    action_id=action.action_id,
+                    cause=_cause_of(injury),
+                )
+            )
+        if injury == "uncontrolled":
+            self._control_fired = True  # injected, deliberately unrecorded
+
+        try:
+            control.execute(action, _executor(injury), key, lease=_lease(injury))
+        except NotExecuted:
+            self._tally(failed=1)
+        except CTRLRunError:
+            self._tally(refused=1)
+        except (TimeoutError, RuntimeError):
+            self._tally(ambiguous=1)
+        else:
+            self._tally(committed=1)
+        self._tally(actions=1)
+
+    def _pick(self) -> str:
+        if self._control and not self._control_fired and self._random.random() < 0.02:
+            return "uncontrolled"
+        population = [name for name, _ in INJECTIONS]
+        weights = [weight for _, weight in INJECTIONS]
+        return self._random.choices(population, weights=weights, k=1)[0]
+
+    def _tally(self, **counts: int) -> None:
+        with self._lock:
+            for name, value in counts.items():
+                setattr(self.progress, name, getattr(self.progress, name) + value)
+
+
+def _cause_of(injury: str) -> str:
+    return injury
+
+
+def _lease(injury: str) -> timedelta:
+    # A lease short enough to lapse while the executor is still working, which is how §5.2's
+    # expiry path is reached without waiting for one.
+    return timedelta(milliseconds=1) if injury == "lease_expired" else timedelta(minutes=5)
+
+
+def _executor(injury: str) -> Callable[[], object]:
+    def run() -> object:
+        if injury == "executor_timeout":
+            raise TimeoutError("soak: the response was lost")
+        if injury == "executor_unknown_exception":
+            raise RuntimeError("soak: the remote answered something nobody parsed")
+        if injury == "not_executed":
+            raise NotExecuted("soak: the remote refused before acting")
+        if injury == "uncontrolled":
+            # The positive control: an ambiguity with no ledger entry behind it.
+            raise TimeoutError("soak: an ambiguity the harness did not record")
+        if injury == "lease_expired":
+            time.sleep(0.01)
+        return {"ok": True}
+
+    return run
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def ambiguities_in(store: object) -> list[Ambiguity]:
+    """Every `AMBIGUOUS` record the store holds, with what it says about itself."""
+    records = store.list_effects(EffectState.AMBIGUOUS)  # type: ignore[attr-defined]
+    return [
+        Ambiguity(
+            effect_key=record.effect_key,
+            action_id=record.action_id,
+            error=record.error,
+            resolved_by=record.resolved_by,
+        )
+        for record in records
+    ]
+
+
+def sqlite_store(path: Path) -> Callable[[], object]:
+    from ctrlrun import SQLiteStateStore
+
+    def opened() -> object:
+        return SQLiteStateStore(path)
+
+    return opened
+
+
+def postgres_store(url: str, schema: str) -> Callable[[], object]:
+    from ctrlrun.postgres import PostgresStateStore
+
+    def opened() -> object:
+        return PostgresStateStore(url, schema=schema)
+
+    return opened

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -529,6 +529,18 @@ def test_T136_the_ctrlrun_distributions_contain_no_adapter():
     ]
     assert not offending, offending
 
+    # **And `research/`, on the same build rather than a second one.** SPEC-v0.6 §8.1 and
+    # `v0.4 §7` both keep a harness out of the distribution while its *results* are published,
+    # and `tests/test_soak.py` skips itself when the directory is absent -- so this is the
+    # assertion that makes that skip safe rather than a hole. Anchored on a path **segment**,
+    # so a file called `research.py` is not a hit and a directory called `research/` is.
+    from pathlib import Path as _Path
+
+    unpackaged = [
+        name for name in names if any(part in {"research", "packs"} for part in _Path(name).parts)
+    ]
+    assert not unpackaged, unpackaged
+
 
 def test_T136_an_adapter_depends_on_ctrlrun_and_never_the_reverse():
     """The direction, asserted rather than assumed: `ctrlrun`'s own metadata names no adapter

--- a/tests/test_soak.py
+++ b/tests/test_soak.py
@@ -1,0 +1,190 @@
+"""The soak harness. Item 8; SPEC-v0.6 §8.1.
+
+The harness lives in `research/soak/`, outside `src/` and never packaged — but **its definition
+of "unexplained" is the release gate**, so it is tested here rather than trusted. `ROADMAP.md`'s
+exit criterion is a week with no unexplained `AMBIGUOUS`, and a harness that miscounts is a
+criterion that cannot be met or cannot be failed.
+
+What these assert is the two ways the count can lie:
+
+- **counting an injected ambiguity as unexplained**, which would make the gate unpassable and
+  invite somebody to relax it;
+- **counting an unexplained one as explained**, which is the failure that matters — it publishes
+  a zero that means nothing.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+RESEARCH = Path(__file__).resolve().parents[1] / "research" / "soak"
+if str(RESEARCH) not in sys.path:
+    sys.path.insert(0, str(RESEARCH))
+
+from soak.ledger import (  # noqa: E402
+    CAUSES,
+    EXPLAINED,
+    Ambiguity,
+    Injection,
+    Ledger,
+    classify,
+    render,
+    report,
+)
+
+T0 = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+
+
+def an_ambiguity(key: str = "soak:a", action_id: str = "act_1") -> Ambiguity:
+    return Ambiguity(effect_key=key, action_id=action_id, error="lost", resolved_by=None)
+
+
+def test_an_injected_ambiguity_is_explained(tmp_path) -> None:
+    """The ordinary case: the harness caused it, so it is not a finding."""
+    ledger = Ledger(tmp_path / "ledger.db")
+    ledger.record(
+        Injection(at=T0, effect_key="soak:a", action_id="act_1", cause="executor_timeout")
+    )
+    assert classify([an_ambiguity()], ledger) == []
+
+
+def test_an_ambiguity_with_no_injection_is_a_finding(tmp_path) -> None:
+    """The positive control, as a unit. **This is the whole release gate.**
+
+    A harness that could not produce a finding here would publish "zero unexplained" from a run
+    in which it was incapable of reporting anything else — `v0.4 §1.3`'s false green, applied to
+    the number `ROADMAP.md` gates the release on.
+    """
+    ledger = Ledger(tmp_path / "ledger.db")
+    findings = classify([an_ambiguity()], ledger)
+    assert len(findings) == 1
+    assert findings[0].effect_key == "soak:a"
+    assert findings[0].error == "lost"
+
+
+def test_an_injection_against_another_attempt_explains_nothing(tmp_path) -> None:
+    """Keyed on the **attempt**, not the effect key.
+
+    One key may be attempted more than once — `v0.1 §5.4`'s retry is the ordinary way — and an
+    injection against attempt 1 says nothing about attempt 2. Keying on the effect key alone
+    would let one recorded injection excuse every later ambiguity on that key, which is exactly
+    how a real finding would be absorbed and never reported.
+    """
+    ledger = Ledger(tmp_path / "ledger.db")
+    ledger.record(
+        Injection(at=T0, effect_key="soak:a", action_id="act_1", cause="executor_timeout")
+    )
+    findings = classify([an_ambiguity(action_id="act_2")], ledger)
+    assert len(findings) == 1, "an injection against a different attempt excused this one"
+
+
+def test_the_control_cause_never_explains_anything(tmp_path) -> None:
+    """`uncontrolled` is injected and deliberately unrecorded, so it must not be in `EXPLAINED`.
+
+    If it were, the positive control would silently stop firing and every later run would report
+    a zero nobody had earned.
+    """
+    assert "uncontrolled" in CAUSES
+    assert "uncontrolled" not in EXPLAINED
+
+    ledger = Ledger(tmp_path / "ledger.db")
+    ledger.record(Injection(at=T0, effect_key="soak:a", action_id="act_1", cause="uncontrolled"))
+    assert len(classify([an_ambiguity()], ledger)) == 1
+
+
+def test_an_unknown_cause_is_refused_rather_than_counted(tmp_path) -> None:
+    """A cause the harness does not know is a defect in the harness, not a finding about the
+    kernel. Accepting it would let a typo in an injection turn every ambiguity it caused into an
+    unexplained one — a false finding, which is the other way this number can lie."""
+    ledger = Ledger(tmp_path / "ledger.db")
+    with pytest.raises(ValueError, match="unknown cause"):
+        ledger.record(Injection(at=T0, effect_key="soak:a", action_id="act_1", cause="typo_here"))
+
+
+def test_the_table_says_the_criterion_is_unmet_when_the_control_did_not_fire() -> None:
+    """§8.1: the count is published either way, and publication is not the criterion.
+
+    A run whose control did not fire has no evidence about unexplained ambiguity at all, so it
+    must not report the criterion met even with zero findings — and the rendered table has to say
+    so in words, because the number alone looks like a pass.
+    """
+    document = report(
+        started=T0,
+        ended=T0 + timedelta(hours=2),
+        actions=1000,
+        ambiguities=[],
+        findings=[],
+        control_fired=False,
+        backend="sqlite",
+    )
+    assert document["unexplained"] == 0
+    assert document["exit_criterion_met"] is False, (
+        "a run that could not see an unexplained ambiguity reported the criterion met"
+    )
+    assert "did not fire" in render(document)
+
+
+def test_the_table_reports_the_duration_it_measured_and_asserts_nothing_about_it() -> None:
+    """§8.1's week is calendar time and does not compress, so the harness **measures** it.
+
+    A harness that decided for itself whether the criterion's duration was met would be making
+    the one claim §8.1 says would be exactly as false as it looks. `exit_criterion_met` is about
+    the ambiguity count; the clock is reported and left to a human.
+    """
+    document = report(
+        started=T0,
+        ended=T0 + timedelta(minutes=7),
+        actions=10,
+        ambiguities=[],
+        findings=[],
+        control_fired=True,
+        backend="sqlite",
+    )
+    assert document["elapsed_seconds"] == 420.0
+    assert document["elapsed_human"] == "7m 0s"
+    assert document["exit_criterion_met"] is True
+    text = render(document)
+    assert "7m 0s" in text
+    assert "week" not in text.lower(), (
+        "the table claims a duration it did not measure; §8.1's week is the maintainer's "
+        "criterion and not something a thirty-minute run may assert"
+    )
+
+
+def test_a_finding_carries_what_an_operator_needs_to_investigate() -> None:
+    """A count with no rows behind it is a number nobody can act on. §8.1 says a non-zero count
+    is investigated before v0.6 is tagged, which needs the key, the attempt and the error."""
+    document = report(
+        started=T0,
+        ended=T0 + timedelta(hours=1),
+        actions=5,
+        ambiguities=[an_ambiguity()],
+        findings=classify([an_ambiguity()], _empty_ledger()),
+        control_fired=True,
+        backend="postgres",
+    )
+    assert document["exit_criterion_met"] is False
+    (finding,) = document["findings"]
+    assert finding["effect_key"] == "soak:a"
+    assert finding["action_id"] == "act_1"
+    assert "UNEXPLAINED" in render(document)
+
+
+def _empty_ledger() -> Ledger:
+    import tempfile
+
+    return Ledger(Path(tempfile.mkdtemp()) / "ledger.db")
+
+
+def test_the_harness_ships_nowhere() -> None:
+    """§8.1: `research/soak/` is outside `src/` and never packaged, on
+    `research/framework-probe/`'s precedent."""
+    root = Path(__file__).resolve().parents[1]
+    assert (root / "research" / "soak" / "run.py").exists()
+    assert not (root / "src" / "ctrlrun" / "soak").exists()
+    manifest = (root / "MANIFEST.in").read_text(encoding="utf-8")
+    assert "research/soak" not in manifest

--- a/tests/test_soak.py
+++ b/tests/test_soak.py
@@ -22,6 +22,23 @@ from pathlib import Path
 import pytest
 
 RESEARCH = Path(__file__).resolve().parents[1] / "research" / "soak"
+
+# **The harness is not in the sdist, and this file is.** `MANIFEST.in` ships `tests/*.py` so a
+# distribution packager can run the suite; §8.1 keeps `research/soak/` out on
+# `research/framework-probe/`'s precedent. So from inside an sdist there is nothing to import,
+# and the `package` CI job found it: `ModuleNotFoundError: No module named 'soak'`.
+#
+# The skip is **narrow on purpose**, and the narrowness is the whole argument. It fires only when
+# the directory is genuinely absent, and that absence is itself asserted by
+# `test_T136_the_ctrlrun_distributions_contain_no_adapter`, which builds a distribution and
+# looks inside it. So there is no configuration in which both go unchecked: in a checkout this
+# module runs, and in an sdist the packaging test is what proves the directory should be
+# missing. Same reasoning as T136's own two halves.
+if not RESEARCH.is_dir():  # pragma: no cover - running from a distribution
+    pytest.skip(
+        "research/soak/ is not in this distribution, which SPEC-v0.6 §8.1 requires",
+        allow_module_level=True,
+    )
 if str(RESEARCH) not in sys.path:
     sys.path.insert(0, str(RESEARCH))
 
@@ -182,7 +199,15 @@ def _empty_ledger() -> Ledger:
 
 def test_the_harness_ships_nowhere() -> None:
     """§8.1: `research/soak/` is outside `src/` and never packaged, on
-    `research/framework-probe/`'s precedent."""
+    `research/framework-probe/`'s precedent.
+
+    This runs in a checkout only — the module-level skip above sees to that — and what it checks
+    there is that the harness has not crept into `src/` and that `MANIFEST.in` has not grown a
+    line shipping it. The *distribution* half is asserted from inside the distribution by
+    `test_T136_the_ctrlrun_distributions_contain_no_adapter`, which builds one and looks.
+    `MANIFEST.in` resolves against the working tree rather than the index, so reading it is a
+    check on intent and building is the check on fact; both are wanted.
+    """
     root = Path(__file__).resolve().parents[1]
     assert (root / "research" / "soak" / "run.py").exists()
     assert not (root / "src" / "ctrlrun" / "soak").exists()


### PR DESCRIPTION
Build-list item 8; `SPEC-v0.6.md` §8.1, T178. The harness is in `research/soak/`, outside `src/` and packaged nowhere, on `research/framework-probe/`'s precedent.

## The run

```
CTRLRun soak — postgres (schema soak_968eae6651)
  ran            20m 0s (2026-09-05T19:05:37Z → 2026-09-05T19:25:37Z)
  actions        889735
  ambiguous      133393  (133393 explained, 0 unexplained)
  control fired  yes
```

Four worker threads, one `PostgresStateStore` each, against a real server, into a schema created for the run and dropped after it. Injection mix: 70% clean, 10% executor timeout, 10% unknown exception, 8% `NotExecuted`, 2% a lease short enough to lapse mid-execution.

**What it is evidence of.** Across 889,735 attempts, every `AMBIGUOUS` the store held at the end had a ledger entry recorded *before* the failure that produced it. The positive control fired, so the run was capable of reporting otherwise.

**What it is not evidence of: `ROADMAP.md`'s exit criterion.** That asks for a soak of at least **one week**. This ran for twenty minutes. A larger action count is not a substitute for calendar time — a ten-hour run would meet the criterion no better, it would only put a bigger number next to something still unmet. `exit_criterion_met: true` in the JSON is about the **ambiguity count**, which is all the harness is permitted to decide; the clock is measured, printed, and left to a human. `tests/test_soak.py` asserts the rendered table never contains the word "week".

The throughput figure is a by-product and is published as one. It is a poor measure of the thing an operator would want it for: most of these actions are denied or refused before any receipt is written, so it barely touches the one-row chain head that §6.3 serializes every receipt write on. The README says so rather than leaving it to be inferred.

## How "unexplained" is defined, before the run starts

Or the criterion is unfalsifiable.

- An `AMBIGUOUS` whose **attempt** has a recorded injection is *explained*.
- One with no corresponding injection is *unexplained*, and is what the criterion counts.

Keyed on `(effect_key, action_id)` and never on the effect key alone — one key may be attempted more than once, and an injection against attempt 1 says nothing about attempt 2. **Injections are recorded before they are caused**: a crash in between leaves an injection with no ambiguity, which is harmless; recording afterwards would leave an ambiguity with no injection, which is a false finding manufactured by the harness in the exact number it exists to report.

## The positive control runs first, in its own store

A harness that reports "zero unexplained" without being able to *see* one is reporting that it looked. So a control phase injects an ambiguity it deliberately does not record and requires the classifier to report it — in its own store and its own ledger, because a first version ran the control inside the measured phase and made `exit_criterion_met` unreachable: the run could prove it could see, or report zero, never both.

A table whose control did not fire says so in words and is not evidence.

`tests/test_soak.py` tests the ledger rather than trusting it, because its definition of *unexplained* is the release gate: nine tests covering both ways the count can lie.

2380 passed, 45 skipped; 2420 passed with `CTRLRUN_TEST_POSTGRES` set. `ruff` and `mypy --strict` clean.