### PR TITLE
Item 9: the 0.6 release pass, without the tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,35 @@ All notable changes to this project are documented here. The format follows
 Public API names are frozen in `docs/SPEC-v0.1.md` §8. Before 1.0 they may still change, and
 any change to one appears here.
 
-## [Unreleased]
+## [0.6.0] - unreleased — Durable runtime
+
+**Not tagged.** `docs/ROADMAP.md`'s v0.6 exit criterion is a soak of at least one week with no
+unexplained `AMBIGUOUS`, and a week of calendar time has not passed. The harness, its definition
+of *unexplained*, its positive control and the run it did do are all here and published;
+`research/soak/README.md` carries the duration actually measured. This entry stays dated
+`unreleased` rather than being given a date the criterion has not earned.
+
+v0.5 asked *can somebody else implement this?* v0.6 asks: **does it still hold when the process
+dies, the host goes away, and the database is somewhere else?**
+
+Every guarantee shipped so far was a guarantee about one process holding one SQLite file.
+`BEGIN IMMEDIATE` is a whole-database write lock on a local file; take the file away, put the
+store on another host, and E1 — *at most one caller per effect key* — has to be re-earned with a
+different mechanism. That is the milestone.
+
+**The suite was written before the backend it grades.** `ctrlrun.conformance.store` runs this
+repository's own acceptance tests — the cases of `v0.1 §7`, `v0.2 §10` and `v0.3 §10` that are
+statements about `StateStore` rather than about `Control` — against any backend, and it landed
+two items before Postgres existed. A backend measured against a suite written for it has marked
+its own homework. The ordering paid for itself on the first three runs, which found three real
+bugs in the Postgres store before a single test in its own file existed.
+
+**And the distinction that made it tractable: the store is reconcilable by re-reading; the remote
+is not.** A Postgres transaction is atomic, so an ambiguous *store write* has exactly one truth
+and the store can go and look at it. An ambiguous *remote effect* has no such move, which is why
+`AMBIGUOUS` is terminal there. Two ambiguities, one word, different remedies — and an
+implementation that collapsed them would look correct while either refusing work one query could
+have recovered or retrying work nothing can.
 
 ### Added
 
@@ -23,9 +51,142 @@ any change to one appears here.
 - **`SchemaMismatch`**, exported from `ctrlrun`. Raised at open when a store meets a database it
   does not recognise. Its own type because *"your database is from the future"* and *"your lease
   is negative"* have entirely different remedies.
+- **`PostgresStateStore`** — `ctrlrun[postgres]`, lazily imported (v0.6 item 3). The frozen
+  `v0.1 §5.3` protocol, extended by **nothing**, with `UNIQUE(effect_key)` plus
+  `INSERT … ON CONFLICT DO NOTHING` under `READ COMMITTED` where SQLite had `BEGIN IMMEDIATE`.
+  The guarantee is the unique index and not the isolation level, which the store does not set.
+  Every later transition is a compare-and-set with **the row count checked**. It passes item 1's
+  suite 23/23, with no N/A. `import ctrlrun` imports no `psycopg` module.
+
+  The decisions did not move: `plan_reservation`, `plan_lease_extension`, `check_consumable` and
+  `check_answerable` stay pure functions, and all three backends decide with them and then only
+  write — so `v0.1 §5.4`'s retry table has one implementation rather than three, and a backend
+  cannot drift into permitting something SQLite refuses.
+- **`--store-url` accepts a `postgresql://` URL**, and is now on every command that reads or
+  resolves the operator's own store — `receipts`, `effects`, `inspect`, `resolve`, `approve`,
+  `deny` — reading `CTRLRUN_STORE_URL`. CTRLRun's own `?ctrlrun_schema=` parameter selects the
+  schema and is peeled off before the URL reaches the driver.
+
+  **It creates nothing and migrates nothing.** A review found the first version doing both: a
+  `ctrlrun effects` against an empty schema printed "no effects yet", exited 0 and left eight
+  tables behind, and against a database one migration short, a `ctrlrun receipts` applied it.
+  On the milestone that first shares a store across hosts, that is one reader altering a table
+  every other process is still running against. A schema that is missing, behind or ahead is now
+  refused with an instruction.
+- **`ctrlrun receipts --control ID`** — shows only the receipts citing that control. A **filter
+  and not a lookup**: it does not consult the policy, so an id no document defines matches
+  nothing rather than erroring, which is the right answer for a reader running against a store
+  whose policy has since changed. A dangling *citation* is still a load error, in the place that
+  can see the registry.
+- **`ctrlrun receipts --verify-chain`** — reads the chain in the operator's own store and reports
+  every break by `seq` and by name: `content_altered`, `hash_missing`, `link_broken`, `missing`,
+  `head_mismatch`, `unchained`. Six names rather than one boolean, because *"receipt 41 was
+  edited"* and *"the last nine were deleted"* are different incidents.
+- **Receipts carry `seq`, `prev_hash` and `hash`** (v0.6 item 6). One chain per store — not one
+  per effect key, which would not detect the deletion of every receipt for one key, and not one
+  per process, which is not a chain. `seq` is **inside** the hashed content, so two adjacent
+  receipts swapped with their `seq` values change both documents; `hash` is a column, because a
+  document cannot contain its own hash. `put_receipt` takes the head row's lock **first** and
+  advances it in the same transaction.
+- **`policy_hash`, `policy_version` and `controls` on every receipt** (v0.6 item 7). A receipt
+  from six months ago says what the rules were, not what they are now. `policy_hash` is over the
+  **parsed decision inputs** — schema, actions and rules in document order, `mode`, `environment`,
+  the authority grants — and not the file's bytes, so a comment or a reordering of keys does not
+  change it. `version:` is a free string the operator chooses, recorded and **never
+  authoritative**: two documents sharing a `version:` and differing in content are two different
+  policies, and the hash is what says so.
+- **`ctrlrun.policy.PolicyControl`** — a registry entry: an id, a title, and an optional
+  `source`. Named `PolicyControl` and not `Control`, because a second `Control` in a package
+  whose central object is `Control` is a collision every call site would have to disambiguate,
+  and one this milestone would have frozen for a long time.
+- **`ctrlrun.policy/v4`**, with three new top-level keys and a closed key set, so a typo is still
+  a load error:
+  - **`controls:`** — a registry of ids, each with a `title` and an optional `source`. An action
+    cites some, a rule may narrow or add, and the receipt carries the union of the action's and
+    the **matched rule's** in registry order. **CTRLRun does not interpret a control**: `source:`
+    is a string the operator wrote and the registry records and never enforces. It maps to no
+    standard, and citing one is not a claim about it.
+  - **`data:`** — an action declares which of its arguments carry which class of data.
+    `data_scope` is the set of labels present in **the arguments actually supplied**, not the
+    whole declared map: an action that carries no PHI is not a PHI action because some other call
+    of it would be. `data_scope_in: [phi]` reuses the membership `_in` already expresses and adds
+    no operator, deliberately — `_OPERATORS` is shared with authority `constraints:`, so an
+    operator added here would become available to grants.
+  - **`version:`** — see above.
+- **`resolved_by` on every effect record** (v0.6 item 5). Out of `AMBIGUOUS` there are exactly
+  two authorities — a human and a reconcile hook — and the record now says which one acted.
+  `ctrlrun effects` prints it, and prints `executing (lease expired)` for a lease that lapsed and
+  was never contended, because nothing sweeps and the state alone hid it.
+- **`research/soak/`** (v0.6 item 8) — a soak harness, outside `src/` and packaged nowhere, on
+  `research/framework-probe/`'s precedent. It defines *unexplained* **before** the run starts —
+  an `AMBIGUOUS` caused by an injected failure is explained, one with no corresponding injection
+  is not — records every injection **before** causing it, and carries a positive control that
+  runs in its own store: a deliberately unrecorded ambiguity that the table must report. A soak
+  with no unexplained `AMBIGUOUS` is a result; a soak whose harness could not have detected one
+  is not.
+- **`docs/postgres.md`** — the operator's page: connection strings, what to grant, what happens
+  on failover, the one row every receipt write serializes on, and what the store does **not** do
+  for you.
+
+### Changed
+
+- **Observe mode no longer spends a presented approval, and that is a change to shipped v0.3
+  behaviour.** `_observe_secure` routed a presented approval through the same consuming path
+  enforce mode uses, so an operator evaluating a policy in observe mode was silently burning
+  their humans' single-use answers on actions observe mode was never going to gate. It now
+  **checks** the grant — with the same pure predicate every store applies, so the refusals it
+  records are the ones enforce mode would have raised — and writes nothing.
+
+  The **reservation is still taken**, and the asymmetry is deliberate: in observe mode the action
+  genuinely executes, so the effect record has to exist or the duplicate refusal has nothing to
+  refuse with. Observe mode suppresses CTRLRun's *decisions*; it does not suppress the record of
+  an effect that really happened. The `APPROVAL_CONSUMED` event on that path is **gone rather
+  than renamed** — v0.6 adds no event type, and an event naming a write that did not happen is
+  worse than no event.
+- **A denial now names the approval that was presented**, on the `ACTION_DENIED` event and on the
+  receipt. Where a policy denies an action a human had already approved, the approval stays
+  `granted` and unspent — that is deliberate, and `SPEC-v0.6.md` §7.2.1 argues it — but nothing
+  previously connected the live grant to the refusal it met.
+- **`data_scope` is now refused as an argument name**, at every place an argument is named: a
+  `data:` key, an `effect:` or `resource:` template placeholder, and a `@protect`-ed function's
+  parameter. §7.4 said it always was; no such check existed. A document or a decorated function
+  using that name stops loading, with the reason.
+- **`data_scope_eq:` and `data_scope_neq:` compare the set and not its order.** The derived value
+  is sorted, and list equality is order-sensitive, so `data_scope_eq: [phi, internal]` silently
+  never matched while `[internal, phi]` did — an operator writing the labels in their own
+  declaration order got a rule that never fired, and where that rule was the `deny` or the
+  `approve`, that is fail-open. Narrowed to derived subjects: an ordinary list argument still
+  means *that exact list*.
+- **`policy_hash` covers what §7.1 said it covered.** Four things were missing and each is now
+  in: an authority document loaded separately from the policy (the gateway's shape, and
+  `verify --authority`'s — two deployments with different grants produced byte-identical
+  provenance on every receipt); an action's `data:` labels; per-action and per-rule `controls:`
+  citations; and the `controls:` registry itself, whose titles are what a receipt's control ids
+  *mean*. The **effective** environment is hashed rather than the document's, since
+  `$CTRLRUN_ENVIRONMENT` and `Control(environment=...)` outrank it.
+- **A control's citations are recorded in registry order**, not in the order the action and the
+  matched rule cite them, so two receipts citing the same set list it the same way whichever
+  rule matched.
+- **A relaxed policy now closes the approval it made unnecessary, and this is a change to shipped
+  behaviour.** A policy relaxed between a human granting an approval and an agent presenting it
+  left that approval `granted` for its full TTL, bound to a hash a later edit could make
+  `APPROVE`-requiring again — a live bearer token for an action a human already answered, and
+  `v0.1 §4.1` calls a request id a bearer token in as many words. The approval is now spent, in a
+  write of its own **after** the reservation, so that an allowed action's success never depends on
+  the approval store.
+- **Every entry point re-checks the policy in force at execution**, and the receipt says which
+  policy that was. Where the policy changed between a grant and its consumption, `SPEC-v0.6.md`
+  §7.2's table decides by observation: a policy that now denies leaves the approval granted (the
+  action is refused on the policy axis, and spending the approval would destroy the evidence a
+  human answered); a policy that now allows invalidates rather than consumes it.
 
 ### Fixed
 
+- **A store failure closing an unneeded approval no longer refuses the action.** Where a policy
+  had been relaxed to `allow`, a locked database or a dropped connection while closing the
+  now-unnecessary approval propagated to the caller — **after** the effect was reserved and
+  **before** execution began. No receipt was written at all, and the effect key was left
+  `RESERVED` until its lease lapsed: an ambiguity manufactured by the *permissive* decision path.
 - **Concurrent store opens no longer fail.** Switching a database to WAL takes a brief exclusive
   lock that SQLite's busy handler does not cover, and `busy_timeout` was being set *after* the
   switch — so simultaneous opens raced and lost. It was survivable while opening a store was a
@@ -52,8 +213,6 @@ any change to one appears here.
   database with no `continuations` and no `delegations` table. `docs/SPEC-v0.6.md` §9.6.1 records
   all twenty-one with where each landed.
 
-### Changed
-
 - **`docs/ROADMAP.md`'s v0.6 bullet said "receipt integrity (hash chain / signatures)", and the
   slash was the problem.** A chain detects **alteration**; a signature proves **origin**, and
   proving origin brings key generation, rotation and revocation with it — which is issuing, and
@@ -61,9 +220,11 @@ any change to one appears here.
   Corrected in the same commit as the specification, on the rule `SPEC-v0.4.md` §9.4 set.
 - **`docs/THREAT_MODEL.md`'s "Receipts are not signed; a database admin can alter history
   (v0.6)"** promised something v0.6 does not deliver. Rewritten to say which half v0.6 closes —
-  the partial tamper: an `UPDATE` on one row, a `DELETE` from the middle, a reordering, a
-  truncation — and which half it does not: authorship, an adversary who can rewrite every row
-  including the chain head, and the question of whether every action wrote a receipt at all.
+  the partial tamper: an `UPDATE` on one row, a `DELETE` from the middle, a reordering — and
+  which half it does not: **truncation at the end**, authorship, an adversary who can rewrite
+  every row including the chain head, and the question of whether every action wrote a receipt
+  at all. Two drafts of that line claimed truncation, and a review measured it: deleting a
+  suffix and rewinding the head is two statements, undetected.
 
 ## [0.5.0] - 2026-09-05 — Adapter contract
 
@@ -993,7 +1154,7 @@ until it gets one, which is the point.
 - Requires Python ≥ 3.11. Runtime dependencies are `pyyaml` and `click`.
 - Single-host only: reservation is atomic across processes on one machine via SQLite.
   Multi-host needs the Postgres store planned for v0.6.
-- Receipts are not signed. A database administrator can alter history (v0.6).
+- Receipts are not signed. A database administrator can alter history. **This line read "(v0.6)" until v0.6 was built, and that was a promise v0.6 does not keep**: v0.6 adds a hash chain, which detects alteration and is not evidence of authorship, and it does not stop an administrator who can rewrite every row including the chain head. Signing is out of scope (`SPEC-v0.6.md` §11).
 - Approver identity is free text and is not authenticated (v0.3).
 - Generated ids (`act_`, `apr_`, `ctr_`) are 128 bits. An approval id is not a bearer token
   in v0.1 — consuming one needs write access to the store — but it becomes one with the
@@ -1004,7 +1165,8 @@ until it gets one, which is the point.
 - Policy conditions address an action's arguments only. Scoping a rule by environment,
   resource or principal arrives with the authority model in v0.3.
 
-[Unreleased]: https://github.com/CTRLRun/ctrlrun/compare/v0.4.0...HEAD
+[0.6.0]: https://github.com/CTRLRun/ctrlrun/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/CTRLRun/ctrlrun/releases/tag/v0.5.0
 [0.4.0]: https://github.com/CTRLRun/ctrlrun/releases/tag/v0.4.0
 [0.2.0]: https://github.com/CTRLRun/ctrlrun/releases/tag/v0.2.0
 [0.1.0]: https://github.com/CTRLRun/ctrlrun/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -256,6 +256,55 @@ and not a kernel event. Each states its supported kernel range and framework ran
 [`docs/adapters.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/adapters.md) has the
 three ways in, and how to write one for a framework not listed here.
 
+## More than one host
+
+Everything above holds for one process holding one SQLite file. `BEGIN IMMEDIATE` is a write
+lock on a local file — take the file away, put the store on a database, and the promise has to be
+earned again with a different mechanism.
+
+```console
+$ pip install "ctrlrun[postgres]"
+```
+
+```python
+from ctrlrun.postgres import PostgresStateStore
+
+store = PostgresStateStore("postgresql://ctrlrun@db.internal/ctrlrun", schema="ctrlrun")
+```
+
+Same `StateStore` protocol, extended by nothing. The exclusion that stops two agents issuing the
+same refund is a unique index on the effect key and compare-and-set updates whose row counts are
+checked; every case of the acceptance suite that is a statement about the store runs against both
+backends, from the same file, and the suite was written before this backend existed.
+
+**A lost connection during `COMMIT` is the case worth naming.** Postgres very often did commit,
+so nobody knows — that is `AMBIGUOUS`, never `FAILED`, and the store re-reads the row to find out
+which. An agent that read it as `FAILED` and retried is the exact failure this library exists to
+prevent, arriving through the storage layer.
+
+**The schema is versioned and migrations are automatic at open**, forward-only, with no flag that
+opens a database un-migrated. A store refuses a database it does not recognise in **both**
+directions: a newer binary migrates, and an older binary against a newer schema refuses
+immediately rather than reading columns it does not understand.
+
+**Each receipt carries the hash of the one before it.** An edit to receipt 41, a deletion from the
+middle, a reordering — each is detected and named, and `ctrlrun receipts --verify-chain` reports
+it by `seq`. **This detects alteration, and alteration is not authorship: receipts are not signed
+and the chain is no evidence of who wrote one.** Nor is it tamper-proof — it does not survive an
+administrator who can rewrite every row including the chain head, and erasing the end of the log
+costs two statements, because the head lives in the same database as the receipts.
+[`docs/THREAT_MODEL.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/THREAT_MODEL.md) states
+what remains open.
+
+**Every receipt records which policy decided it** — the policy's declared `version:` and a hash of
+its canonical content — so a receipt from six months ago says what the rules were, rather than
+what they are now. Where a policy changes between a human approving and an agent executing, the
+approval is re-checked against the policy in force at execution.
+
+[`docs/postgres.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/postgres.md) is the
+operator's page: connection strings, what to grant, what happens on failover, and what the store
+does not do for you.
+
 ## Two more things
 
 **Resolving an unknown outcome without a human.** `@protect(..., reconcile=...)` takes a
@@ -337,6 +386,10 @@ CTRLRun cannot guarantee exactly-once execution against external systems it does
 | [`docs/SPEC-v0.2.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/SPEC-v0.2.md) | The v0.2 delta: gateway, sinks, reconciliation, webhooks |
 | [`docs/SPEC-v0.3.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/SPEC-v0.3.md) | The v0.3 delta: identity, authority, delegation, observe mode |
 | [`docs/SPEC-v0.4.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/SPEC-v0.4.md) | The v0.4 delta: the guarantee catalogue, the scenario engine, the badge |
+| [`docs/SPEC-v0.5.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/SPEC-v0.5.md) | The v0.5 delta: the adapter contract and the conformance kit |
+| [`docs/SPEC-v0.6.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/SPEC-v0.6.md) | The v0.6 delta: Postgres, migrations, recovery, the receipt chain, policy versioning |
+| [`docs/postgres.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/postgres.md) | Running the store on Postgres: grants, failover, and what it does not do for you |
+| [`docs/adapters.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/adapters.md) | The three ways in, when you do **not** need an adapter, and how to write one |
 | [`docs/verify.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/verify.md) | `ctrlrun verify`, the guarantees, the N/A rule, and what the badge means |
 | [`docs/OWASP-AGENTIC-TOP10.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/OWASP-AGENTIC-TOP10.md) | A reading of the OWASP Top 10 for Agentic Applications against the guarantees |
 | [`docs/authority.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/authority.md) | Grants, delegation and the omission rule, in plain language |

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -8,7 +8,7 @@ removed from the README in the same commit — the README is not allowed to desc
 that no longer ships. If you find a row here that does not hold against the version you
 installed, that is a bug: please open an issue.
 
-Regenerated for: **v0.5.0**, with rows re-pointed on `main` since. Line numbers refer to the current `main`, not to the tag, and item 9 of v0.6 regenerates the file wholesale. `test_the_claims_table_line_numbers_point_at_what_they_name` resolves every one of them against the line it cites, which is why they are re-pointed rather than left to rot.
+Regenerated for: **v0.6.0**. Line numbers refer to the commit this file was regenerated on, and `scripts/repoint-claims.py` re-derives them for the commits in between — it **refuses** rather than guessing when a symbol has no definition, because a row pointing at a docstring that happens to contain the right word makes the guard green and the claim false. `test_the_claims_table_line_numbers_point_at_what_they_name` resolves every one against the line it cites.
 
 ## The opening paragraph
 
@@ -181,3 +181,24 @@ The adapter section. Every sentence, mapped the same way.
 | "An adapter never constructs one, and never supplies a principal" | `needs_approval` — `adapter.py:408` — resolves the principal from the `Control` so no adapter builds an `Action` | `test_T129_no_public_callable_takes_a_principal`, `test_T129_the_module_exposes_no_way_to_construct_a_control` |
 | "prevention" / "attribution" | `carries_approved_arguments` gates §3.4's rebuild in `_check_answer` — `adapter.py:320` | `test_T137b_the_readme_says_the_binding_is_attribution_and_why` |
 | "Adapters ship on their own version line" | `adapters/*/pyproject.toml`, never in the `ctrlrun` wheel or sdist | `test_T136_the_ctrlrun_distributions_contain_no_adapter` |
+
+## What v0.6 adds to the README
+
+The durable-runtime section. Every sentence, mapped the same way.
+
+| Claim | Code | Proof |
+|---|---|---|
+| "Same `StateStore` protocol, extended by nothing" | `PostgresStateStore.reserve_effect` — `postgres.py:528` — and every other method implement `v0.1 §5.3`'s frozen protocol; the decisions stay in `plan_reservation` (`effect.py:156`) | `test_T154_postgres_passes_the_store_conformance_suite` |
+| "a unique index on the effect key and compare-and-set updates whose row counts are checked" | `reserve_effect` — `postgres.py:528` — `INSERT … ON CONFLICT DO NOTHING` against `effect_key TEXT PRIMARY KEY COLLATE "C"` (`migrations.py:107`) | `test_T3_exactly_one_agent_reserves_and_seven_are_blocked` (8 OS processes, both backends) |
+| "every case … runs against both backends, from the same file" | `ctrlrun.conformance.store.run` — `conformance/store/__init__.py:52` | `test_T140_every_fixture_fails_the_suite_named_for_it` |
+| "A lost connection during `COMMIT` … is `AMBIGUOUS`, never `FAILED`" | `_resolve_lost_insert` — `postgres.py:648`; `_resolve_lost_update` — `postgres.py:995`; only `NotExecuted` maps to `FAILED` — `control.py:1036` | `test_T155_a_connection_killed_during_commit_is_resolved_by_the_re_read`, `test_T155_no_effect_is_ever_recorded_failed_by_a_lost_commit` |
+| "the store re-reads the row to find out which" | The six branches, named and logged — `A2_LANDED` — `postgres.py:127` | `test_T155b_a_landed_commit_on_a_transition_is_seen_as_landed`, `test_T155d_a_commit_the_server_never_received_retries_the_insert` |
+| "migrations are automatic at open, forward-only" | `migrate` — `migrations.py:525`, called from both stores' constructors; `HEAD` — `migrations.py:306` | `test_T147_a_v05_database_migrates_and_keeps_every_row`, `test_T150_reopening_does_not_rerun` |
+| "an older binary against a newer schema refuses immediately" | `_refuse` — `migrations.py:451`; `SchemaMismatch` — `errors.py` | `test_T148_an_older_binary_refuses_a_newer_database`, `test_T148_no_other_table_is_read_before_the_refusal` |
+| "Each receipt carries the hash of the one before it" | `Receipt.chain_hash` — `receipt.py:284`; `prev_hash` — `receipt.py:41`; `GENESIS_HASH` — `receipt.py:41`; `put_receipt` takes the head row's lock first — `postgres.py:1464` | `test_T164_an_altered_receipt_is_content_altered_at_its_seq`, `test_T164_reordering_two_receipts_is_detected_either_way` |
+| "`ctrlrun receipts --verify-chain` reports it by `seq`" | `verify_chain` — `receipt.py:479`; the six names — `CHAIN_BREAKS` — `receipt.py:479` | `test_the_verify_chain_flag_reports_a_break_by_seq_and_by_name`, `test_verify_chain_reads_a_postgres_store_through_store_url` |
+| "erasing the end of the log costs two statements" | No code — this is what the chain does **not** cover, and it is asserted rather than argued | `test_erasing_a_suffix_and_rewinding_the_head_is_two_statements_and_undetected` |
+| "This detects alteration … not authorship" | n/a — a disclaimer, and the scan that keeps it one | `test_T180_the_release_documents_do_not_blur_alteration_and_authorship` |
+| "Every receipt records which policy decided it" | `Policy.policy_hash` — `policy.py:559`, over `_canonical_policy` — `policy.py:698`; carried into the receipt by `policy_in_force` — `control.py:1595` | `test_T172_every_receipt_carries_the_hash_and_the_declared_version`, `test_T172_two_policies_sharing_a_version_string_are_told_apart_by_the_hash` |
+| "the policy's declared `version:` … rather than what they are now" | `version:` is recorded and never authoritative; `policy_hash` is what tells two documents apart — `policy.py:559` | `test_T171_the_declared_version_alone_does_not_change_the_hash`, `test_T171_comments_key_order_and_whitespace_do_not_change_the_hash` |
+| "the approval is re-checked against the policy in force at execution" | `policy_in_force` — `control.py:1595` | `test_T173_the_DENY_row_refuses_and_leaves_the_approval_granted`, `test_T173_the_ALLOW_row_invalidates_the_approval_it_did_not_need` |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -114,7 +114,7 @@ Versioned as `adapters-<framework>-MAJOR.MINOR` — `adapters-crewai-1.0`, `adap
 
 Standards: none of its own.
 
-## v0.6 — Durable runtime (Current)
+## v0.6 — Durable runtime (Code complete 2026-09-06; **not tagged** — see Exit)
 
 - Postgres StateStore (cross-host reservation).
 - Schema migrations, recovery on restart, policy versioning, receipt integrity — a hash chain, which detects **alteration** and not authorship.
@@ -123,6 +123,12 @@ Standards: none of its own.
 - Control registry and data-scope primitives: the kernel-side objects a sector pack configures, shipped here so that a pack is configuration rather than code.
 
 Exit: the v0.1 concurrency and mutation standard met against a real Postgres on two hosts under failure injection; a soak of at least one week with no unexplained AMBIGUOUS; a receipt chain tamper test.
+
+**Two of the three were met, and the third is reconciled here rather than quietly rephrased.**
+
+- *The concurrency and mutation standard against a real Postgres* — met, with one narrowing stated in item 4's PR and repeated here: it was run as **separate OS processes against one Postgres, with the connection broken by a proxy the tests own**, not as two hosts, because this build environment has no container runtime. Separate processes give separate connections, no shared memory and no shared file locks, which is what `BEGIN IMMEDIATE` was silently relying on and what a second host removes, so the reservation guarantee is exercised. A **network partition between hosts** is not, and stays unclaimed.
+- *The receipt chain tamper test* — met. Six cases, each asserting **which** break was reported and **where**; `SPEC-v0.6.md` §6.5 names all six, and §6.4 says what the chain does not cover before saying what it does.
+- *A soak of at least one week with no unexplained AMBIGUOUS* — **not met as written.** The harness landed, its definition of *unexplained* is fixed before any run starts, and its positive control fires; what has not happened is a week of calendar time. `research/soak/README.md` publishes the duration actually measured and the count actually found, and the harness asserts nothing about the clock — a table that reported "criterion met" after thirty minutes would be making the one claim this project said would be exactly as false as it looks. The criterion is left standing, unmet, rather than rewritten to fit the run: **v0.6 ships its code and its evidence, and the week is still owed.**
 
 Standards: `docs/CONTROL-MAPPING.md` — clause-level mapping of receipt integrity/retention to EU AI Act Art. 12 and SOC 2 CC6/CC7, and of exact-action approval to Art. 14. Each row points at a test. Written only when a design partner asks.
 

--- a/docs/SPEC-v0.6.md
+++ b/docs/SPEC-v0.6.md
@@ -2142,6 +2142,30 @@ sentences this rule exists to produce. It would then be removed as a false posit
 would be gone. An allow-list fails on a **new** occurrence — which is exactly the event worth
 failing on — and forces whoever adds one to say, in the test, that they meant it.
 
+**Amended in item 9, because writing it found the sentence above to be two-thirds true.** Ten of
+the twenty-one allow-listed lines disclaim one of the words, as this paragraph assumed. The other
+eleven are about something else entirely and the word-boundary pattern cannot tell them apart: a
+changelog entry about JWT **signature** verification, the HMAC on a webhook POST, `Signing keys
+fetched from somewhere else` in the threat model's identity table, and the Python word for a
+function's parameters — *"`Control.evaluate`'s **signature** is amended"*. Describing the list as
+sentences that disclaim would have made the next person delete those eleven as mistakes, which is
+the false positive this design exists to prevent, arriving through the specification instead of
+through the pattern.
+
+So the list is **two named groups** — the ones that disclaim, and the ones about another subject —
+merged into one allow-list. The mechanism and its guarantee are unchanged: a **new** occurrence
+fails, and whoever adds it comes to the test and says which kind it is. Two further checks make
+the list itself load-bearing rather than decorative: every entry must still resolve to a line in
+its file and must still contain a forbidden word (an entry that stopped matching is an entry doing
+nothing), and a positive control asserts the pattern would fire on *"receipts are signed, which
+proves authorship"*, *"the chain is tamper-proof"* and *"CTRLRun gives you non-repudiation"* while
+not firing on `design`, `assign` or `designated`.
+
+**What the check does not cover**, stated rather than assumed: a claim made in words the pattern
+does not contain. *"CTRLRun proves who wrote each receipt"* passes it. The scan is a guard against
+the vocabulary drifting back in, not a reader of prose, and §6.4 remains the thing that has to be
+true.
+
 The third rule of §1.2, made a test rather than an intention.
 
 #### T181 — Core still installs nothing new

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -1,0 +1,309 @@
+# Postgres
+
+`PostgresStateStore` puts the state store on a database instead of a local file. It implements
+the same `StateStore` protocol as `SQLiteStateStore`, frozen in `SPEC-v0.1.md` §5.3, and extends
+it by nothing. The guarantees are the ones `SPEC-v0.1.md` §7 already states; what changes is the
+mechanism that earns them, because `BEGIN IMMEDIATE` is a write lock on a local file and there is
+no file any more.
+
+This page is for whoever runs the database. It says what to grant, what happens when the
+connection or the server goes away, and — the part that is easy to skip and expensive to assume —
+what the store does **not** do for you.
+
+## Install
+
+```bash
+pip install 'ctrlrun[postgres]'
+```
+
+`psycopg` version 3. `import ctrlrun` imports no `psycopg` module, and neither does anything in
+the core; the driver is loaded when a `PostgresStateStore` is first constructed, and its absence
+raises `MissingDependency` naming this install line.
+
+## Connect
+
+```python
+from ctrlrun.postgres import PostgresStateStore
+
+store = PostgresStateStore("postgresql://ctrlrun@db.internal:5432/ctrlrun")
+```
+
+The URL is passed to `psycopg.connect` unchanged, so everything libpq accepts works: a
+`postgres://` scheme, `?sslmode=require`, `?connect_timeout=5`, a `service=` name, or the
+standard `PG*` environment variables with an otherwise-bare URL. CTRLRun parses none of it.
+
+A second schema is a keyword:
+
+```python
+store = PostgresStateStore(url, schema="ctrlrun")
+```
+
+**Every statement names its schema**, so nothing in the store depends on `search_path` being set
+for it, and two stores against two schemas in one database do not see each other. The schema must
+be a plain identifier — letters, digits and underscores — which is what makes it safe to
+interpolate; it is the only name in the module that reaches SQL, and it never comes from an
+action, an argument or a request header.
+
+On the command line the schema travels in the URL, as CTRLRun's own query parameter, peeled off
+before anything reaches the driver:
+
+```bash
+ctrlrun effects --store-url 'postgresql://db.internal/ctrlrun?ctrlrun_schema=ctrlrun'
+```
+
+`ctrlrun_schema` defaults to `public`. It is the same spelling the store conformance suite uses,
+so an operator who has seen one does not have to learn the other.
+
+**The store does not create the schema.** `PostgresStateStore.create_schema(url, name)` exists and
+is used by the conformance backend and by `ctrlrun verify`'s scratch store, but constructing a
+store against a schema that is not there is refused, naming the schema. Creating databases for
+operators is not this library's job and doing it silently is how a typo becomes a second, empty,
+authoritative-looking store.
+
+### Passwords
+
+Put the password in `~/.pgpass`, in `PGPASSWORD`, or in a secret your process manager injects —
+not in a URL you commit or pass on a command line. A URL in a config file is a URL in a backup,
+and `--store-url` also reads `CTRLRUN_STORE_URL`, which is the better place for it.
+
+## What to grant
+
+The database user needs, on the schema the store lives in:
+
+```sql
+CREATE SCHEMA ctrlrun;
+GRANT USAGE, CREATE ON SCHEMA ctrlrun TO ctrlrun_app;
+```
+
+`CREATE` is not optional and it is not only a first-run convenience. Migrations run **at open**,
+automatically, and there is no flag that opens a database without migrating it (`SPEC-v0.6.md`
+§3.6): a store that could run un-migrated would be a second configuration nobody tested. A user
+without `CREATE` is refused at construction with the exact `GRANT` it is missing, rather than at
+the first write with the SQL that failed.
+
+If your policy is that application users hold no DDL rights, the supported shape is to run one
+start with a migrating role during the deployment and let the application role connect afterwards
+— but understand what you have bought: the next upgrade fails closed at open, on every host, until
+somebody runs the migrating role again. That is louder than a partial migration, which is the
+direction this project chooses; it is still an outage if nobody expected it.
+
+Nothing else is needed. The store creates no extension, no function, no trigger, no role, and
+touches no other schema.
+
+### The database's encoding
+
+**The store refuses a database whose `server_encoding` is not `UTF8`**, at open, naming it.
+
+This looks fussy and is not. CTRLRun hashes the exact code points it is given and applies no
+Unicode normalization (`SPEC-v0.1.md` §2.3). An effect key that survives a round trip through
+`SQL_ASCII` as different bytes is a **different identity**, so two attempts at one logical effect
+would reserve two different keys and both would execute. That is a double execution reached
+through the storage layer's character set — the exact failure the library exists to prevent,
+arriving somewhere nobody looks. It is refused at open rather than discovered in an incident.
+
+For the same reason `effect_key`, `approval_id`, `action_id`, `delegation_id` and `continuation`
+are declared `COLLATE "C"`: byte comparison, no locale. A non-deterministic collation would merge
+two distinct keys into one, which is the safe direction — but the store should not depend on which
+direction a deployment's `lc_collate` happens to fail in.
+
+## Connections and pooling
+
+- **One connection per thread.** `psycopg` connections are not thread-safe and the store does not
+  share one. `close()` releases every connection the store opened; it is a release of resources,
+  not a fence, and a caller that uses the store afterwards gets a fresh connection.
+- **No pool ships.** Sizing a pool is a deployment decision and a library that guessed would be
+  wrong on most of them.
+- **pgbouncer in `transaction` mode works**, and it works because the store deliberately holds
+  nothing session-scoped: no advisory lock, no temporary table, no prepared statement it needs to
+  survive, no `SET` it depends on. Reads run outside a transaction; writes re-assert their schema
+  with `SET LOCAL`, which reverts at the end of the transaction and cannot leak into a pooled
+  connection's next tenant. `session` mode also works and buys nothing here.
+- **A host running agents on an unbounded number of threads will open an unbounded number of
+  connections.** Bound your worker pool, or put pgbouncer in front. The store does not bound it
+  for you, and `max_connections` is where you will find out.
+
+## What happens when things go away
+
+This is the section worth reading twice, because it is where a plausible-looking implementation
+would be wrong and the wrongness would only show up in an incident.
+
+### The rule
+
+**`FAILED` means it definitely did not happen.** Anything else unknown is `AMBIGUOUS`. A
+connection that dies during `COMMIT` tells you nothing about whether Postgres committed, and
+Postgres very often did — so that is `AMBIGUOUS`, never `FAILED`, and an agent that read it as
+`FAILED` and retried is the failure mode this library exists to prevent.
+
+### A store write whose outcome is unknown is re-read
+
+There are two kinds of ambiguity and they have different remedies, which is why `SPEC-v0.6.md` §4
+carries two tables rather than one.
+
+A Postgres transaction is atomic, so an ambiguous **store write** has exactly one truth and the
+store can go and look at it. On a lost `COMMIT` the store re-reads the row:
+
+- it carries our `action_id` **and matches the row we attempted to write** → the commit landed,
+  and we hold the reservation;
+- the row is absent → the commit did not land, and the insert is re-issued;
+- the row is another caller's → we are blocked, which is the correct answer and not an error.
+
+**Only if the re-read itself fails** does the store refuse to let execution proceed, writing no
+effect state at all. Fail closed: the remote is not called, so there is nothing to be ambiguous
+about.
+
+An ambiguous **remote effect** has no such move. Nothing you can read settles whether the refund
+landed, which is why `AMBIGUOUS` is a terminal state there and why a blind retry against that key
+is refused until a human or a reconciliation hook answers.
+
+Which branch ran is logged on the `ctrlrun.postgres` logger at `INFO`, by name — `A1_OURS`,
+`A1_REINSERT`, `A1_REFUSE`, `A2_LANDED`, `A2_REISSUE`, `A2_REFUSE`. Turn that logger on before
+you need it.
+
+### Failover
+
+On a managed failover, a promotion, or a `pg_ctl restart`, in-flight connections break. What
+follows depends on where each one was:
+
+- **Before `COMMIT` was issued** — nothing committed. The store write is `FAILED` and may be
+  retried, which is the one place `FAILED` is correct: the server stated, in band, that it never
+  got there.
+- **During or after `COMMIT`** — the re-read above, against a new connection. If the new primary
+  is up, it answers and the ambiguity is resolved. If it is not up yet, the re-read fails and the
+  store refuses to proceed and writes nothing.
+- **A broken connection is replaced only between transactions**, and for the re-read. The store
+  never silently reconnects mid-transaction; a reconnect is a new transaction, and pretending
+  otherwise is how a partial write becomes invisible.
+
+**Point the store at whatever your deployment uses to name the current primary** — a virtual IP,
+a proxy, a `target_session_attrs=read-write` multi-host URL. The store does not discover a new
+primary, does not retry a connection in a loop, and does not fail over between URLs. It reports
+what it saw and fails closed.
+
+**Do not point it at a read replica.** Every guarantee here rests on a unique index on
+`effect_key` and on compare-and-set updates whose row counts are checked, and a replica can do
+neither. Reads would appear to work, which is the problem.
+
+### Losing the primary, honestly
+
+An asynchronous replica that is promoted after losing transactions loses effect records with
+them, and CTRLRun cannot tell that this happened — a key that was reserved and executed comes
+back absent, and the next attempt reserves it again and executes again. If you need the store's
+guarantee to survive a failover, you need the *database's* durability to survive it: synchronous
+commit to at least one standby. This is a property of your Postgres configuration and not
+something a client library can add.
+
+## Concurrent starts, and restarts
+
+**Concurrent starts are safe and are not clever.** The migration transaction takes the backend's
+own write lock, so a second process either finds the work done or waits for it. There is no
+advisory lock, no leader election and no retry loop.
+
+**A restart does nothing on its own.** Opening a store migrates it and reads nothing else. A
+process that came back does not scan, does not repair and does not report; it waits to be asked
+about an effect key, exactly as it did before it died.
+
+**Nothing sweeps.** There is no background thread, no timer and no reaper. An expired lease
+becomes `AMBIGUOUS` lazily, when the next contender plans a reservation against that key. An
+expired lease nobody contends stays `EXECUTING` in the table, and `ctrlrun effects` shows it as
+`executing (lease expired)` so that the display does not hide it. `get_effect` and `list_effects`
+are reads and transition nothing.
+
+## Throughput, and the one row everything queues on
+
+Every receipt write serializes on a single row.
+
+`SPEC-v0.6.md` §6.3's chain advances a one-row head table, and `put_receipt` takes that row's lock
+**first** and holds it across the receipt insert. That is deliberate — a compare-and-set with a
+bounded retry silently dropped receipts under three concurrent writers, and a dropped receipt is
+evidence loss — but it is a real ceiling and this is the first place in the kernel where two
+unrelated actions contend with each other at all.
+
+What that means in practice:
+
+- Receipt writes are serialized per database. Effect reservations are not; they contend only per
+  effect key, which is the whole point of the key.
+- The lock is held for one `INSERT`, so the ceiling is set by your round-trip time to the
+  database. Putting the store on another continent is the way to find it.
+- Two schemas in one database have two head rows and do not contend. Sharding by schema works and
+  gives you two chains to verify rather than one.
+
+The soak in `research/soak/` measures this; its published table carries the actions-per-second it
+saw and against what.
+
+## Verifying the chain
+
+```bash
+ctrlrun receipts --store-url 'postgresql://db.internal/ctrlrun?ctrlrun_schema=ctrlrun' --verify-chain
+```
+
+Every break is reported by `seq` and by name — `content_altered`, `hash_missing`, `link_broken`,
+`missing`, `head_mismatch`, `unchained` — rather than as one boolean, because *"receipt
+41 was edited"* and *"the last nine were deleted"* are different incidents.
+
+`ctrlrun receipts --control <id>` filters the same listing down to the receipts citing one
+control, which is how you get from a written expectation to the actions taken under it. It is a
+filter and not a lookup: an id no receipt cites returns nothing rather than an error.
+
+`--store-url` is on every command that reads or resolves the operator's own store — `receipts`,
+`effects`, `inspect`, `resolve`, `approve`, `deny` — and it reads `CTRLRUN_STORE_URL`. **It opens
+the database you name and creates nothing**: a schema that is empty, or behind, or ahead is
+refused with an instruction rather than migrated. A command an operator runs to read evidence must
+not have a side effect on the database it reads.
+
+`ctrlrun verify --store-url postgresql://…` is different and is worth understanding before you run
+it against production: it creates a `ctrlrun_verify_<hex>` schema of its own for each guarantee,
+works inside it, and drops it when the run ends, including when the run ends by exception. It does
+not migrate, read or write your schema. It needs `CREATE` on the database to do that and refuses,
+naming the reason, when it cannot.
+
+## What the store does not do for you
+
+Stated plainly, because each of these is something an operator could reasonably assume and none of
+them is true:
+
+- **It does not back anything up.** The receipts and effect records are your data in your
+  database, and they are exactly as durable as your backup policy.
+- **It does not rehash a receipt written by an older build.** The chain hashes the whole receipt
+  document, so a release that *adds* a receipt field reports every receipt written before it as
+  `content_altered`. Migrations are forward-only and there is no rehash. An operator meeting this
+  accepts the break window — `--verify-chain` names the `seq` range, so it is legible — or
+  truncates. Receipts written before the chain existed at all report `unchained`, which is a
+  different and documented case.
+- **It does not prune, roll or retain.** `effects`, `events`, `receipts`, `approvals`,
+  `delegations` and `continuations` grow without bound. Deciding what may be deleted is a
+  retention policy and this library does not have one; note that deleting receipts from the middle
+  or the end of the chain is detected as a break by design, so a retention job needs to be written
+  with that in mind and `ctrlrun inspect --verify-chain` needs to be told where a legitimate
+  boundary is.
+- **It does not create the schema, the database, the user or the grants.**
+- **It does not pool, discover a primary, retry a failed connection, or fail over.**
+- **It does not sweep expired leases**, and nothing runs in the background at all.
+- **It does not prove who wrote a receipt.** The chain in `SPEC-v0.6.md` §6 detects **alteration**
+  — an edited row, a deletion from the middle, a reordering — and that is all it detects.
+  Receipts are not signed, alteration is not authorship, and the chain is not tamper-proof
+  against an administrator with write access to every row including the chain head.
+  `docs/THREAT_MODEL.md` states what remains open.
+- **It does not make a read replica safe to use.** See above.
+- **It is not a queue, a scheduler or a workflow engine.** It records decisions and outcomes for
+  actions somebody else is executing.
+
+## Running the store's own tests against your database
+
+The store conformance suite is this repository's acceptance tests, runnable against any
+`StateStore` — including one pointed at a database configured the way yours is:
+
+```python
+from ctrlrun.conformance.store import run
+from ctrlrun.conformance.store.backends import PostgresBackend
+
+report = run(PostgresBackend("postgresql://…"))
+print(report.to_text())
+raise SystemExit(0 if report.ok else 1)
+```
+
+The suite is core and stdlib — no extra beyond `ctrlrun[postgres]` itself — and it takes a private
+schema per case, which it drops. Two of its cases contend from eight OS processes, so point it at
+a database you are willing to have hammered briefly.
+
+Running it against a staging database that shares your production's encoding, collation, pooling
+and Postgres version is the cheapest way to find out that one of them is not what you thought.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ctrlrun"
-version = "0.5.0"
+version = "0.6.0"
 description = "Make consequential AI-agent actions safe to execute."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_release_v0_6.py
+++ b/tests/test_release_v0_6.py
@@ -1,0 +1,245 @@
+"""The v0.6 release pass. Item 9; SPEC-v0.6 §8's T180 and T181.
+
+Two claims about the *documents*, made testable because they are the two the release is most
+likely to get wrong quietly.
+
+**T180 — alteration is not authorship.** §1.2's third rule, and §6.4's whole argument: a hash
+chain says the log was not altered after the fact and says nothing about who wrote it. A README
+that blurs the two would be the false-green problem in prose, and prose has no CI of its own.
+
+**T181 — core still installs nothing new.** v0.6 adds `ctrlrun[postgres]`, and an extra is only
+an extra while `pip install ctrlrun` does not pull it in.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tarfile
+import tempfile
+import tomllib
+import zipfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: SPEC-v0.6 §8's T180. Word boundaries, so `design`, `assign`, `assignment` and `designated`
+#: are not hits -- a substring list would flag those, be softened, and stop failing on the thing
+#: it exists for.
+FORBIDDEN = re.compile(
+    r"\b(sign|signs|signed|signing|signature|signatures|authorship|"
+    r"non-repudiation|tamper-proof)\b",
+    re.IGNORECASE,
+)
+
+#: The documents the rule binds. `docs/SPEC-v0.6.md` is deliberately **not** here: it is the
+#: place the distinction is argued at length, and scanning it would make the allow-list a copy
+#: of §6.
+SCANNED = (
+    "README.md",
+    "CHANGELOG.md",
+    "docs/postgres.md",
+    "docs/THREAT_MODEL.md",
+)
+
+
+def _lines(name: str) -> list[str]:
+    """One scanned document's lines.
+
+    A **missing** file is a failure and not a skip: `docs/postgres.md` is required by §8 and by
+    this milestone's definition of done, and skipping on its absence would make the scan
+    disappear exactly when somebody deleted the document it covers. The only skip admitted is
+    the whole repository being absent, which is the sdist job running this suite from inside a
+    distribution that carries `docs/` but not `pyproject.toml`.
+    """
+    if not (REPO_ROOT / "pyproject.toml").exists():  # pragma: no cover - not a checkout
+        pytest.skip("no repository checkout")
+    path = REPO_ROOT / name
+    assert path.exists(), f"{name} is required by SPEC-v0.6 §8 and is not here"
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+def _load(name: str) -> set[str]:
+    """The allow-listed lines of one file, stripped, as a set."""
+    return {line.strip() for line in ALLOWED.get(name, ())}
+
+
+#: **Every line below is allow-listed because somebody wrote it down here on purpose.**
+#:
+#: §8's T180 describes the list as sentences that *disclaim* one of the words, and most of these
+#: are. Some are not, and saying so is the point of splitting the list rather than pretending:
+#: a historical changelog entry about JWT signature verification, an HMAC on a webhook, and the
+#: Python word for a function's parameters are all `\bsignature\b` and none of them is a claim
+#: about receipts. `docs/SPEC-v0.6.md` §8's T180 is amended in this item's PR to say so, on the
+#: rule that a contract defect found while implementing it is fixed in the contract.
+#:
+#: What the list is *for* is unchanged and is the whole design: it fails on a **new** occurrence,
+#: which is the event worth failing on, and forces whoever adds one to come here and say what
+#: they meant. A plain forbidden-word list would flag §6.4's own "Not authorship", be removed as
+#: a false positive, and be gone.
+#: Sentences that **disclaim** one of the words. §8's T180 describes the whole
+#: list this way, and this half of it is.
+DISCLAIMS: dict[str, tuple[str, ...]] = {
+    "README.md": (
+        "it by `seq`. **This detects alteration, and alteration is not authorship: receipts are not signed",  # noqa: E501
+        "and the chain is no evidence of who wrote one.** Nor is it tamper-proof — it does not survive an",  # noqa: E501
+    ),
+    "CHANGELOG.md": (
+        '- **`docs/ROADMAP.md`\'s v0.6 bullet said "receipt integrity (hash chain / signatures)", and the',  # noqa: E501
+        "slash was the problem.** A chain detects **alteration**; a signature proves **origin**, and",  # noqa: E501
+        "this project verifies what it is handed. Signing is out of scope for v0.6 (`SPEC-v0.6.md` §11).",  # noqa: E501
+        "- **`docs/THREAT_MODEL.md`'s \"Receipts are not signed; a database admin can alter history",  # noqa: E501
+        "which half it does not: **truncation at the end**, authorship, an adversary who can rewrite",  # noqa: E501
+        '- Receipts are not signed. A database administrator can alter history. **This line read "(v0.6)" until v0.6 was built, and that was a promise v0.6 does not keep**: v0.6 adds a hash chain, which detects alteration and is not evidence of authorship, and it does not stop an administrator who can rewrite every row including the chain head. Signing is out of scope (`SPEC-v0.6.md` §11).',  # noqa: E501
+    ),
+    "docs/postgres.md": (
+        "Receipts are not signed, alteration is not authorship, and the chain is not tamper-proof",
+    ),
+    "docs/THREAT_MODEL.md": (
+        "- Receipts are not signed, and they are not signed after v0.6 either. v0.6 adds a **hash chain** (`SPEC-v0.6.md` §6): each receipt carries the hash of the one before it, with `seq` inside the hashed content, so a partial tamper is detected and named — an `UPDATE` on one row, a `DELETE` from the middle, a reordering. What that closes is **alteration that keeps the receipts after it**: changing what receipt *n* says while leaving the rest in place costs a rewrite of all of them plus the head, rather than one statement. **Not a truncation at the end, and not an append.** Two earlier versions of this line claimed the first; a review measured both at **two statements, undetected** — delete the rows and rewind the head, or insert a well-formed row and advance it. The head is a row in the same database as the receipts, so it raises the cost of *forgetting* and not the cost of erasing; an anchor outside the database is what would close that, and v0.6 has none. What it does **not** close is authorship, and it does not close a database admin who can rewrite every row including the chain head: such an adversary recomputes the chain and it verifies. The malicious-administrator line above is unchanged; v0.6 narrows it rather than removing it. Nor does the chain prove that every action wrote a receipt — a receipt whose write failed leaves no gap in `seq` and is invisible to the chain by construction; the events log is where that is reconciled.",  # noqa: E501
+    ),
+}
+
+#: Sentences about something else entirely, which the word-boundary pattern cannot
+#: tell apart: JWT signature verification, an HMAC on a webhook, and the Python word for a
+#: function's parameters. §8's T180 did not anticipate these and is amended in item 9's PR.
+#: They are allow-listed for the same reason the others are -- so that a **new** occurrence
+#: fails and somebody has to come here and say which kind it is.
+ANOTHER_SUBJECT: dict[str, tuple[str, ...]] = {
+    "CHANGELOG.md": (
+        "as widening, expired and revoked authority, token forgery, cross-JWT confusion, and signing",  # noqa: E501
+        "token from the same issuer, signed with the same key, carrying the configured `aud`, passes",  # noqa: E501
+        "fetch its signing keys in cleartext from wherever it pointed, cache them for the life of",
+        "the process, and verify every token the attacker then signed.",
+        "- **`Control.evaluate` returns the combined decision**, not the policy axis alone. Its signature",  # noqa: E501
+        "one `Control` each. `SPEC-v0.1.md` §8's frozen signature is amended in the same change, as the",  # noqa: E501
+        "- **`WebhookApprovalProvider`** — core, over stdlib `urllib.request`. One signed POST on",
+        "`APPROVAL_REQUESTED`; the gateway serves the signed inbound grant/deny at",
+    ),
+    "docs/THREAT_MODEL.md": (
+        "| A forged or tampered token | `JWTIdentityProvider` verifies the signature against a JWKS or a pinned key, with the algorithm taken from its own allow-list and never from the token (RFC 8725 §3.1) |",  # noqa: E501
+        "| Signing keys fetched from somewhere else | JWKS over HTTPS only, redirects refused outright, a duplicate `kid` refused rather than resolved, a failed fetch never emptying the cache |",  # noqa: E501
+        "- **A compromised identity provider.** CTRLRun *consumes* identities: it verifies a token somebody else issued and maps the verified claims onto a `Principal`. It issues nothing, and an issuer that signs a token for the wrong subject has told CTRLRun the truth as far as CTRLRun can tell. Everything downstream — grants, delegation, receipts — is then wrong, correctly and consistently.",  # noqa: E501
+    ),
+}
+
+
+#: The two groups, merged. Both are allow-listed; the split is what keeps the reason for each
+#: entry visible instead of averaging them into one undifferentiated list.
+ALLOWED: dict[str, tuple[str, ...]] = {
+    name: DISCLAIMS.get(name, ()) + ANOTHER_SUBJECT.get(name, ())
+    for name in set(DISCLAIMS) | set(ANOTHER_SUBJECT)
+}
+
+
+def test_T180_the_release_documents_do_not_blur_alteration_and_authorship() -> None:
+    """SPEC-v0.6 §1.2's third rule, as a test rather than an intention."""
+    unexpected: list[str] = []
+    for name in SCANNED:
+        allowed = _load(name)
+        for number, line in enumerate(_lines(name), start=1):
+            if FORBIDDEN.search(line) and line.strip() not in allowed:
+                unexpected.append(f"{name}:{number}  {line.strip()[:110]}")
+    assert unexpected == [], (
+        "a release document gained a sentence about signing, signatures or authorship that "
+        "nobody allow-listed. If it disclaims one of them, add the exact line to ALLOWED with "
+        "the reason. If it claims one of them, SPEC-v0.6 §6.4 says it is not true:\n"
+        + "\n".join(unexpected)
+    )
+
+
+def test_T180_the_allow_list_is_not_stale() -> None:
+    """An allow-list nobody prunes becomes a list of lines that no longer exist, and the next
+    person to edit one of these sentences would find the guard silently not covering it.
+
+    So every entry must still resolve to a line in its file **and** still contain a forbidden
+    word: an entry that stopped matching is an entry doing nothing.
+    """
+    orphaned: list[str] = []
+    for name, entries in ALLOWED.items():
+        present = {line.strip() for line in _lines(name)}
+        for entry in entries:
+            if entry.strip() not in present:
+                orphaned.append(f"{name}: no longer present — {entry.strip()[:90]}")
+            elif not FORBIDDEN.search(entry):
+                orphaned.append(f"{name}: allow-listed but matches nothing — {entry.strip()[:90]}")
+    assert orphaned == [], orphaned
+
+
+def test_T180_the_scan_would_see_a_new_claim() -> None:
+    """The positive control (`v0.4 §1.3`). A guard whose pattern never matched anything would
+    pass this file on any content at all, and the two tests above would both stay green."""
+    assert FORBIDDEN.search("Receipts are signed, which proves authorship.")
+    assert FORBIDDEN.search("The chain is tamper-proof.")
+    assert FORBIDDEN.search("CTRLRun gives you non-repudiation.")
+    # And the words it must not fire on, which is why it is a word-boundary pattern.
+    assert not FORBIDDEN.search("the design of the store")
+    assert not FORBIDDEN.search("assign the lease to the caller")
+    assert not FORBIDDEN.search("a designated approver")
+
+
+def test_T181_core_still_installs_pyyaml_and_click_and_nothing_else() -> None:
+    """SPEC-v0.6 §8's T181. v0.6 adds `ctrlrun[postgres]`, and `psycopg` is only an extra
+    while `pip install ctrlrun` does not pull it in."""
+    path = REPO_ROOT / "pyproject.toml"
+    if not path.exists():  # pragma: no cover - not a checkout
+        pytest.skip("no repository checkout")
+    project = tomllib.loads(path.read_text(encoding="utf-8"))["project"]
+    names = {re.split(r"[<>=!\[ ]", entry)[0].lower() for entry in project["dependencies"]}
+    assert names == {"pyyaml", "click"}, names
+    assert "postgres" in project["optional-dependencies"], (
+        "v0.6 ships a Postgres backend and it must be an extra"
+    )
+
+
+def test_T181_the_distributions_carry_no_adapter_no_research_and_no_pack() -> None:
+    """The other half of T181, and the reason it is built rather than read: `MANIFEST.in`
+    resolves against the **working tree** and not the index, so the only way to know what ships
+    is to build it. v0.2 shipped four policy files `.gitignore` had swallowed, and every green
+    build had already accounted for them.
+
+    `research/` is the new name here. `research/framework-probe/` and `research/soak/` are both
+    harnesses whose *results* are published and whose code ships nowhere (`v0.4 §7`, §8.1).
+
+    **This overlaps `test_T136_the_ctrlrun_distributions_contain_no_adapter`, deliberately.**
+    T136 grew the `research/` and `packs/` check when item 8's `tests/test_soak.py` needed a
+    guarantee behind its skip; §8 asks T181 for all three in one place as the release check, and
+    the two are allowed to agree. What is not allowed is neither of them running, which is why
+    the skip below is the whole repository being absent and nothing narrower.
+    """
+    root = REPO_ROOT
+    if not (root / "pyproject.toml").exists():  # pragma: no cover - not a checkout
+        pytest.skip("no repository checkout")
+
+    with tempfile.TemporaryDirectory() as area:
+        built = subprocess.run(
+            [sys.executable, "-m", "build", "--outdir", area, str(root)],
+            capture_output=True,
+            text=True,
+        )
+        if built.returncode != 0:
+            if "No module named build" in built.stderr:  # pragma: no cover - dev dependency
+                pytest.skip("python -m build is not installed")
+            raise AssertionError(f"python -m build failed:\n{built.stderr[-2000:]}")
+
+        names: list[str] = []
+        for artifact in Path(area).iterdir():
+            if artifact.suffix == ".whl":
+                names += zipfile.ZipFile(artifact).namelist()
+            elif artifact.name.endswith(".tar.gz"):
+                with tarfile.open(artifact) as archive:
+                    names += archive.getnames()
+
+    assert names, "nothing was built"
+    offending = [
+        name
+        for name in names
+        # Anchored on a path **segment**, so a file called `research.py` is not a hit and a
+        # directory called `research/` is. The first version matched the bare substring and
+        # would have fired on `docs/research.md`.
+        if any(part in {"adapters", "research", "packs"} for part in Path(name).parts)
+    ]
+    assert offending == [], offending


### PR DESCRIPTION
Build-list item 9; `SPEC-v0.6.md` §8's T179–T181. Changelog, `docs/CLAIMS.md` regenerated, README, ROADMAP reconciled, `docs/postgres.md`.

**Stacked on #61 (item 8).** Merge that one first.

## It does not tag, and the documents say so

`ROADMAP.md`'s v0.6 exit criterion is a soak of at least **one week** with no unexplained `AMBIGUOUS`. Item 8's harness, its definition of *unexplained*, its positive control and its measured run are all here. A week of calendar time is not.

So the criterion is left standing and marked **unmet** rather than rewritten to fit the run:

- the changelog entry is dated `unreleased` and opens by saying why;
- `ROADMAP.md`'s heading reads *"Code complete 2026-09-06; **not tagged** — see Exit"*, and its Exit section reconciles all three criteria — two met, one not, with item 4's narrowing (separate processes, not two hosts; no network partition) repeated rather than quietly dropped.

A `v0.6.0` whose changelog says a week happened is the one claim this project said would be exactly as false as it looks. The tag is one line away when the maintainer decides the week matters or decides it does not.

## `docs/postgres.md`

Operator-facing: connection strings, what to grant, what happens on failover, the one row every receipt write serializes on, and what the store does **not** do for you.

**Every executable line in it was run against a live Postgres before it was written down** — and four claims in my first draft were wrong, which is why. `--verify-chain` is on `receipts` and not `inspect`; `--store-url` is on six commands and not two; the report method is `to_text` and not `render`; and the six chain-break names were six names I had invented.

The "does not do" list is the part worth reading: no backup, no retention, no pool, no primary discovery, no sweeper, no read replica, **no rehash of a receipt written by an older build**, and no evidence of who wrote a receipt.

## T180 — alteration is not authorship

A scan of `README.md`, `CHANGELOG.md`, `docs/postgres.md` and `THREAT_MODEL.md` for `sign`/`signature`/`authorship`/`tamper-proof` on word boundaries, against an allow-list of exact lines.

Writing it found §8's description of that list to be **two-thirds true**. Ten of the twenty-one lines disclaim one of the words, as §8 assumed. The other eleven are about something else the pattern cannot tell apart — JWT signature verification, a webhook HMAC, `Signing keys fetched from somewhere else` in the threat model, and the Python word for a function's parameters. Describing the list as *"sentences that disclaim"* would have had the next person delete those eleven as mistakes — the false positive the design exists to prevent, arriving through the specification instead of through the pattern. §8's T180 is amended here to say so, including what the check does **not** cover: a claim made in words the pattern does not contain.

## Two false claims already in the tree

- The changelog said the chain closes *"a truncation"*. A review had already measured erasing a suffix and rewinding the head at **two statements, undetected**, and `THREAT_MODEL.md` was corrected — but the changelog entry *describing that correction* still claimed the thing being corrected.
- The v0.1 notes said *"Receipts are not signed. A database administrator can alter history (v0.6)."* That `(v0.6)` was a promise v0.6 does not keep.

`docs/CLAIMS.md`'s own guard caught five test names in the new v0.6 section that I had guessed rather than looked up, which is the guard doing the job it was added for.

2385 passed, 45 skipped. `ruff` and `mypy --strict` clean.