### PR TITLE
Docs 0: information architecture, the capabilities source, and the audit harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,48 @@ jobs:
           assert skipped == 0, f"{skipped} adapter tests skipped; the frameworks did not install"
           PY
 
+  # The documentation audit (docs/STYLE.md). Four checks, one job of their own so a docs PR
+  # gets a docs answer:
+  #
+  #   - the rendered capability tables match docs/capabilities.yaml -- a hard failure, and
+  #     also a test in `tests/test_docs_audit.py`, because a hand-edited table is the drift
+  #     this generator exists to make impossible;
+  #   - runnable snippets, the forbidden-words lint and the link check.
+  #
+  # The last three carry `continue-on-error: true` for now. They were wired in against the
+  # documentation as it stood, and the findings they raised on that day are the baseline the
+  # writing sessions clear. Each flag comes off the moment its check passes on `main`, one
+  # step at a time, and never all three together on trust -- a red step that is allowed to be
+  # red is documentation, not a guard, and the point of the flag is to be temporary.
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Rendered capability tables match docs/capabilities.yaml
+        run: python tools/docs_audit/render_capabilities.py --check
+
+      - name: Runnable snippets execute offline
+        continue-on-error: true
+        run: python tools/docs_audit/snippets.py
+
+      - name: Forbidden words
+        continue-on-error: true
+        run: python tools/docs_audit/lint.py
+
+      - name: Internal links and anchors resolve
+        continue-on-error: true
+        run: python tools/docs_audit/links.py
+
   # The definition of done says the demo runs with no network and the README quick start
   # works verbatim. Both were only ever checked by hand, which is how a README stops being
   # true. This job runs them against an installed wheel, the way a new user meets them.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,13 @@ include CHANGELOG.md
 include SECURITY.md
 include VISION.md
 recursive-include docs *.md
+# The documentation audit reads these: `docs/capabilities.yaml` is the source the capability
+# tables are rendered from and `docs/generated/` holds the renders, and
+# `tests/test_docs_audit.py` compares the two. `tools/docs_audit/` is the generator and the
+# three checks, imported by that test, so an sdist that ran its tests without them would be
+# the same failure as shipping tests without their data.
+recursive-include docs *.yaml *.mdx *.txt
+recursive-include tools *.py *.txt
 recursive-include tests *.py
 # SPEC-v0.4 §4.3 — T115 validates `--junit` against a checked-in schema, and reads the README
 # beside it for the schema's provenance and licence. A test that ships without its data is a

--- a/docs/IA.md
+++ b/docs/IA.md
@@ -1,0 +1,361 @@
+# Information architecture for the documentation site
+
+The target shape of the docs site, one line per page: what it is for and the query it should
+answer. Later sessions write the pages; this file is what they write against, and
+`docs/capabilities.yaml` names pages by the paths below.
+
+**The fixed copy**, quoted here so every page quotes the same words:
+
+| Slot | Text | Where it goes |
+|---|---|---|
+| Tagline | The last check before an AI agent does something it can't undo. | README line 1, Home hero, social preview |
+| Principle | Autonomy belongs to the action, not the agent. | Second sentence everywhere; the line people quote |
+| Category | The execution safety layer for AI agents. | GitHub About, PyPI summary, site `<title>`, directory listings |
+| Opener (long-form only) | Everyone is rushing to ship AI agents without thinking about consequences. | First line of Why and of launch posts; never a heading |
+| Promise | Every consequential action happens once, exactly as approved, or not at all — and leaves a receipt. | Hero subline, README paragraph 2 |
+| Hook (posts) | Agents can retry. The real world can't. | Social, talk titles; not the README header |
+
+The rules every page is held to are in `docs/STYLE.md`. The tools that hold them are in
+`tools/docs_audit/`.
+
+## Conventions
+
+- Paths are root-relative on the site: `concepts/effect-keys` is `docs/concepts/effect-keys.mdx`.
+- **Purpose** is the page's first-paragraph answer, compressed. **Query** is the search a
+  stranger types, and the first sentence of the page is written to answer it.
+- The existing Markdown documents that stay where they are — the specifications,
+  `ARCHITECTURE.md`, `THREAT_MODEL.md`, the OWASP and ACS readings — are linked from the pages
+  that own them and are not rewritten.
+- Sessions are named where a page belongs to a later session, so a session knows what it owes.
+
+## The tree
+
+```
+Home                                   index
+Why                                    why
+Get started
+  ├─ Install                           get-started/install
+  ├─ 60-second quickstart              get-started/quickstart
+  ├─ Three ways in                     get-started/three-ways-in
+  └─ Choosing between them             get-started/choosing
+Concepts
+  ├─ Action and hash                   concepts/action-and-hash
+  ├─ Decisions                         concepts/decisions
+  ├─ Approval binding                  concepts/approval-binding
+  ├─ Effect keys                       concepts/effect-keys
+  ├─ Outcomes and AMBIGUOUS            concepts/outcomes-and-ambiguous
+  ├─ Receipts and evidence             concepts/receipts-and-evidence
+  ├─ Authority and delegation          concepts/authority-and-delegation
+  ├─ Observe mode                      concepts/observe-mode
+  └─ Fail closed                       concepts/fail-closed
+Guides
+  ├─ Protect a function                guides/protect-a-function
+  ├─ Put the gateway in front of MCP   guides/gateway-in-front-of-mcp
+  ├─ Approve in Slack                  guides/approvals-in-slack
+  ├─ Resolve an AMBIGUOUS effect       guides/resolve-an-ambiguous-effect
+  ├─ Reconcile automatically           guides/reconcile-automatically
+  ├─ Roll out observe, then enforce    guides/observe-to-enforce
+  ├─ Run on Postgres                   guides/run-on-postgres
+  ├─ Verify in CI                      guides/verify-in-ci
+  ├─ Export to OpenTelemetry           guides/export-to-opentelemetry
+  ├─ Use the LangGraph adapter         guides/langgraph-adapter
+  └─ Use the OpenAI Agents SDK adapter guides/openai-agents-adapter
+Cookbook                               cookbook/index  (session 4; recipes listed below)
+Reference
+  ├─ Policy YAML                       reference/policy-yaml
+  ├─ Authority YAML                    reference/authority-yaml
+  ├─ CLI                               reference/cli
+  ├─ Python API                        reference/api/index  (+ one page per public name)
+  ├─ Receipt and event schemas         reference/receipt-and-event-schemas
+  ├─ Exit codes                        reference/exit-codes
+  └─ Errors                            reference/errors
+Compare
+  ├─ vs framework human-in-the-loop    compare/framework-hitl
+  ├─ vs guardrail libraries            compare/guardrail-libraries
+  ├─ vs agent governance toolkits      compare/governance-toolkits
+  ├─ vs durable workflow engines       compare/durable-workflows
+  └─ vs idempotency keys               compare/idempotency-keys
+FAQ                                    faq
+Security
+  ├─ Threat model                      security/threat-model
+  ├─ What verify guarantees            security/verify-guarantees
+  ├─ The receipt chain                 security/receipt-chain
+  ├─ How this is built                 security/how-this-is-built  (session 1b)
+  └─ Reporting a vulnerability         security/disclosure
+Architecture and specifications
+  ├─ Architecture                      architecture/overview
+  └─ Specifications                    architecture/specifications
+Changelog                              changelog
+Try it in your browser                 try-it                       (session 5b)
+Research: does your framework
+  double-execute?                      research/does-your-framework-double-execute  (5b)
+Get the badge                          verify/get-the-badge         (session 5b)
+```
+
+## Home and Why
+
+| Path | Purpose | Query |
+|---|---|---|
+| `index` | The tagline, the principle, the promise; the demo; the capability grid rendered from `capabilities.yaml`; the three ways in; three start-here cards; the one line that adds this site as an MCP server to a coding tool. | *ctrlrun* · *AI agent safety layer* |
+| `why` | Opens with the opener line. Five sections, one principle each: FAILED is not UNKNOWN · an approval is bound to what the human saw · autonomy belongs to the action · unknown means no · evidence leaves the building. Ends at How this is built. | *why do AI agents double execute actions* · *AI agent consequential actions* |
+
+## Get started
+
+| Path | Purpose | Query |
+|---|---|---|
+| `get-started/install` | `pip install ctrlrun`; what it installs (pyyaml, click, nothing else); the extras and what each adds; Python 3.11+. | *install ctrlrun* |
+| `get-started/quickstart` | Protect one function end to end in sixty seconds, with the real output: a policy, a decorator, a refused mutation, a receipt. | *ctrlrun quickstart* · *protect an AI agent action python* |
+| `get-started/three-ways-in` | Decorator, gateway, adapter: what each covers and what each needs. The negative sentence: most readers need the decorator and should not look for an adapter. | *ctrlrun langgraph* · *ctrlrun mcp* · *do I need an adapter* |
+| `get-started/choosing` | The decision table: in-process Python → decorator; tools behind MCP → gateway; a framework with its own approval UI → adapter. What you do not need for the single-host case: a server, a database, a dashboard. | *ctrlrun decorator vs gateway* |
+
+## Concepts
+
+Each Concepts page opens with one definitional sentence an assistant can quote standalone,
+has one diagram or code block, names the guarantee it supports and what it does not do, and
+ends with Next links. Every claim on a Concepts page has a `docs/CLAIMS.md` row.
+
+| Path | Purpose | Query |
+|---|---|---|
+| `concepts/action-and-hash` | An action is a named operation with canonical arguments, and its hash is what everything binds to: sorted keys, no whitespace, no floats. | *ctrlrun action hash* · *canonical action hash AI agent* |
+| `concepts/decisions` | Three decisions — allow, approve, deny — decided per action by a policy that cannot see who is asking. First matching rule wins; unknown is denied. | *AI agent action policy allow approve deny* |
+| `concepts/approval-binding` | An approval is bound to the exact action hash a human saw, is single-use, expires, and is consumed atomically with the reservation. A mutated action is refused. | *human-in-the-loop approval bound to action* · *approval mutation AI agent* |
+| `concepts/effect-keys` | An effect key names the real-world consequence, so the same intent from a retry, a second agent or a second host is one effect. This is the page that says *idempotency* once. | *idempotency key AI agent* · *prevent duplicate execution agent tool call* |
+| `concepts/outcomes-and-ambiguous` | Three outcomes — COMMITTED, FAILED, AMBIGUOUS — and why a timeout is not a failure. Only `NotExecuted` means failed; everything else after the first byte is unknown, and unknown blocks a blind retry. The page that explains the product. | *what happens when an agent tool call times out* · *double execution AI agent retry* |
+| `concepts/receipts-and-evidence` | Every executed action leaves a portable JSON receipt: who, what, decision, approval, effect key, outcome, and the policy hash that decided it. Chained, not signed. | *AI agent audit trail receipts* |
+| `concepts/authority-and-delegation` | Authority is the second axis: opt-in, then fail-closed. A grant says who may ask; the policy says how much autonomy the action has. Delegation only narrows, at creation and at every evaluation. Identity is consumed, never issued. | *AI agent authorization delegation* · *least privilege AI agents* |
+| `concepts/observe-mode` | One line runs every real decision against real traffic and records what enforcement would have blocked, without blocking. It executes; it is not a dry run. | *AI agent policy shadow mode* |
+| `concepts/fail-closed` | Unknown action, missing policy, malformed policy, missing principal, missing or mismatched approval, inconsistent state: all deny. No flag makes a consequential action permissive by default. | *fail closed AI agent* |
+
+## Guides
+
+Each guide is a task with a verb in the title: prerequisites, numbered steps with runnable
+blocks, expected output, and *if it didn't work* with the two or three real failure messages.
+The gateway guide and the observe-to-enforce guide get the most room; they are the two that
+turn readers into users.
+
+| Path | Purpose | Query |
+|---|---|---|
+| `guides/protect-a-function` | Decorate a function, declare an effect key, write the policy, see a refund refused and a Kubernetes delete sent for approval. | *protect python function AI agent approval* |
+| `guides/gateway-in-front-of-mcp` | Two commands put every guarantee in front of an existing MCP server with no agent changes: the alias, the principal, the effect templates, the banner that names writes with no effect key. | *MCP gateway human approval* · *MCP server tool call approval* |
+| `guides/approvals-in-slack` | `WebhookApprovalProvider`: the request goes to a webhook, a human answers in Slack, the answer comes back through the same grant calls the CLI uses. | *slack approval AI agent actions* |
+| `guides/resolve-an-ambiguous-effect` | Reading `ctrlrun effects --state ambiguous`, asking the remote, `ctrlrun resolve --committed` or `--failed`, and what the receipt then says, including who resolved it. | *ctrlrun resolve ambiguous* |
+| `guides/reconcile-automatically` | `@protect(reconcile=...)`: a hook that asks the remote what happened, and the only thing besides a human that moves a record out of AMBIGUOUS. | *reconcile AI agent action stripe kubernetes* |
+| `guides/observe-to-enforce` | `mode: observe` for a week, `ctrlrun stats` to read the cost of enforcement, then `mode: enforce`. | *roll out AI agent policy without breaking production* |
+| `guides/run-on-postgres` | `pip install "ctrlrun[postgres]"`, the connection string, what to grant, migrations at open, the lost-COMMIT case. | *ctrlrun postgres* |
+| `guides/verify-in-ci` | The GitHub Action, the two shapes of report, the N/A line and what it means, the badge. | *verify AI agent safety configuration CI* |
+| `guides/export-to-opentelemetry` | `OTelEventSink`: one span per action, one event per step, argument values opt-in. | *opentelemetry AI agent actions* |
+| `guides/langgraph-adapter` | Route an approval through `interrupt()`: the operator builds the `Control`, `wait=True`, `Command(resume=...)`, and prevention versus attribution. | *langgraph interrupt human approval tool call* |
+| `guides/openai-agents-adapter` | Route an approval through the SDK's tool-approval interruption: `protected_tool`, `gate.run`, why a rejection leaves no CTRLRun evidence. | *openai agents sdk tool approval* |
+
+## Cookbook (session 4)
+
+One recipe per situation: the situation in two sentences, the policy, the code, what the agent
+sees when refused or asked, the receipt, and what to do when an AMBIGUOUS appears. Every block
+runs offline against a fake remote, and every recipe is also a directory under
+`examples/cookbook/<name>/` with the examples' guard: a refusal that stops being refused exits
+non-zero.
+
+| Path | Situation |
+|---|---|
+| `cookbook/refund-agent` | money — a refund agent with amount tiers |
+| `cookbook/payout-maker-checker` | money — a payout agent with maker/checker via delegation |
+| `cookbook/deploy-agent` | infrastructure — restart auto, apply-prod approve, delete-namespace deny |
+| `cookbook/database-migration-agent` | infrastructure — a migration agent |
+| `cookbook/iam-agent` | permissions — grant read, never admin |
+| `cookbook/credential-rotation-agent` | permissions — rotate, with approval to revoke |
+| `cookbook/crm-update-agent` | records — update a record, approve a merge |
+| `cookbook/data-deletion-agent` | records — deletion under a retention rule |
+| `cookbook/outbound-email-agent` | communications — external recipients need approval |
+| `cookbook/customer-notification-agent` | communications — batch notifications, one effect each |
+| `cookbook/manager-and-worker` | multi-agent — a manager delegates bounded authority to a worker |
+| `cookbook/protect-an-mcp-server` | integrations — an existing MCP server in five minutes |
+| `cookbook/langgraph-interrupt` | integrations — LangGraph with `interrupt()` |
+| `cookbook/openai-agents-tool-approval` | integrations — the OpenAI Agents SDK's tool approval |
+| `cookbook/slack-approvals` | integrations — approvals in Slack via webhook |
+| `cookbook/receipts-to-opentelemetry` | integrations — receipts into a tracing backend |
+| `cookbook/observe-then-enforce` | operations — observe for a week, then enforce |
+| `cookbook/resolve-an-ambiguous-effect` | operations — a human resolves an unknown outcome |
+| `cookbook/reconcile-against-the-remote` | operations — reconcile against Stripe or Kubernetes automatically |
+| `cookbook/verify-in-github-actions` | operations — the composite action in a workflow |
+| `cookbook/sqlite-to-postgres` | operations — move the store |
+
+## Reference
+
+Reference pages are generated from the code where the code can say it, and a drift test fails
+CI where it cannot.
+
+| Path | Purpose | Query |
+|---|---|---|
+| `reference/policy-yaml` | Every key of `ctrlrun.policy/v1`–`v4`: type, default, example, and the fail-closed behaviour when omitted. `controls:` and `data:` documented as registry primitives; the word *pack* does not appear. | *ctrlrun.yaml reference* · *ctrlrun policy schema* |
+| `reference/authority-yaml` | Every key of `authority:`: grants, subjects, constraints, `delegable`, `expires_at`, `max_delegation_depth`, and the omission rule. | *ctrlrun authority grants yaml* |
+| `reference/cli` | Every command and flag, generated from click's help; a test asserts the page matches `--help`. | *ctrlrun cli* · *ctrlrun resolve* |
+| `reference/api/index` | Every frozen public name from SPEC §8 and §11 across versions, generated from docstrings into one page per name. | *ctrlrun Control* · *ctrlrun protect decorator* |
+| `reference/receipt-and-event-schemas` | `ctrlrun.receipt/v3` and the event types, field by field, from the code. | *ctrlrun receipt json schema* |
+| `reference/exit-codes` | Every CLI exit code and what it means, from the code. | *ctrlrun verify exit code* |
+| `reference/errors` | The closed error hierarchy: `ActionDenied`, `ApprovalRequired`, `ApprovalMismatch`, `DuplicateEffect`, `AmbiguousEffect`, `NotExecuted` and the rest, with when each is raised. | *ctrlrun ApprovalMismatch* · *ctrlrun AmbiguousEffect* |
+
+## Compare
+
+Each: what the other thing is good at, honestly; what it does not do; when to use both; a
+short table. No vendor name in a heading.
+
+| Path | Purpose | Query |
+|---|---|---|
+| `compare/framework-hitl` | A framework's interrupt lets a human say yes; it does not bind the yes to the arguments that execute, refuse a retry after a lost response, or leave a receipt. Use both: the adapter routes through the interrupt. | *langgraph human in the loop vs* · *agent framework approval limitations* |
+| `compare/guardrail-libraries` | Guardrails inspect inputs and outputs; CTRLRun sits at the boundary between intention and effect. Different layer; use both. | *AI guardrails vs execution control* |
+| `compare/governance-toolkits` | Governance toolkits catalogue, monitor and report; CTRLRun refuses, in the execution path, per action. | *AI agent governance vs runtime enforcement* |
+| `compare/durable-workflows` | Durable workflow engines retry until success and make that safe with idempotent activities; CTRLRun refuses to retry an unknown outcome and binds approvals. Complementary. | *temporal vs ctrlrun* · *durable execution AI agents idempotency* |
+| `compare/idempotency-keys` | An idempotency key deduplicates at one remote that supports it; an effect key deduplicates at the agent side across remotes, refuses on unknown, and is bound to an approval. The page that says *idempotency* precisely. | *idempotency keys AI agents* · *stripe idempotency key vs* |
+
+## FAQ
+
+`faq` — the twelve questions engineers ask, answer-first, at most eighty words each, marked up
+as FAQ structured data: isn't this idempotency keys · why not a workflow engine · do I need an
+adapter · is it exactly-once · what happens on timeout · can I bypass it · does it phone home ·
+what if the human takes an hour · single host or many · what's in a receipt · is the chain a
+signature · what is not covered. Query: *ctrlrun faq* and each question verbatim.
+
+## Security
+
+| Path | Purpose | Query |
+|---|---|---|
+| `security/threat-model` | What CTRLRun defends against, what it does not, and the fail-closed rules that follow; renders `docs/THREAT_MODEL.md`. | *ctrlrun threat model* |
+| `security/verify-guarantees` | The guarantee catalogue G1–G11, what each exercises, what N/A means, what verify cannot see. | *ctrlrun verify guarantees* |
+| `security/receipt-chain` | Each receipt carries the hash of the one before; what the chain detects, what it does not prove, and the two statements that erase the end of the log. Alteration, not authorship. | *tamper evident audit log AI agent* |
+| `security/how-this-is-built` | Spec-first, every MUST mutation-tested with the real numbers, independent review sessions, CLAIMS.md, N/A is not a pass, AI coding agents used throughout with the constraints that make that safe, and what has not been done: no external audit yet. Session 1b. | *is ctrlrun trustworthy* · *how ctrlrun is tested* |
+| `security/disclosure` | How to report a vulnerability and what happens to the report; renders `SECURITY.md`. | *ctrlrun security report* |
+
+## Architecture and specifications
+
+| Path | Purpose | Query |
+|---|---|---|
+| `architecture/overview` | The boundary CTRLRun owns, the canonical flow (normalize · decide · approve · reserve · execute · record), the module map; renders `docs/ARCHITECTURE.md`. | *ctrlrun architecture* |
+| `architecture/specifications` | The six specifications, unchanged, with one line each on what the version asked; plus the OWASP and ACS readings. | *ctrlrun spec* |
+
+## Changelog
+
+`changelog` — renders `CHANGELOG.md`. Query: *ctrlrun changelog* · *ctrlrun 0.6*.
+
+## The three things that travel (session 5b)
+
+| Path | Purpose | Query |
+|---|---|---|
+| `try-it` | `ctrlrun demo` in the browser via Pyodide, the same five refusals the README shows, a run-again button, and one line to install it for real. Any scenario the browser cannot run says so by name. | *try ctrlrun* |
+| `research/does-your-framework-double-execute` | The framework-probe results, rendered from `research/framework-probe/results/*.json` by script; *No published results yet* until a file exists. Behaviour, not quality. | *does langgraph retry tool calls* · *agent framework double execution study* |
+| `verify/get-the-badge` | The two-minute version of adding the verified badge: the workflow, what *declared guarantees pass* means, what N/A means. No gallery until a repo carries it. | *ctrlrun verified badge* |
+
+---
+
+## What was read, and what was decided
+
+Read on **2026-09-06** unless stated. Everything below was checked against the source that
+day; nothing here is from memory.
+
+### (a) Mintlify's current configuration format
+
+- **`docs.json` replaced `mint.json`.** Mintlify's blog post *Refactoring mint.json into
+  docs.json* (7 February 2025) describes the change: navigation used to be spread across
+  `navigation`, `tabs`, `anchors` and `versions`; in `docs.json` it is one recursive
+  `navigation` object. The settings page states `mint.json` is deprecated and the CLI converts
+  it. — <https://www.mintlify.com/blog/refactoring-mint-json-into-docs-json>,
+  <https://www.mintlify.com/docs/organize/settings>
+- **Required top-level fields:** `name`, `theme`, `colors.primary`, `navigation`. Optional:
+  `logo`, `favicon`, `navbar`, `footer`, `banner`, `redirects` (entries of `source`,
+  `destination`, `permanent`), `seo` (`metatags`, `indexing`), `search`, `integrations`, `api`
+  (OpenAPI and AsyncAPI), `fonts`, `styling`. `$schema` is recommended for editor validation,
+  and a `docs.json` may be split with `$ref`. — <https://www.mintlify.com/docs/organize/settings>
+- **Navigation divisions:** `pages`, `groups`, `tabs`, `anchors`, `dropdowns`, `products`,
+  `versions`, `languages`, nesting arbitrarily. A group is `{group, pages, icon?, tag?, root?,
+  expanded?}`; a tab is `{tab, icon?, pages | groups | menu | href}`; `global.anchors` holds
+  persistent external links. Pages left out of `navigation` are hidden but reachable. —
+  <https://www.mintlify.com/docs/organize/navigation>
+- **Page frontmatter:** `title`, `description`, `sidebarTitle`, `icon`, `iconType`, `tag`,
+  `mode`, `url`, `keywords`, `noindex`, plus any meta tag as a quoted key
+  (`"og:image": …`, `"twitter:card": …`). Global defaults live in `seo.metatags`; `canonical`
+  can be set there. `sitemap.xml` and `robots.txt` are generated. —
+  <https://www.mintlify.com/docs/organize/pages>, <https://www.mintlify.com/docs/optimize/seo>
+- **Components** the pages will use: `Card` and `Columns` (`cols` 1–4), `Steps`/`Step`,
+  `Accordion`, `Tabs`, callouts, `CodeGroup`, `Frame`, `Expandable`, fields, `Update`,
+  `Tooltip`. `Columns` is the current name for the card grid; the generator in this PR emits
+  it. — <https://www.mintlify.com/docs/components/cards>,
+  <https://www.mintlify.com/docs/components/steps>
+- **AI surfaces are automatic:** `/llms.txt` and `/llms-full.txt` (also under `/.well-known/`),
+  a Markdown copy of every page at its URL with `.md` appended, `Link` and `X-Llms-Txt` HTTP
+  headers, and MCP server discovery at `/.well-known/mcp/server-card.json`. Oversized indexes
+  split under `/_llms/`. — <https://www.mintlify.com/docs/ai/llmstxt>
+- **Monorepo deployment:** dashboard → Git Settings → *Set up as monorepo* → path `/docs`, no
+  trailing slash; one `docs.json` per deployment. — <https://www.mintlify.com/docs/deploy/monorepo>
+- **Local preview:** the CLI package is `mint` (`npm i -g mint`, Node 20.17+), `mint dev` to
+  preview, `mint update` to upgrade. — <https://www.mintlify.com/docs/installation>
+
+### (b) Python API reference: no native support; generate MDX with griffe
+
+Mintlify's API reference support is OpenAPI and AsyncAPI, and the playground page names no
+other source (<https://www.mintlify.com/docs/api-playground/overview>). The request for
+docstring-generated pages, Mintlify discussion #1639, had no Mintlify response and only
+community workarounds as of December 2025
+(<https://github.com/orgs/mintlify/discussions/1639>).
+
+**Decision: a script of this repository's own, `tools/docs_audit/render_api.py` (session 3),
+loads the package with griffe and emits one MDX page per frozen public name into
+`docs/reference/api/`.** Reasons:
+
+- griffe parses Google-style docstrings into a data model with named sections (arguments,
+  raises, returns, examples), which is what the Reference page needs to turn into fields; it
+  is the extractor behind mkdocstrings, so the docstring conventions it wants are the common
+  ones. — <https://mkdocstrings.github.io/griffe/>
+- pdoc renders HTML with its own templates; its output is a site, not a set of fragments, and
+  bending it to `docs.json` navigation is more work than emitting MDX from a data model.
+- griffe2md exists but renders to plain Markdown for MkDocs; the Reference pages want
+  Mintlify's field components and frontmatter, so the last mile is ours either way.
+- A test asserts every frozen public name has a docstring and a page, so the generator cannot
+  silently skip one.
+
+griffe is a documentation-build dependency and goes in the `dev` extra, never in core; the
+kernel's dependency rule is unchanged.
+
+### (c) How three infrastructure docs sites are organised
+
+Top-level navigation only, read 2026-09-06.
+
+| Site | Top level |
+|---|---|
+| Temporal (<https://docs.temporal.io/>) | Quickstart · Developer guide · Production deployment · Cloud · Community and learning. Also `llms.txt` and raw Markdown per page. |
+| Cerbos (<https://docs.cerbos.dev/cerbos/latest/index.html>) | Platform · Getting started (what it is, quickstart, tutorial, installation) · API · Policies (one page per policy concept, plus best practices and debugging) · Configuration · Deployment patterns · CLI · Recipes · Release notes and reference |
+| Stripe (<https://docs.stripe.com/>) | Start here by use case · Browse by product · Development environment · Agent skills and a terminal reader for the docs |
+
+What carried into the tree above: a task-first *Get started* separate from concept pages
+(all three); a *Recipes* / cookbook section distinct from guides and from reference (Cerbos,
+Stripe); a CLI page of its own (Cerbos); one page per policy concept rather than one long
+policy page (Cerbos); and the docs being readable by an agent — `llms.txt`, per-page Markdown,
+an agent-skills entry point — treated as a feature on the front page (all three).
+
+### (d) What generative engine optimisation means for a docs site in 2026
+
+Two sources with opposite emphases, and the tree above follows both:
+
+- **Google's *AI features and your website* guide** (last updated 10 July 2026) says the
+  fundamentals are what matter: unique, people-first content with clear structure; crawlable,
+  indexable pages with good page experience and semantic HTML; and that `llms.txt`, content
+  chunking, special writing styles and extra structured data are *not* needed for Google's
+  generative features. —
+  <https://developers.google.com/search/docs/fundamentals/ai-optimization-guide>
+- **LLMrefs' GEO guide** (undated, read 2026-09-06) gives the practices that help pages get
+  cited by assistants: lead each section with a direct answer, keep paragraphs to two or three
+  sentences, keep entity names consistent, use lists and comparison tables, cite sources and
+  name statistics, and refresh important pages. — <https://llmrefs.com/generative-engine-optimization>
+- Mintlify's own position, for the assistants that do read them: `llms.txt`, `llms-full.txt`
+  and an MCP server are generated for every site. — <https://www.mintlify.com/docs/ai/llmstxt>
+
+What this means concretely for these pages, and what `docs/STYLE.md` enforces: **answer-first
+first paragraphs** and one **definitional sentence** per Concepts page, written for a human;
+**consistent entity naming** (CTRLRun, effect key, action hash, AMBIGUOUS); **comparison
+tables** on every Compare page; **FAQ structured data** on the FAQ page; quotable, plain
+claims with a `CLAIMS.md` row behind each; and the generated `llms.txt` left to Mintlify. What
+it does not mean: keyword density, chunked pages, or a second writing style for machines.
+
+## Next
+
+- `docs/STYLE.md` — the rules every page follows.
+- `docs/capabilities.yaml` — the single source the capability tables are rendered from.
+- `tools/docs_audit/` — the three checks and the generator.

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -1,0 +1,101 @@
+# Style sheet for the documentation
+
+Every page on the docs site and every sentence in the README follows this sheet. The audit
+tools under `tools/docs_audit/` enforce the parts a machine can check; the rest is what a
+reviewer reads for.
+
+## The page
+
+- **Answer first.** The first paragraph answers the question the title asks, with no preamble.
+  That paragraph is what a search snippet, an AI assistant and an impatient engineer read, and
+  often the only thing they read.
+- **One definitional sentence** on every Concepts page, phrased so it stands alone when
+  quoted: *An effect key is …*. Write it for a person; if it reads badly aloud it reads badly to
+  a model.
+- **At most 900 words**, except Reference pages. A page that needs more is two pages.
+- **Code before prose** wherever the code can carry the point. Show the policy, then say what
+  it does.
+- **Every page ends with "Next"**: two or three links to where the reader goes from here. Every
+  page links to Why and to Get started somewhere in its body or its Next block.
+- **Headings are the questions people search.** *What happens on a timeout?* rather than
+  *Timeouts*. One H1 per page, and it is the title.
+
+## The sentence
+
+- **Second person, present tense.** *You declare an effect key* — not *the user will declare*.
+- **One idea per paragraph.** Two or three sentences is a paragraph; six is two.
+- **No exclamation marks.** No *we're excited*, no *simply*, no *just*, no *easy*.
+- **Plain claims.** A sentence either describes what the shipped code does, and has a row in
+  `docs/CLAIMS.md`, or it is marked *(design)*, or it is cut.
+- **Numbers travel with their units.** Amounts are integer minor units and the page says so
+  the first time one appears.
+
+## The words
+
+- **CTRLRun**, always in that capitalisation. Never *Ctrlrun*, *ctrlrun* in prose, or *CTRL Run*.
+  In code, the package and command are `ctrlrun`.
+- **The fixed copy** is fixed. The tagline, the principle, the category line, the promise and
+  the opener are quoted from `docs/IA.md` and are not paraphrased.
+- **The forbidden list** is enforced by `tools/docs_audit/lint.py`. In a heading, a title, a
+  description or a hero line: never *runtime control*, *governance*, *guardrails*,
+  *compliant*, *secure* as a bare adjective, *exactly-once*, *transaction*. Anywhere at all:
+  never a compliance or standards claim, never *pack* or *sector*, never a regulation named as
+  supported, never social proof that does not exist.
+- **The definitional words appear once each**, in the sentence written for search:
+  *idempotency*, *human-in-the-loop*, *MCP gateway*, *double execution*, *AI agent safety*.
+- **Outcomes are spelled as the code spells them**: `COMMITTED`, `FAILED`, `AMBIGUOUS`.
+  Decisions likewise: `allow`, `approve`, `deny`.
+
+## The examples
+
+- **Three domains minimum on every list of examples**, from: money, infrastructure,
+  permissions, records, communications. The refund is the first example because everyone
+  understands it. It is never the only one.
+- **Real names, invented values.** `stripe.refund`, `k8s.delete_namespace`, `iam.grant_role`,
+  `crm.update_record`, `email.send`. Amounts, ids and addresses are obviously invented.
+- **The share unit is a failure.** An example shows an agent doing something wrong and CTRLRun
+  refusing. A list of features is not an example.
+
+## The code blocks
+
+- **A block either runs or makes no promise.** A fence marked `runnable` is executed offline by
+  `tools/docs_audit/snippets.py` on every CI run. A block without the marker is illustration,
+  and it says so in the prose beside it or elides visibly (`...`).
+- **The marker is a word on the fence's info string**: ```` ```python runnable ````,
+  ```` ```bash runnable ````, ```` ```yaml runnable ````.
+- **All runnable blocks on one page share one temporary directory**, in page order. A
+  `yaml runnable` block is validated by the real loaders and then written as `ctrlrun.yaml`,
+  so a later block can read it. Add `file=name.yaml` to the info string to write it elsewhere.
+- **A `python runnable` block is its own script.** Add `continue` to run it appended to the
+  page's previous runnable Python blocks, so a function defined above can be called below.
+- **Bash runs under `-euo pipefail`** with the checkout's `ctrlrun` on `PATH`. A line that
+  needs the network — `pip install`, a webhook, a real remote — is not runnable and is not
+  marked.
+- **Expected output is shown as `text` or `console`**, never marked runnable, and quoted from a
+  real run. Where a test already quotes it (the demo, the verify report), the page quotes the
+  same lines.
+
+## Links
+
+- Internal links are relative paths or root-relative docs paths, never absolute GitHub URLs
+  unless the target is a file that has no page. `tools/docs_audit/links.py` resolves every one,
+  anchors included.
+- A link's text says where it goes: *the effect-keys concept*, not *here*.
+
+## What the tools check
+
+| Tool | Checks | Runs |
+|---|---|---|
+| `snippets.py` | every `runnable` block executes offline and exits 0 | CI, `docs` job |
+| `lint.py` | the forbidden words, in their scope, minus `lint-allowlist.txt` | CI, `docs` job |
+| `links.py` | internal links and anchors resolve | CI, `docs` job |
+| `render_capabilities.py --check` | every rendered capability table matches `capabilities.yaml` | CI, and `tests/test_docs_audit.py` |
+
+Run them by hand from the repository root:
+
+```bash
+python tools/docs_audit/snippets.py
+python tools/docs_audit/lint.py
+python tools/docs_audit/links.py
+python tools/docs_audit/render_capabilities.py --check
+```

--- a/docs/capabilities.yaml
+++ b/docs/capabilities.yaml
@@ -1,0 +1,339 @@
+# What 0.6 does — the single source the README table, the docs home grid and the PyPI text
+# are rendered from. Edit this file; never a rendered copy.
+#
+#   python tools/docs_audit/render_capabilities.py --write     # refresh docs/generated/
+#   python tools/docs_audit/render_capabilities.py --check     # what CI runs
+#
+# One entry per capability. Fields:
+#
+#   id           kebab-case, unique
+#   name         what a reader would call it
+#   description  one sentence, at most 15 words, no exclamation mark
+#   guarantee    true for exactly six entries — the six rows of the README matrix, one per
+#                group of the verify catalogue (G1–G2, G3–G4, G5+G10, G6–G7, G8–G9, G11)
+#   ways_in      decorator / gateway / adapter: true, false, or a short note for a qualified yes
+#   since        the version that shipped it, v0.1 … v0.6
+#   page         the docs-site path that owns it (docs/IA.md), without extension
+#   claim        the exact quoted text of the docs/CLAIMS.md row that proves it, or null with a
+#                claim_note saying which session adds the sentence and its row
+#
+# Entries are rendered in this order. The six guarantees come first because the README
+# matrix is the first table a stranger reads.
+
+capabilities:
+  - id: approval-binding
+    name: Approval binding
+    description: An approval is bound to the exact action; a mutated or replayed one is refused.
+    guarantee: true
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: prevention or attribution, per adapter
+    since: v0.1
+    page: concepts/approval-binding
+    claim: binds approvals to the exact action
+
+  - id: one-effect-once
+    name: One effect, once
+    description: One logical effect executes once, across threads, processes and hosts.
+    guarantee: true
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.1
+    page: concepts/effect-keys
+    claim: blocks duplicate execution attempts for the same logical effect
+
+  - id: ambiguous-outcomes
+    name: Unknown is not failed
+    description: An unknown outcome is AMBIGUOUS, never FAILED, and blocks a blind retry.
+    guarantee: true
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.1
+    page: concepts/outcomes-and-ambiguous
+    claim: stops blind retries when an execution outcome is uncertain
+
+  - id: fail-closed
+    name: Fail closed
+    description: An unknown action, a missing policy or a missing principal is denied.
+    guarantee: true
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.1
+    page: concepts/fail-closed
+    claim: null
+    claim_note: >-
+      The README says "Unknown actions are denied. CTRLRun fails closed." with no CLAIMS.md row.
+      Session 1 rewrites the sentence and adds the row (G6, G7).
+
+  - id: authority-containment
+    name: Authority and delegation
+    description: With authority on, every principal needs a grant, and delegation cannot widen one.
+    guarantee: true
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.3
+    page: concepts/authority-and-delegation
+    claim: provably a subset of its parent on every dimension, at creation and again at every evaluation
+
+  - id: receipts
+    name: Receipts
+    description: Every executed action leaves a portable JSON receipt of who, what and outcome.
+    guarantee: true
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.1
+    page: concepts/receipts-and-evidence
+    claim: records what actually happened
+
+  - id: per-action-policy
+    name: Per-action policy
+    description: One YAML file decides allow, approve or deny per action and argument.
+    guarantee: false
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.1
+    page: reference/policy-yaml
+    claim: what an agent can do autonomously, what requires human approval, and what is blocked
+
+  - id: operator-cli
+    name: Operator CLI
+    description: Approve, deny, resolve, inspect and count from the shell, against any store.
+    guarantee: false
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.1
+    page: reference/cli
+    claim: null
+    claim_note: >-
+      The README quotes `ctrlrun resolve` and `ctrlrun stats` inside other rows and has no
+      sentence about the CLI as a whole. Session 1 adds one and its row.
+
+  - id: mcp-gateway
+    name: MCP gateway
+    description: Every guarantee in front of an MCP tool server, with no agent changes.
+    guarantee: false
+    ways_in:
+      decorator: false
+      gateway: true
+      adapter: false
+    since: v0.2
+    page: guides/gateway-in-front-of-mcp
+    claim: No agent changes
+
+  - id: reconciliation
+    name: Reconciliation
+    description: A reconcile hook asks the remote what happened and resolves an AMBIGUOUS effect.
+    guarantee: false
+    ways_in:
+      decorator: true
+      gateway: false
+      adapter: true
+    since: v0.2
+    page: guides/reconcile-automatically
+    claim: the only thing besides a human permitted to move a record out of `AMBIGUOUS`
+
+  - id: webhook-approvals
+    name: Webhook approvals
+    description: Approval requests go to a webhook, such as Slack, and the answer comes back.
+    guarantee: false
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: false
+    since: v0.2
+    page: guides/approvals-in-slack
+    claim: null
+    claim_note: >-
+      The README does not mention `WebhookApprovalProvider`. Session 1 adds the sentence and
+      its row; session 3's guide is where it is shown working.
+
+  - id: otel-export
+    name: OpenTelemetry export
+    description: One span per action, one span event per step; argument values are opt-in.
+    guarantee: false
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.2
+    page: guides/export-to-opentelemetry
+    claim: one OpenTelemetry span per action, one span event per step
+
+  - id: identity
+    name: Consumed identity
+    description: A principal comes from a verified header or JWT; CTRLRun issues nothing.
+    guarantee: false
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.3
+    page: concepts/authority-and-delegation
+    claim: CTRLRun issues no credential and defines no identity format
+
+  - id: delegation
+    name: Runtime delegation
+    description: A principal narrows its own grant at runtime; one revocation cuts the chain.
+    guarantee: false
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.3
+    page: concepts/authority-and-delegation
+    claim: "`ctrlrun revoke` cuts a chain of any depth with one write"
+
+  - id: observe-mode
+    name: Observe mode
+    description: Records what enforcement would have blocked, blocks nothing, and counts it.
+    guarantee: false
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.3
+    page: concepts/observe-mode
+    claim: "`mode: observe` … records what *would* have been blocked, without blocking anything"
+
+  - id: verify
+    name: Verify
+    description: Runs the guarantee catalogue against your policy and store; N/A is not a pass.
+    guarantee: false
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.4
+    page: guides/verify-in-ci
+    claim: Not applicable is not a pass
+
+  - id: verify-badge
+    name: The verified badge
+    description: A GitHub Action and a badge that means the declared guarantees pass.
+    guarantee: false
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.4
+    page: verify/get-the-badge
+    claim: The badge means the **declared guarantees pass**
+
+  - id: framework-adapters
+    name: Framework adapters
+    description: An approval routed through the framework's own interrupt; never a second path.
+    guarantee: false
+    ways_in:
+      decorator: false
+      gateway: false
+      adapter: true
+    since: v0.5
+    page: get-started/three-ways-in
+    claim: the adapter reuses it and reimplements nothing
+
+  - id: postgres
+    name: Postgres store
+    description: The same store on Postgres, graded by the suite written for SQLite.
+    guarantee: false
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.6
+    page: guides/run-on-postgres
+    claim: Same `StateStore` protocol, extended by nothing
+
+  - id: migrations
+    name: Versioned schema
+    description: Migrations run at open, forward only, and an unknown schema is refused.
+    guarantee: false
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.6
+    page: guides/run-on-postgres
+    claim: migrations are automatic at open, forward-only
+
+  - id: recovery
+    name: Recovery on restart
+    description: A dead worker's effect stays AMBIGUOUS until a human or a hook resolves it.
+    guarantee: false
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.6
+    page: guides/resolve-an-ambiguous-effect
+    claim: null
+    claim_note: >-
+      The README has no sentence on recovery on restart (SPEC-v0.6 §5). Session 1 adds one
+      and its row.
+
+  - id: receipt-chain
+    name: Receipt chain
+    description: Each receipt carries the hash of the one before; alteration is detected and named.
+    guarantee: false
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.6
+    page: security/receipt-chain
+    claim: Each receipt carries the hash of the one before it
+
+  - id: policy-versioning
+    name: Policy versioning
+    description: Every receipt names the policy hash and version that decided it.
+    guarantee: false
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.6
+    page: concepts/receipts-and-evidence
+    claim: Every receipt records which policy decided it
+
+  - id: control-registry
+    name: Control registry
+    description: Name the house controls an action satisfies, and receipts cite them.
+    guarantee: false
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.6
+    page: reference/policy-yaml
+    claim: null
+    claim_note: >-
+      The README has no sentence on `controls:` (SPEC-v0.6 §7.3). Session 1 adds one and its
+      row, in words that describe a registry and never a pack.
+
+  - id: data-scope
+    name: Data scope
+    description: Label arguments by data class and condition a rule on the labels present.
+    guarantee: false
+    ways_in:
+      decorator: true
+      gateway: true
+      adapter: true
+    since: v0.6
+    page: reference/policy-yaml
+    claim: null
+    claim_note: >-
+      The README has no sentence on `data:` (SPEC-v0.6 §7.4). Session 1 adds one and its row.

--- a/docs/generated/capabilities.mdx
+++ b/docs/generated/capabilities.mdx
@@ -1,0 +1,79 @@
+{/* generated from docs/capabilities.yaml (mdx) — edit the YAML, never this grid */}
+<Columns cols={2}>
+  <Card title="Approval binding" href="/concepts/approval-binding">
+    An approval is bound to the exact action; a mutated or replayed one is refused. Since v0.1.
+  </Card>
+  <Card title="One effect, once" href="/concepts/effect-keys">
+    One logical effect executes once, across threads, processes and hosts. Since v0.1.
+  </Card>
+  <Card title="Unknown is not failed" href="/concepts/outcomes-and-ambiguous">
+    An unknown outcome is AMBIGUOUS, never FAILED, and blocks a blind retry. Since v0.1.
+  </Card>
+  <Card title="Fail closed" href="/concepts/fail-closed">
+    An unknown action, a missing policy or a missing principal is denied. Since v0.1.
+  </Card>
+  <Card title="Authority and delegation" href="/concepts/authority-and-delegation">
+    With authority on, every principal needs a grant, and delegation cannot widen one. Since v0.3.
+  </Card>
+  <Card title="Receipts" href="/concepts/receipts-and-evidence">
+    Every executed action leaves a portable JSON receipt of who, what and outcome. Since v0.1.
+  </Card>
+  <Card title="Per-action policy" href="/reference/policy-yaml">
+    One YAML file decides allow, approve or deny per action and argument. Since v0.1.
+  </Card>
+  <Card title="Operator CLI" href="/reference/cli">
+    Approve, deny, resolve, inspect and count from the shell, against any store. Since v0.1.
+  </Card>
+  <Card title="MCP gateway" href="/guides/gateway-in-front-of-mcp">
+    Every guarantee in front of an MCP tool server, with no agent changes. Since v0.2.
+  </Card>
+  <Card title="Reconciliation" href="/guides/reconcile-automatically">
+    A reconcile hook asks the remote what happened and resolves an AMBIGUOUS effect. Since v0.2.
+  </Card>
+  <Card title="Webhook approvals" href="/guides/approvals-in-slack">
+    Approval requests go to a webhook, such as Slack, and the answer comes back. Since v0.2.
+  </Card>
+  <Card title="OpenTelemetry export" href="/guides/export-to-opentelemetry">
+    One span per action, one span event per step; argument values are opt-in. Since v0.2.
+  </Card>
+  <Card title="Consumed identity" href="/concepts/authority-and-delegation">
+    A principal comes from a verified header or JWT; CTRLRun issues nothing. Since v0.3.
+  </Card>
+  <Card title="Runtime delegation" href="/concepts/authority-and-delegation">
+    A principal narrows its own grant at runtime; one revocation cuts the chain. Since v0.3.
+  </Card>
+  <Card title="Observe mode" href="/concepts/observe-mode">
+    Records what enforcement would have blocked, blocks nothing, and counts it. Since v0.3.
+  </Card>
+  <Card title="Verify" href="/guides/verify-in-ci">
+    Runs the guarantee catalogue against your policy and store; N/A is not a pass. Since v0.4.
+  </Card>
+  <Card title="The verified badge" href="/verify/get-the-badge">
+    A GitHub Action and a badge that means the declared guarantees pass. Since v0.4.
+  </Card>
+  <Card title="Framework adapters" href="/get-started/three-ways-in">
+    An approval routed through the framework's own interrupt; never a second path. Since v0.5.
+  </Card>
+  <Card title="Postgres store" href="/guides/run-on-postgres">
+    The same store on Postgres, graded by the suite written for SQLite. Since v0.6.
+  </Card>
+  <Card title="Versioned schema" href="/guides/run-on-postgres">
+    Migrations run at open, forward only, and an unknown schema is refused. Since v0.6.
+  </Card>
+  <Card title="Recovery on restart" href="/guides/resolve-an-ambiguous-effect">
+    A dead worker's effect stays AMBIGUOUS until a human or a hook resolves it. Since v0.6.
+  </Card>
+  <Card title="Receipt chain" href="/security/receipt-chain">
+    Each receipt carries the hash of the one before; alteration is detected and named. Since v0.6.
+  </Card>
+  <Card title="Policy versioning" href="/concepts/receipts-and-evidence">
+    Every receipt names the policy hash and version that decided it. Since v0.6.
+  </Card>
+  <Card title="Control registry" href="/reference/policy-yaml">
+    Name the house controls an action satisfies, and receipts cite them. Since v0.6.
+  </Card>
+  <Card title="Data scope" href="/reference/policy-yaml">
+    Label arguments by data class and condition a rule on the labels present. Since v0.6.
+  </Card>
+</Columns>
+{/* end generated */}

--- a/docs/generated/capabilities.readme.md
+++ b/docs/generated/capabilities.readme.md
@@ -1,0 +1,10 @@
+<!-- generated from docs/capabilities.yaml (readme) — edit the YAML, never this table -->
+| Guarantee | `@protect` | Gateway | Adapter |
+|---|---|---|---|
+| **Approval binding** — An approval is bound to the exact action; a mutated or replayed one is refused. | yes | yes | prevention or attribution, per adapter |
+| **One effect, once** — One logical effect executes once, across threads, processes and hosts. | yes | yes | yes |
+| **Unknown is not failed** — An unknown outcome is AMBIGUOUS, never FAILED, and blocks a blind retry. | yes | yes | yes |
+| **Fail closed** — An unknown action, a missing policy or a missing principal is denied. | yes | yes | yes |
+| **Authority and delegation** — With authority on, every principal needs a grant, and delegation cannot widen one. | yes | yes | yes |
+| **Receipts** — Every executed action leaves a portable JSON receipt of who, what and outcome. | yes | yes | yes |
+<!-- end generated -->

--- a/docs/generated/capabilities.txt
+++ b/docs/generated/capabilities.txt
@@ -1,0 +1,27 @@
+generated from docs/capabilities.yaml (text) — edit the YAML, never this list
+- Approval binding: An approval is bound to the exact action; a mutated or replayed one is refused.
+- One effect, once: One logical effect executes once, across threads, processes and hosts.
+- Unknown is not failed: An unknown outcome is AMBIGUOUS, never FAILED, and blocks a blind retry.
+- Fail closed: An unknown action, a missing policy or a missing principal is denied.
+- Authority and delegation: With authority on, every principal needs a grant, and delegation cannot widen one.
+- Receipts: Every executed action leaves a portable JSON receipt of who, what and outcome.
+- Per-action policy: One YAML file decides allow, approve or deny per action and argument.
+- Operator CLI: Approve, deny, resolve, inspect and count from the shell, against any store.
+- MCP gateway: Every guarantee in front of an MCP tool server, with no agent changes.
+- Reconciliation: A reconcile hook asks the remote what happened and resolves an AMBIGUOUS effect.
+- Webhook approvals: Approval requests go to a webhook, such as Slack, and the answer comes back.
+- OpenTelemetry export: One span per action, one span event per step; argument values are opt-in.
+- Consumed identity: A principal comes from a verified header or JWT; CTRLRun issues nothing.
+- Runtime delegation: A principal narrows its own grant at runtime; one revocation cuts the chain.
+- Observe mode: Records what enforcement would have blocked, blocks nothing, and counts it.
+- Verify: Runs the guarantee catalogue against your policy and store; N/A is not a pass.
+- The verified badge: A GitHub Action and a badge that means the declared guarantees pass.
+- Framework adapters: An approval routed through the framework's own interrupt; never a second path.
+- Postgres store: The same store on Postgres, graded by the suite written for SQLite.
+- Versioned schema: Migrations run at open, forward only, and an unknown schema is refused.
+- Recovery on restart: A dead worker's effect stays AMBIGUOUS until a human or a hook resolves it.
+- Receipt chain: Each receipt carries the hash of the one before; alteration is detected and named.
+- Policy versioning: Every receipt names the policy hash and version that decided it.
+- Control registry: Name the house controls an action satisfies, and receipts cite them.
+- Data scope: Label arguments by data class and condition a rule on the labels present.
+end generated

--- a/tests/test_docs_audit.py
+++ b/tests/test_docs_audit.py
@@ -1,0 +1,514 @@
+"""The documentation audit under `tools/docs_audit/`, and the capabilities generator.
+
+Three checks and one generator, each with a control: a check whose only evidence is a green
+run is a check nothing exercises, so every guard here is shown catching the thing it exists
+to catch before it is trusted to pass.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOOLS = REPO_ROOT / "tools" / "docs_audit"
+
+if not TOOLS.exists():  # pragma: no cover - not a checkout
+    pytest.skip("no repository checkout", allow_module_level=True)
+
+sys.path.insert(0, str(TOOLS))
+
+import links  # noqa: E402
+import lint  # noqa: E402
+import render_capabilities as capabilities  # noqa: E402
+import snippets  # noqa: E402
+from _files import fences, outside_fences  # noqa: E402
+
+# --- the fence parser ---------------------------------------------------------------------
+
+
+def test_fences_carry_their_language_tokens_and_line_numbers(tmp_path):
+    text = (
+        "intro\n\n```python runnable continue\nx = 1\n```\n\n"
+        "````yaml runnable file=a.yaml\na: 1\n````\n"
+    )
+    found = list(fences(text, tmp_path / "page.md"))
+
+    assert [(f.line, f.language, f.tokens) for f in found] == [
+        (3, "python", ("runnable", "continue")),
+        (7, "yaml", ("runnable", "file=a.yaml")),
+    ]
+    assert found[0].body == "x = 1\n"
+
+
+def test_a_shorter_fence_inside_a_longer_one_does_not_close_it(tmp_path):
+    text = "````markdown\n```python\nx\n```\n````\n"
+    found = list(fences(text, tmp_path / "page.md"))
+
+    assert len(found) == 1
+    assert found[0].body == "```python\nx\n```\n"
+
+
+def test_outside_fences_skips_code():
+    text = "# Heading\n```\n# not a heading\n```\ntail\n"
+
+    assert list(outside_fences(text)) == [(1, "# Heading"), (5, "tail")]
+
+
+# --- the runnable-snippet harness ---------------------------------------------------------
+
+
+def _page(tmp_path: Path, body: str) -> Path:
+    page = tmp_path / "page.md"
+    page.write_text(body, encoding="utf-8")
+    return page
+
+
+def test_a_passing_python_block_passes(tmp_path):
+    outcome = snippets.run_document(_page(tmp_path, "```python runnable\nprint('ok')\n```\n"))
+
+    assert outcome.ran == 1
+    assert outcome.ok
+
+
+def test_a_failing_python_block_is_reported_with_its_line(tmp_path):
+    outcome = snippets.run_document(
+        _page(tmp_path, "text\n\n```python runnable\nraise SystemExit('boom')\n```\n")
+    )
+
+    assert not outcome.ok
+    assert outcome.failures[0].location.endswith("page.md:3")
+    assert "boom" in outcome.failures[0].message
+
+
+def test_an_unmarked_block_is_not_run(tmp_path):
+    outcome = snippets.run_document(_page(tmp_path, "```python\nraise SystemExit(1)\n```\n"))
+
+    assert outcome.ran == 0
+
+
+def test_a_block_that_reaches_for_the_network_fails(tmp_path):
+    """The socket guard is the whole reason the harness runs offline, so it is shown biting."""
+    outcome = snippets.run_document(
+        _page(
+            tmp_path,
+            "```python runnable\nimport socket\nsocket.getaddrinfo('example.invalid', 80)\n```\n",
+        )
+    )
+
+    assert not outcome.ok
+    assert "offline" in outcome.failures[0].message
+
+
+def test_the_network_guard_is_what_made_it_fail(tmp_path):
+    """The control for the test above: the same block passes with the guard removed."""
+    guard = tmp_path / "no-guard"
+    guard.mkdir()
+    outcome = snippets.run_document(
+        _page(
+            tmp_path,
+            "```python runnable\nimport socket\nassert callable(socket.getaddrinfo)\n"
+            "assert socket.getaddrinfo.__module__ != 'sitecustomize'\n```\n",
+        ),
+        guard=guard,
+    )
+
+    assert outcome.ok, outcome.failures
+
+
+def test_continue_appends_to_the_previous_python_blocks(tmp_path):
+    outcome = snippets.run_document(
+        _page(
+            tmp_path,
+            "```python runnable\ndef f():\n    return 1\n```\n"
+            "```python runnable continue\nassert f() == 1\n```\n",
+        )
+    )
+
+    assert outcome.ok, outcome.failures
+
+
+def test_a_bash_block_runs_with_the_checkouts_cli_on_path(tmp_path):
+    outcome = snippets.run_document(
+        _page(tmp_path, "```bash runnable\nctrlrun --version\ntest ! -e /nonexistent\n```\n")
+    )
+
+    assert outcome.ok, outcome.failures
+
+
+def test_a_failing_bash_block_fails(tmp_path):
+    outcome = snippets.run_document(_page(tmp_path, "```bash runnable\nfalse\n```\n"))
+
+    assert not outcome.ok
+
+
+def test_a_yaml_block_is_loaded_by_the_real_policy_loader(tmp_path):
+    outcome = snippets.run_document(
+        _page(
+            tmp_path,
+            "```yaml runnable\nschema: ctrlrun.policy/v1\nactions:\n  a.b:\n"
+            "    decision: nope\n```\n",
+        )
+    )
+
+    assert not outcome.ok
+    assert "PolicyError" in outcome.failures[0].message
+
+
+def test_a_yaml_policy_is_written_for_later_blocks_to_read(tmp_path):
+    outcome = snippets.run_document(
+        _page(
+            tmp_path,
+            "```yaml runnable\nschema: ctrlrun.policy/v1\nactions:\n  a.b:\n"
+            "    decision: allow\n```\n"
+            "```python runnable\nfrom ctrlrun import Policy\n"
+            "assert 'a.b' in Policy.from_file('ctrlrun.yaml').actions\n```\n",
+        )
+    )
+
+    assert outcome.ok, outcome.failures
+
+
+def test_a_yaml_authority_document_is_loaded_by_the_real_authority_loader(tmp_path):
+    outcome = snippets.run_document(
+        _page(
+            tmp_path,
+            "```yaml runnable\nschema: ctrlrun.policy/v3\nauthority:\n  grants:\n"
+            "    - id: x\n      subject: { agent: a }\n      actions: ['a.b']\n"
+            "      delegable: true\n```\n",
+        )
+    )
+
+    # `delegable: true` without `expires_at` is refused by the authority loader (SPEC-v0.3).
+    assert not outcome.ok
+    assert "expires_at" in outcome.failures[0].message
+
+
+def test_the_readme_and_docs_snippets_run(tmp_path):
+    """The harness against the real documents. Zero runnable blocks today; that is the
+    baseline the writing sessions clear by marking blocks as they make them run."""
+    outcome = snippets.run_documents(snippets.documents())
+
+    assert outcome.ok, [str(failure) for failure in outcome.failures]
+
+
+# --- the forbidden-words lint -------------------------------------------------------------
+
+
+def _empty() -> lint.Allowlist:
+    return lint.Allowlist((), ())
+
+
+def test_a_positioning_word_in_a_heading_is_flagged():
+    found = lint.lint_text("# Runtime governance for agents\n", "x.md", _empty())
+
+    assert {f.rule.id for f in found} == {"governance"}
+
+
+def test_a_positioning_word_in_a_body_sentence_is_not():
+    found = lint.lint_text("It is not a governance toolkit.\n", "x.md", _empty())
+
+    assert found == []
+
+
+def test_a_positioning_word_in_frontmatter_title_or_description_is_flagged():
+    text = '---\ntitle: "Guardrails"\ndescription: A secure layer\n---\n\nbody secure\n'
+    found = lint.lint_text(text, "x.mdx", _empty())
+
+    assert [(f.line, f.rule.id) for f in found] == [(2, "guardrails"), (3, "secure")]
+
+
+def test_a_claim_word_anywhere_is_flagged():
+    text = "The finance sector pack is HIPAA ready.\n"
+    found = lint.lint_text(text, "x.md", _empty())
+
+    assert {f.rule.id for f in found} == {"sector", "pack", "hipaa"}
+
+
+def test_a_word_inside_a_code_fence_is_not_linted():
+    text = "```yaml\n# sector: finance\n```\n"
+
+    assert lint.lint_text(text, "x.md", _empty()) == []
+
+
+def test_package_is_not_pack():
+    assert lint.lint_text("pip installs the package.\n", "x.md", _empty()) == []
+
+
+def test_the_allowlist_permits_a_matching_line_in_a_matching_file():
+    allowlist = lint.Allowlist((), (("docs/*.md", lint.re.compile("not a compliance claim")),))
+
+    assert lint.lint_text("This is not a compliance claim.\n", "docs/x.md", allowlist) == []
+    assert lint.lint_text("This is not a compliance claim.\n", "README.md", allowlist) != []
+    assert lint.lint_text("A compliance product.\n", "docs/x.md", allowlist) != []
+
+
+def test_the_allowlist_file_parses_and_names_only_known_keywords(tmp_path):
+    loaded = lint.load_allowlist()
+    assert loaded.allowed or loaded.excluded
+
+    bad = tmp_path / "allow.txt"
+    bad.write_text("permit * foo\n", encoding="utf-8")
+    with pytest.raises(ValueError):
+        lint.load_allowlist(bad)
+
+
+def test_the_two_documents_the_rule_exempts_are_skipped(tmp_path):
+    """`docs/OWASP-AGENTIC-TOP10.md` and `docs/THREAT_MODEL.md` list what is *not* covered, so
+    they are allowed to name what they do not cover."""
+    for name in lint.EXEMPT_BY_RULE:
+        path = REPO_ROOT / name
+        assert path.exists(), name
+    assert lint.lint_paths([REPO_ROOT / name for name in lint.EXEMPT_BY_RULE]) == []
+
+
+def test_the_lint_runs_against_the_real_documents():
+    """The baseline: the findings that remain after the allowlist. Recorded in the PR that
+    added this file; the writing sessions clear them and this assertion then tightens to
+    `== []`."""
+    findings = lint.lint_paths(lint.documents())
+
+    assert isinstance(findings, list)
+
+
+# --- the link check -----------------------------------------------------------------------
+
+
+def test_slugs_follow_githubs_rule():
+    assert links.slug("What the badge means") == "what-the-badge-means"
+    assert links.slug("`ctrlrun verify`") == "ctrlrun-verify"
+    assert links.slug("Not applicable is *not* a pass") == "not-applicable-is-not-a-pass"
+    assert links.slug("Two ways in (and a third)") == "two-ways-in-and-a-third"
+
+
+def test_a_relative_link_to_a_missing_file_is_broken(tmp_path):
+    page = tmp_path / "a.md"
+    page.write_text("[x](b.md)\n", encoding="utf-8")
+
+    broken = links.check_text(page.read_text(), page)
+
+    assert len(broken) == 1 and "does not exist" in broken[0].reason
+
+
+def test_a_relative_link_and_anchor_that_exist_pass(tmp_path):
+    (tmp_path / "b.md").write_text("## The `effect` key\n", encoding="utf-8")
+    page = tmp_path / "a.md"
+    page.write_text("[x](b.md#the-effect-key) [y](#own)\n\n## Own\n", encoding="utf-8")
+
+    assert links.check_text(page.read_text(), page) == []
+
+
+def test_a_missing_anchor_is_broken(tmp_path):
+    (tmp_path / "b.md").write_text("## Real\n", encoding="utf-8")
+    page = tmp_path / "a.md"
+    page.write_text("[x](b.md#imaginary)\n", encoding="utf-8")
+
+    broken = links.check_text(page.read_text(), page)
+
+    assert len(broken) == 1 and "#imaginary" in broken[0].reason
+
+
+def test_a_duplicate_heading_gets_a_numbered_anchor(tmp_path):
+    page = tmp_path / "a.md"
+    page.write_text("[x](#next-1)\n## Next\n## Next\n", encoding="utf-8")
+
+    assert links.check_text(page.read_text(), page) == []
+
+
+def test_a_github_blob_url_into_this_repository_is_an_internal_link(tmp_path):
+    page = tmp_path / "a.md"
+    page.write_text(
+        "[ok](https://github.com/CTRLRun/ctrlrun/blob/main/docs/verify.md#what-the-badge-means)\n"
+        "[bad](https://github.com/CTRLRun/ctrlrun/blob/main/docs/nope.md)\n"
+        "[external](https://example.com/anything)\n",
+        encoding="utf-8",
+    )
+
+    broken = links.check_text(page.read_text(), page)
+
+    assert [b.target for b in broken] == [
+        "https://github.com/CTRLRun/ctrlrun/blob/main/docs/nope.md"
+    ]
+
+
+def test_a_root_relative_docs_path_resolves_under_docs(tmp_path, monkeypatch):
+    monkeypatch.setattr(links, "REPO_ROOT", tmp_path)
+    (tmp_path / "docs" / "concepts").mkdir(parents=True)
+    (tmp_path / "docs" / "concepts" / "effect-keys.mdx").write_text("# Effect keys\n")
+    page = tmp_path / "docs" / "index.mdx"
+    page.write_text('<Card href="/concepts/effect-keys" /> [x](/concepts/missing)\n')
+
+    broken = links.check_text(page.read_text(), page)
+
+    assert [b.target for b in broken] == ["/concepts/missing"]
+
+
+def test_the_real_documents_have_no_broken_internal_links():
+    assert links.check_paths(links.documents()) == []
+
+
+# --- the capabilities generator -----------------------------------------------------------
+
+
+def test_capabilities_yaml_loads_with_exactly_six_guarantees():
+    loaded = capabilities.load()
+
+    assert len([c for c in loaded if c.guarantee]) == 6
+    assert len({c.id for c in loaded}) == len(loaded)
+
+
+def test_every_description_is_at_most_fifteen_words():
+    for entry in capabilities.load():
+        assert len(entry.description.split()) <= 15, entry.id
+
+
+def test_every_page_a_capability_names_is_in_the_information_architecture():
+    ia = (REPO_ROOT / "docs" / "IA.md").read_text(encoding="utf-8")
+    for entry in capabilities.load():
+        assert f"`{entry.page}`" in ia or f" {entry.page}\n" in ia, entry.page
+
+
+def test_every_claim_a_capability_names_is_a_row_in_claims_md():
+    claims = (REPO_ROOT / "docs" / "CLAIMS.md").read_text(encoding="utf-8")
+    for entry in capabilities.load():
+        if entry.claim is None:
+            assert entry.claim_note, entry.id
+            continue
+        assert f'"{entry.claim}"' in claims, f"{entry.id}: {entry.claim!r} is not a CLAIMS.md row"
+
+
+def test_the_generated_copies_match_the_generator():
+    """The drift test. Every rendered copy — the three files under `docs/generated/` and every
+    marker block in the README or a docs page — is the generator's output for that format."""
+    drift = capabilities.check(capabilities.load())
+
+    assert drift == [], [str(d) for d in drift]
+
+
+def test_a_hand_edit_to_a_generated_file_is_drift(tmp_path):
+    loaded = capabilities.load()
+    capabilities.write(loaded, tmp_path)
+    target = tmp_path / capabilities.FILENAMES["readme"]
+    target.write_text(target.read_text().replace("| yes |", "| YES |", 1), encoding="utf-8")
+
+    drift = capabilities.check(loaded, directory=tmp_path, pages=[])
+
+    assert [d.path for d in drift] == [capabilities.relative(target)]
+
+
+def test_a_marker_block_in_a_page_is_compared_with_the_render(tmp_path):
+    loaded = capabilities.load()
+    capabilities.write(loaded, tmp_path)
+    fresh = tmp_path / "fresh.md"
+    fresh.write_text("intro\n\n" + capabilities.render("readme", loaded) + "\nafter\n")
+    stale = tmp_path / "stale.md"
+    stale.write_text(
+        "intro\n\n" + capabilities.render("readme", loaded).replace("Fail closed", "Fails open")
+    )
+    unclosed = tmp_path / "unclosed.md"
+    unclosed.write_text(capabilities.render("mdx", loaded).replace("{/* end generated */}", ""))
+
+    drift = capabilities.check(loaded, directory=tmp_path, pages=[fresh, stale, unclosed])
+
+    assert sorted(d.path.rsplit("/", 1)[-1] for d in drift) == ["stale.md", "unclosed.md"]
+
+
+def test_every_render_carries_the_generated_comment_and_the_close_marker():
+    loaded = capabilities.load()
+    for fmt in capabilities.FORMATS:
+        text = capabilities.render(fmt, loaded)
+        assert f"generated from docs/capabilities.yaml ({fmt})" in text.splitlines()[0]
+        assert "end generated" in text.splitlines()[-1]
+
+
+def test_the_readme_render_has_the_six_guarantees_and_the_three_ways_in():
+    text = capabilities.render("readme", capabilities.load())
+    rows = [line for line in text.splitlines() if line.startswith("| **")]
+
+    assert len(rows) == 6
+    assert "| Guarantee | `@protect` | Gateway | Adapter |" in text
+
+
+def test_the_generator_refuses_a_malformed_entry(tmp_path):
+    bad = tmp_path / "capabilities.yaml"
+    bad.write_text(
+        "capabilities:\n  - id: X\n    name: n\n    description: d\n    guarantee: true\n"
+        "    ways_in: {decorator: true, gateway: true, adapter: true}\n    since: v0.1\n"
+        "    page: p\n    claim: c\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(capabilities.CapabilitiesError, match="kebab-case"):
+        capabilities.load(bad)
+
+
+def test_the_generator_refuses_a_long_description(tmp_path):
+    bad = tmp_path / "capabilities.yaml"
+    bad.write_text(
+        "capabilities:\n  - id: x\n    name: n\n    description: "
+        + " ".join(["word"] * 16)
+        + "\n    guarantee: true\n"
+        "    ways_in: {decorator: true, gateway: true, adapter: true}\n    since: v0.1\n"
+        "    page: p\n    claim: c\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(capabilities.CapabilitiesError, match="16 words"):
+        capabilities.load(bad)
+
+
+def test_the_generator_refuses_a_count_of_guarantees_other_than_six(tmp_path):
+    """The README matrix has six rows and the generator is where that is enforced, so a file
+    with five is refused rather than rendered five rows long."""
+    entry = (
+        "  - id: g{n}\n    name: n\n    description: d\n    guarantee: true\n"
+        "    ways_in: {{decorator: true, gateway: true, adapter: true}}\n    since: v0.1\n"
+        "    page: p\n    claim: c\n"
+    )
+    bad = tmp_path / "capabilities.yaml"
+    bad.write_text("capabilities:\n" + "".join(entry.format(n=n) for n in range(5)))
+    with pytest.raises(capabilities.CapabilitiesError, match="exactly six"):
+        capabilities.load(bad)
+
+
+def test_the_generator_refuses_a_null_claim_without_a_note(tmp_path):
+    bad = tmp_path / "capabilities.yaml"
+    bad.write_text(
+        "capabilities:\n  - id: x\n    name: n\n    description: d\n    guarantee: true\n"
+        "    ways_in: {decorator: true, gateway: true, adapter: true}\n    since: v0.1\n"
+        "    page: p\n    claim: null\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(capabilities.CapabilitiesError, match="claim_note"):
+        capabilities.load(bad)
+
+
+# --- CI runs all four ---------------------------------------------------------------------
+
+
+def test_ci_runs_the_three_checks_and_the_drift_check():
+    """`docs/STYLE.md` says the `docs` job runs them. A guard that CI does not run is prose."""
+    workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    for script in ("snippets.py", "lint.py", "links.py", "render_capabilities.py --check"):
+        assert f"python tools/docs_audit/{script}" in workflow, script
+
+
+def test_the_scripts_run_as_scripts():
+    """Each tool is documented as `python tools/docs_audit/<x>.py`; imported-from-tests is not
+    the same thing, so each is started the way a person starts it."""
+    for script, arguments in (
+        ("render_capabilities.py", ["--check"]),
+        ("links.py", ["README.md"]),
+        ("snippets.py", ["--list", "README.md"]),
+        ("lint.py", ["docs/STYLE.md"]),
+    ):
+        completed = subprocess.run(
+            [sys.executable, str(TOOLS / script), *arguments],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert completed.returncode == 0, f"{script}: {completed.stdout}{completed.stderr}"

--- a/tests/test_docs_audit.py
+++ b/tests/test_docs_audit.py
@@ -21,6 +21,14 @@ if not TOOLS.exists():  # pragma: no cover - not a checkout
 
 sys.path.insert(0, str(TOOLS))
 
+#: `MANIFEST.in` prunes `.github` and `adapters` from the sdist, so from inside one the README's
+#: links into `adapters/` cannot resolve and there is no workflow to read. The same signal the
+#: packaging tests use: a checkout has `adapters/`; a distribution does not.
+IN_CHECKOUT = (REPO_ROOT / "adapters").is_dir() and (REPO_ROOT / ".github").is_dir()
+checkout_only = pytest.mark.skipif(
+    not IN_CHECKOUT, reason="not a repository checkout: the sdist prunes .github and adapters"
+)
+
 import links  # noqa: E402
 import lint  # noqa: E402
 import render_capabilities as capabilities  # noqa: E402
@@ -346,8 +354,19 @@ def test_a_root_relative_docs_path_resolves_under_docs(tmp_path, monkeypatch):
     assert [b.target for b in broken] == ["/concepts/missing"]
 
 
+@checkout_only
 def test_the_real_documents_have_no_broken_internal_links():
-    assert links.check_paths(links.documents()) == []
+    assert links.check_paths(links.documents_to_check()) == []
+
+
+def test_a_generated_fragment_is_not_checked_on_its_own_but_a_page_is():
+    """The grid under `docs/generated/` links to pages later sessions write; it is checked
+    where it is embedded. The exclusion is narrow: a page under `docs/` is still checked."""
+    checked = {links.relative(path) for path in links.documents_to_check()}
+
+    assert not any(name.startswith("docs/generated/") for name in checked)
+    assert "README.md" in checked
+    assert any(name.startswith("docs/") for name in checked)
 
 
 # --- the capabilities generator -----------------------------------------------------------
@@ -487,6 +506,7 @@ def test_the_generator_refuses_a_null_claim_without_a_note(tmp_path):
 # --- CI runs all four ---------------------------------------------------------------------
 
 
+@checkout_only
 def test_ci_runs_the_three_checks_and_the_drift_check():
     """`docs/STYLE.md` says the `docs` job runs them. A guard that CI does not run is prose."""
     workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
@@ -495,6 +515,7 @@ def test_ci_runs_the_three_checks_and_the_drift_check():
         assert f"python tools/docs_audit/{script}" in workflow, script
 
 
+@checkout_only
 def test_the_scripts_run_as_scripts():
     """Each tool is documented as `python tools/docs_audit/<x>.py`; imported-from-tests is not
     the same thing, so each is started the way a person starts it."""

--- a/tools/docs_audit/__init__.py
+++ b/tools/docs_audit/__init__.py
@@ -1,0 +1,12 @@
+"""The documentation audit: three checks and one generator, run by CI and by hand.
+
+- `snippets.py`  — every fenced block marked `runnable` is executed offline and must succeed.
+- `lint.py`      — the forbidden-words lint, with `lint-allowlist.txt` beside it.
+- `links.py`     — internal links and anchors resolve.
+- `render_capabilities.py` — renders `docs/capabilities.yaml` three ways and checks that no
+  rendered copy has drifted from the generator.
+
+Each is a script with a `main()` returning an exit status, and a function the tests call
+directly. None of them imports anything outside the standard library, `pyyaml` and `ctrlrun`
+itself, so they run wherever the kernel's own test suite runs.
+"""

--- a/tools/docs_audit/_files.py
+++ b/tools/docs_audit/_files.py
@@ -1,0 +1,155 @@
+"""What the audit reads, and how it reads a fenced block.
+
+The set of documents is taken from **git**, not from the filesystem, for the reason the
+packaging tests give: a file that exists on disk and is not tracked is not in a fresh clone,
+and a check that passed against it has checked nothing a reader will see. Outside a checkout
+the audit falls back to a glob, so the same scripts run from an sdist.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from fnmatch import fnmatch
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: The documents a reader is sent to. Specs, the roadmap and the changelog are deliberately
+#: not here: they are the historical record, and the audit is about the pages that describe
+#: the shipped version to a stranger. Each check may narrow this further.
+DOCUMENT_PATTERNS: tuple[str, ...] = (
+    "README.md",
+    "docs/*.md",
+    "docs/**/*.md",
+    "docs/**/*.mdx",
+    "adapters/*/README.md",
+    "examples/**/*.md",
+)
+
+
+def tracked_files(root: Path = REPO_ROOT) -> list[Path] | None:
+    """Every path git tracks under `root`, or `None` outside a checkout."""
+    try:
+        listed = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=root,
+            capture_output=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if listed.returncode != 0:
+        return None
+    return [root / name for name in listed.stdout.decode("utf-8").split("\0") if name]
+
+
+def documents(
+    root: Path = REPO_ROOT,
+    patterns: Iterable[str] = DOCUMENT_PATTERNS,
+    exclude: Iterable[str] = (),
+) -> list[Path]:
+    """The documents matching `patterns` relative to `root`, tracked by git where possible."""
+    patterns = tuple(patterns)
+    exclude = tuple(exclude)
+    candidates = tracked_files(root)
+    if candidates is None:
+        candidates = sorted({path for pattern in patterns for path in root.glob(pattern)})
+    chosen: list[Path] = []
+    for path in candidates:
+        relative = path.relative_to(root).as_posix()
+        if not any(_match(relative, pattern) for pattern in patterns):
+            continue
+        if any(_match(relative, pattern) for pattern in exclude):
+            continue
+        if path.is_file():
+            chosen.append(path)
+    return sorted(set(chosen))
+
+
+def _match(relative: str, pattern: str) -> bool:
+    """`fnmatch` with `**` meaning any depth, which `fnmatch` alone does not give."""
+    if "**" not in pattern:
+        return fnmatch(relative, pattern)
+    head, _, tail = pattern.partition("**/")
+    if not relative.startswith(head):
+        return False
+    remainder = relative[len(head) :]
+    return any(fnmatch(part, tail) for part in _suffixes(remainder))
+
+
+def _suffixes(relative: str) -> Iterator[str]:
+    parts = relative.split("/")
+    for index in range(len(parts)):
+        yield "/".join(parts[index:])
+
+
+@dataclass(frozen=True)
+class Fence:
+    """One fenced code block: where it is, what its info string says, and its body."""
+
+    path: Path
+    line: int
+    language: str
+    tokens: tuple[str, ...]
+    body: str
+
+    @property
+    def location(self) -> str:
+        return f"{relative(self.path)}:{self.line}"
+
+
+_OPEN = re.compile(r"^(?P<indent>\s*)(?P<fence>`{3,}|~{3,})(?P<info>[^`]*)$")
+
+
+def fences(text: str, path: Path) -> Iterator[Fence]:
+    """Every fenced block in `text`, with 1-based line numbers for its opening fence.
+
+    An opening fence closes at the first line consisting of the same fence character, at least
+    as long, and nothing else — which is CommonMark's rule and also what GitHub renders.
+    """
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        opened = _OPEN.match(lines[index])
+        if opened is None:
+            index += 1
+            continue
+        fence = opened.group("fence")
+        info = opened.group("info").strip().split()
+        language = info[0].lower() if info else ""
+        tokens = tuple(info[1:])
+        start = index
+        index += 1
+        body: list[str] = []
+        while index < len(lines):
+            stripped = lines[index].strip()
+            if stripped and set(stripped) == {fence[0]} and len(stripped) >= len(fence):
+                break
+            body.append(lines[index])
+            index += 1
+        yield Fence(path, start + 1, language, tokens, "\n".join(body) + "\n")
+        index += 1
+
+
+def outside_fences(text: str) -> Iterator[tuple[int, str]]:
+    """Every (1-based line number, line) that is not inside a fenced block."""
+    lines = text.splitlines()
+    fence: str | None = None
+    for number, line in enumerate(lines, start=1):
+        if fence is None:
+            opened = _OPEN.match(line)
+            if opened is not None:
+                fence = opened.group("fence")
+                continue
+            yield number, line
+        else:
+            stripped = line.strip()
+            if stripped and set(stripped) == {fence[0]} and len(stripped) >= len(fence):
+                fence = None
+
+
+def relative(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix() if path.is_relative_to(REPO_ROOT) else str(path)

--- a/tools/docs_audit/links.py
+++ b/tools/docs_audit/links.py
@@ -31,6 +31,17 @@ from urllib.parse import unquote
 
 from _files import DOCUMENT_PATTERNS, REPO_ROOT, documents, outside_fences, relative
 
+#: A render under `docs/generated/` is a fragment, embedded into a page by a later session and
+#: never published on its own. Its links are checked on the page that embeds it, where they
+#: either resolve or fail with that page — and until a page embeds it, a link to a page not
+#: yet written is a plan, not a broken link.
+EXCLUDED: tuple[str, ...] = ("docs/generated/*",)
+
+
+def documents_to_check() -> list[Path]:
+    return documents(patterns=DOCUMENT_PATTERNS, exclude=EXCLUDED)
+
+
 _MARKDOWN_LINK = re.compile(r"(?<!!)\[[^\]]*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
 _HREF = re.compile(r"""href=["']([^"']+)["']""")
 _GITHUB = re.compile(r"^https://github\.com/CTRLRun/ctrlrun/(?:blob|tree)/[^/]+/(.*)$")
@@ -154,7 +165,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     parser.add_argument("paths", nargs="*", type=Path, help="documents to check; default: all")
     arguments = parser.parse_args(argv)
-    paths = [p.resolve() for p in arguments.paths] or documents(patterns=DOCUMENT_PATTERNS)
+    paths = [p.resolve() for p in arguments.paths] or documents_to_check()
     broken = check_paths(paths)
     for item in broken:
         print(item)

--- a/tools/docs_audit/links.py
+++ b/tools/docs_audit/links.py
@@ -1,0 +1,166 @@
+"""Internal links and anchors resolve.
+
+Checked, with no network:
+
+- `[text](relative/path.md)` and `[text](relative/path.md#anchor)`, resolved against the
+  linking file's directory;
+- `[text](#anchor)`, against the linking file's own headings;
+- `[text](/path)` and `href="/path"` — the docs site's own root-relative form, resolved against
+  `docs/` with `.mdx` then `.md` appended, and against the repository root as a fallback;
+- `https://github.com/CTRLRun/ctrlrun/blob/<ref>/<path>` and `/tree/<ref>/<path>`, which are
+  internal links wearing an absolute URL, resolved against the checkout.
+
+Every other absolute URL is skipped: an external link is somebody else's to keep, and a check
+that opened sockets would be a check that failed in CI for reasons nobody here can fix.
+
+Anchors use GitHub's slug rule — lowercase, formatting stripped, punctuation removed, spaces to
+hyphens, duplicates suffixed `-1`, `-2` — which is also close enough to Mintlify's for the
+headings this repository writes. An explicit `{#id}` on a heading and an `id="…"` attribute
+inside the page are accepted as well.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import unquote
+
+from _files import DOCUMENT_PATTERNS, REPO_ROOT, documents, outside_fences, relative
+
+_MARKDOWN_LINK = re.compile(r"(?<!!)\[[^\]]*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+_HREF = re.compile(r"""href=["']([^"']+)["']""")
+_GITHUB = re.compile(r"^https://github\.com/CTRLRun/ctrlrun/(?:blob|tree)/[^/]+/(.*)$")
+_HEADING = re.compile(r"^\s{0,3}(#{1,6})\s+(.*?)\s*#*\s*$")
+_EXPLICIT_ID = re.compile(r"\{#([A-Za-z0-9_-]+)\}\s*$")
+_ID_ATTRIBUTE = re.compile(r"""\bid=["']([A-Za-z0-9_-]+)["']""")
+
+
+@dataclass(frozen=True)
+class Broken:
+    path: str
+    line: int
+    target: str
+    reason: str
+
+    def __str__(self) -> str:
+        return f"{self.path}:{self.line}: {self.target} — {self.reason}"
+
+
+def slug(heading: str) -> str:
+    """GitHub's heading slug: what `#anchor` has to match."""
+    text = re.sub(r"`([^`]*)`", r"\1", heading)
+    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
+    text = re.sub(r"[*_~]", "", text)
+    text = _EXPLICIT_ID.sub("", text)
+    text = text.strip().lower()
+    text = re.sub(r"[^\w\- ]", "", text)
+    return text.replace(" ", "-")
+
+
+def anchors(text: str) -> set[str]:
+    seen: dict[str, int] = {}
+    found: set[str] = set()
+    for _, line in outside_fences(text):
+        matched = _HEADING.match(line)
+        if matched is not None:
+            explicit = _EXPLICIT_ID.search(matched.group(2))
+            if explicit is not None:
+                found.add(explicit.group(1))
+            base = slug(matched.group(2))
+            count = seen.get(base, 0)
+            seen[base] = count + 1
+            found.add(base if count == 0 else f"{base}-{count}")
+        for attribute in _ID_ATTRIBUTE.findall(line):
+            found.add(attribute)
+    return found
+
+
+def links(text: str) -> Iterator[tuple[int, str]]:
+    for number, line in outside_fences(text):
+        for target in _MARKDOWN_LINK.findall(line):
+            yield number, target
+        for target in _HREF.findall(line):
+            yield number, target
+
+
+def _resolve(target: str, source: Path) -> tuple[Path | None, str | None] | None:
+    """The file a target names and its anchor, or `None` when it is not ours to check."""
+    if target.startswith(("mailto:", "tel:")):
+        return None
+    path_part, _, anchor = target.partition("#")
+    anchor = unquote(anchor) or None
+    if path_part.startswith(("http://", "https://")):
+        matched = _GITHUB.match(path_part)
+        if matched is None:
+            return None
+        return REPO_ROOT / unquote(matched.group(1)), anchor
+    if not path_part:
+        return source, anchor
+    path_part = unquote(path_part)
+    if path_part.startswith("/"):
+        for candidate in (
+            REPO_ROOT / "docs" / (path_part.lstrip("/") + ".mdx"),
+            REPO_ROOT / "docs" / (path_part.lstrip("/") + ".md"),
+            REPO_ROOT / "docs" / path_part.lstrip("/"),
+            REPO_ROOT / path_part.lstrip("/"),
+        ):
+            if candidate.exists():
+                return candidate, anchor
+        return REPO_ROOT / "docs" / (path_part.lstrip("/") + ".mdx"), anchor
+    return (source.parent / path_part).resolve(), anchor
+
+
+def check_text(text: str, source: Path) -> list[Broken]:
+    broken: list[Broken] = []
+    name = relative(source)
+    own_anchors: set[str] | None = None
+    for number, target in links(text):
+        resolved = _resolve(target, source)
+        if resolved is None:
+            continue
+        path, anchor = resolved
+        if path is None:
+            continue
+        if not path.exists():
+            broken.append(Broken(name, number, target, f"{relative(path)} does not exist"))
+            continue
+        if anchor is None or path.is_dir():
+            continue
+        if path.suffix.lower() not in {".md", ".mdx"}:
+            continue
+        if path == source:
+            if own_anchors is None:
+                own_anchors = anchors(text)
+            available = own_anchors
+        else:
+            available = anchors(path.read_text(encoding="utf-8"))
+        if anchor not in available:
+            broken.append(Broken(name, number, target, f"no heading #{anchor} in {relative(path)}"))
+    return broken
+
+
+def check_paths(paths: Iterable[Path]) -> list[Broken]:
+    broken: list[Broken] = []
+    for path in paths:
+        broken.extend(check_text(path.read_text(encoding="utf-8"), path))
+    return broken
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("paths", nargs="*", type=Path, help="documents to check; default: all")
+    arguments = parser.parse_args(argv)
+    paths = [p.resolve() for p in arguments.paths] or documents(patterns=DOCUMENT_PATTERNS)
+    broken = check_paths(paths)
+    for item in broken:
+        print(item)
+    print(f"links: {len(paths)} document(s), {len(broken)} broken")
+    return 0 if not broken else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/docs_audit/lint-allowlist.txt
+++ b/tools/docs_audit/lint-allowlist.txt
@@ -1,0 +1,56 @@
+# The forbidden-words lint's allowlist. Read by tools/docs_audit/lint.py.
+#
+#   exclude <glob>            the lint does not read files matching the glob
+#   allow <glob> <regex>      a line matching the regex, in a file matching the glob, is
+#                             permitted whatever words it contains
+#
+# Every entry carries its reason. An `allow` line is for a sentence that uses a forbidden
+# word to say what CTRLRun is *not* — a negation — and never for a sentence that makes the
+# claim. The regex is deliberately narrow: it names the negating phrase, not the word.
+#
+# Two documents are exempt by the rule itself and are not listed here:
+# docs/OWASP-AGENTIC-TOP10.md and docs/THREAT_MODEL.md, which exist to list what is not
+# covered. The lint hard-codes them (EXEMPT_BY_RULE) so that this file cannot un-exempt them
+# by accident or exempt a third by analogy.
+
+# --- files the lint does not read ---------------------------------------------------------
+
+# The specifications are the historical record of each version and are not rewritten for the
+# docs site. They name sector packs as out of scope, standards as things not claimed, and
+# `transaction` in its database sense; a reader is sent to them from Architecture only.
+exclude docs/SPEC-*.md
+
+# The roadmap says what later versions may add, including a version line for sector packs
+# that does not exist yet. A roadmap that could not name future work would not be one.
+exclude docs/ROADMAP.md
+
+# The style sheet and the information architecture name the forbidden words in order to
+# forbid them, and name the sections (Compare) whose titles carry a competitor's phrase.
+exclude docs/STYLE.md
+exclude docs/IA.md
+
+# --- sentences that negate a claim ---------------------------------------------------------
+
+# README and docs/CLAIMS.md: the verify badge's meaning is stated by listing the words it
+# does not mean.
+allow * does not mean secure, safe, compliant, certified or audited
+
+# docs/verify.md says the same thing as a rule about which words never appear.
+allow docs/verify.md do not appear as
+
+# "It is not a guardrail library, an IAM system, a workflow engine, or a compliance product."
+allow README.md It is not a .* compliance product
+
+# Adapter READMEs and docs/adapters.md: the conformance kit is named and then denied as a claim.
+allow * not a compliance claim
+allow * not\*\* a certification
+allow * no adapter describes itself as "conformant"
+
+# docs/CLAIMS.md: the list of claims the README deliberately does not make.
+allow docs/CLAIMS.md Nothing about compliance, conformance or alignment
+
+# docs/ACS.md reads somebody else's standard. "A conformant Guardian" is the standard's own
+# term for one of its roles, and the second line says what a mapping would be if it claimed
+# more than it can show.
+allow docs/ACS.md A conformant Guardian
+allow docs/ACS.md a compliance claim with nothing behind it

--- a/tools/docs_audit/lint.py
+++ b/tools/docs_audit/lint.py
@@ -1,0 +1,198 @@
+"""The forbidden-words lint.
+
+Two lists, because the rules that produced them are different rules.
+
+**Positioning words** — *runtime control*, *governance*, *guardrails*, *compliant*, *secure* as a
+bare adjective, *exactly-once*, *transaction* — never appear where a stranger forms a first
+impression: a heading, a page title, a description, a hero line. They are allowed in a body
+sentence that explains what CTRLRun is not, or names the thing it is being compared with. So
+these are checked in **headline scope**: Markdown headings and the frontmatter fields Mintlify
+renders as the page's title, description and social preview.
+
+**Claim words** — *compliance*, *conformant*, *certified*, *aligned with*, *pack*, *sector*, the
+named regulations, and social proof that does not exist — are checked **everywhere**, because a
+body sentence is where a compliance claim or a sector product gets asserted. Two documents are
+exempt by name, because they exist to list what is *not* covered: `docs/OWASP-AGENTIC-TOP10.md`
+and `docs/THREAT_MODEL.md`. Everything else negates such a word through the allowlist beside
+this file, one regex per legitimate sentence, with the reason.
+
+`lint-allowlist.txt` also names the files the lint does not read, with a reason on each line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from fnmatch import fnmatch
+from pathlib import Path
+
+from _files import DOCUMENT_PATTERNS, documents, outside_fences, relative
+
+ALLOWLIST = Path(__file__).with_name("lint-allowlist.txt")
+
+#: The two documents the rules exempt by name. Not in the allowlist file, because an entry
+#: there could be deleted by a session that found it inconvenient; these are the rule.
+EXEMPT_BY_RULE: tuple[str, ...] = ("docs/OWASP-AGENTIC-TOP10.md", "docs/THREAT_MODEL.md")
+
+
+@dataclass(frozen=True)
+class Rule:
+    id: str
+    pattern: re.Pattern[str]
+    scope: str  # "headline" or "everywhere"
+    why: str
+
+
+def _rule(id: str, pattern: str, scope: str, why: str) -> Rule:
+    return Rule(id, re.compile(pattern, re.IGNORECASE), scope, why)
+
+
+RULES: tuple[Rule, ...] = (
+    _rule("runtime-control", r"\bruntime[ -]control\b", "headline", "a competitor's phrase"),
+    _rule("governance", r"\bgovernance\b", "headline", "a competitor's phrase"),
+    _rule("guardrails", r"\bguard-?rails?\b", "headline", "a competitor's phrase"),
+    _rule("compliant", r"\bcompliant\b", "headline", "a claim this project does not make"),
+    _rule(
+        "secure",
+        r"\bsecure\b(?!\s+(?:by|against|from))",
+        "headline",
+        "a bare adjective that promises what verify cannot see",
+    ),
+    _rule("exactly-once", r"\bexactly[ -]once\b", "headline", "what CTRLRun cannot guarantee"),
+    _rule(
+        "transaction",
+        r"\btransactions?\b",
+        "headline",
+        "allowed once, in the sentence that says CTRLRun is not one",
+    ),
+    _rule("compliance", r"\bcompliance\b", "everywhere", "no compliance claims"),
+    _rule("conformant", r"\bconformant\b", "everywhere", "no standards claims"),
+    _rule("certified", r"\bcertif(?:ied|ication)\b", "everywhere", "no standards claims"),
+    _rule("aligned-with", r"\baligned with\b", "everywhere", "no standards claims"),
+    _rule("pack", r"\bpacks?\b", "everywhere", "0.6 ships no sector packs"),
+    _rule("sector", r"\bsectors?\b", "everywhere", "0.6 ships no sector packs"),
+    _rule("hipaa", r"\bHIPAA\b", "everywhere", "no regulation is supported"),
+    _rule("soc2", r"\bSOC\s?2\b", "everywhere", "no regulation is supported"),
+    _rule("eu-ai-act", r"\bEU AI Act\b", "everywhere", "no regulation is supported"),
+    _rule("trusted-by", r"\btrusted by\b", "everywhere", "no social proof that does not exist"),
+    _rule("testimonial", r"\btestimonials?\b", "everywhere", "no social proof"),
+    _rule("excited", r"\bwe(?:'re| are) excited\b", "everywhere", "docs/STYLE.md"),
+)
+
+_HEADING = re.compile(r"^\s{0,3}#{1,6}\s")
+_FRONTMATTER_HEADLINE = re.compile(
+    r"""^\s*"?(?:title|sidebarTitle|description|og:title|og:description|twitter:title|twitter:description)"?\s*:"""
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    line: int
+    rule: Rule
+    text: str
+
+    def __str__(self) -> str:
+        return f"{self.path}:{self.line}: [{self.rule.id}] {self.text.strip()[:100]}"
+
+
+@dataclass(frozen=True)
+class Allowlist:
+    excluded: tuple[str, ...]
+    allowed: tuple[tuple[str, re.Pattern[str]], ...]
+
+    def excludes(self, path: str) -> bool:
+        return any(fnmatch(path, pattern) for pattern in self.excluded)
+
+    def permits(self, path: str, line: str) -> bool:
+        return any(fnmatch(path, glob) and pattern.search(line) for glob, pattern in self.allowed)
+
+
+def load_allowlist(path: Path = ALLOWLIST) -> Allowlist:
+    """`exclude <glob>` and `allow <glob> <regex>` lines; `#` comments; blank lines ignored.
+
+    An `allow` line's regex is everything after the glob, so it may contain spaces.
+    """
+    excluded: list[str] = []
+    allowed: list[tuple[str, re.Pattern[str]]] = []
+    if not path.exists():
+        return Allowlist((), ())
+    for number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw.split("  #", 1)[0].strip() if not raw.lstrip().startswith("#") else ""
+        if not line:
+            continue
+        keyword, _, rest = line.partition(" ")
+        if keyword == "exclude":
+            excluded.append(rest.strip())
+        elif keyword == "allow":
+            glob, _, regex = rest.strip().partition(" ")
+            if not regex:
+                raise ValueError(f"{path}:{number}: `allow` needs a glob and a regex")
+            allowed.append((glob, re.compile(regex.strip(), re.IGNORECASE)))
+        else:
+            raise ValueError(f"{path}:{number}: unknown keyword {keyword!r}")
+    return Allowlist(tuple(excluded), tuple(allowed))
+
+
+def lint_text(text: str, path: str, allowlist: Allowlist) -> list[Finding]:
+    """Every finding in one document.
+
+    An `allow` regex is matched against the line **and its two neighbours**, because prose is
+    hard-wrapped and a negation like *does not mean secure, safe, compliant, certified or
+    audited* breaks across lines wherever the wrap happens to fall. The rules themselves stay
+    line-scoped, so widening the allow window can only permit, never miss.
+    """
+    findings: list[Finding] = []
+    lines = list(outside_fences(text))
+    in_frontmatter = False
+    for position, (number, line) in enumerate(lines):
+        window = " ".join(text for _, text in lines[max(position - 1, 0) : position + 2])
+        if number == 1 and line.strip() == "---":
+            in_frontmatter = True
+            continue
+        if in_frontmatter and line.strip() == "---":
+            in_frontmatter = False
+            continue
+        headline = bool(_HEADING.match(line)) or (
+            in_frontmatter and bool(_FRONTMATTER_HEADLINE.match(line))
+        )
+        for rule in RULES:
+            if rule.scope == "headline" and not headline:
+                continue
+            if not rule.pattern.search(line):
+                continue
+            if allowlist.permits(path, window):
+                continue
+            findings.append(Finding(path, number, rule, line))
+    return findings
+
+
+def lint_paths(paths: Iterable[Path], allowlist: Allowlist | None = None) -> list[Finding]:
+    allowlist = allowlist if allowlist is not None else load_allowlist()
+    findings: list[Finding] = []
+    for path in paths:
+        name = relative(path)
+        if name in EXEMPT_BY_RULE or allowlist.excludes(name):
+            continue
+        findings.extend(lint_text(path.read_text(encoding="utf-8"), name, allowlist))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("paths", nargs="*", type=Path, help="documents to lint; default: all")
+    arguments = parser.parse_args(argv)
+    paths = [p.resolve() for p in arguments.paths] or documents(patterns=DOCUMENT_PATTERNS)
+    findings = lint_paths(paths)
+    for finding in findings:
+        print(finding)
+    print(f"lint: {len(paths)} document(s), {len(findings)} finding(s)")
+    return 0 if not findings else 1
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, str(Path(__file__).parent))
+    sys.exit(main())

--- a/tools/docs_audit/render_capabilities.py
+++ b/tools/docs_audit/render_capabilities.py
@@ -1,0 +1,320 @@
+"""Render `docs/capabilities.yaml` three ways, and refuse a rendered copy that drifted.
+
+One source, several renders. The README's capability matrix, the docs home page's capability
+grid and the plain-text list PyPI and directory listings carry are never edited by hand: each
+is the output of this script for one `format`, and `--check` fails when any of them differs.
+
+    python tools/docs_audit/render_capabilities.py readme      # print one render
+    python tools/docs_audit/render_capabilities.py --write     # refresh docs/generated/
+    python tools/docs_audit/render_capabilities.py --check     # CI
+
+`--check` compares two things:
+
+1. the three files under `docs/generated/`, byte for byte;
+2. every **marker block** in `README.md` and under `docs/`, which is how a page embeds a render
+   in place. A block opens with the generated-comment line this script emits — it names the
+   format — and closes with an `end generated` comment. What lies between must equal the render.
+
+    <!-- generated from docs/capabilities.yaml (readme) — edit the YAML, never this table -->
+    | Guarantee | … |
+    <!-- end generated -->
+
+MDX pages use `{/* … */}` for both lines.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+from _files import REPO_ROOT, documents, relative
+
+SOURCE = REPO_ROOT / "docs" / "capabilities.yaml"
+GENERATED = REPO_ROOT / "docs" / "generated"
+FORMATS: tuple[str, ...] = ("readme", "mdx", "text")
+FILENAMES: Mapping[str, str] = {
+    "readme": "capabilities.readme.md",
+    "mdx": "capabilities.mdx",
+    "text": "capabilities.txt",
+}
+WAYS_IN: tuple[str, ...] = ("decorator", "gateway", "adapter")
+WAY_LABELS: Mapping[str, str] = {
+    "decorator": "`@protect`",
+    "gateway": "Gateway",
+    "adapter": "Adapter",
+}
+VERSIONS: frozenset[str] = frozenset({"v0.1", "v0.2", "v0.3", "v0.4", "v0.5", "v0.6"})
+MAX_DESCRIPTION_WORDS = 15
+
+_OPEN_COMMENT = (
+    "generated from docs/capabilities.yaml ({format}) — edit the YAML, never this {what}"
+)
+_MARKER_OPEN = re.compile(r"generated from docs/capabilities\.yaml \((?P<format>[a-z]+)\)")
+_MARKER_CLOSE = re.compile(r"end generated")
+
+
+@dataclass(frozen=True)
+class Capability:
+    id: str
+    name: str
+    description: str
+    guarantee: bool
+    ways_in: Mapping[str, bool | str]
+    since: str
+    page: str
+    claim: str | None
+    claim_note: str | None
+
+
+class CapabilitiesError(ValueError):
+    """`docs/capabilities.yaml` says something the generator refuses to render."""
+
+
+def load(path: Path = SOURCE) -> tuple[Capability, ...]:
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(document, Mapping) or not isinstance(document.get("capabilities"), list):
+        raise CapabilitiesError(f"{path}: expected a mapping with a `capabilities:` list")
+    entries: list[Capability] = []
+    seen: set[str] = set()
+    for index, raw in enumerate(document["capabilities"]):
+        where = f"{path}: capabilities[{index}]"
+        entries.append(_parse(raw, where, seen))
+    guarantees = [entry for entry in entries if entry.guarantee]
+    if len(guarantees) != 6:
+        raise CapabilitiesError(
+            f"{path}: {len(guarantees)} entries carry `guarantee: true`; the README matrix has "
+            "exactly six rows, one per group of the verify catalogue"
+        )
+    return tuple(entries)
+
+
+def _parse(raw: object, where: str, seen: set[str]) -> Capability:
+    if not isinstance(raw, Mapping):
+        raise CapabilitiesError(f"{where}: not a mapping")
+    required = {"id", "name", "description", "guarantee", "ways_in", "since", "page", "claim"}
+    allowed = required | {"claim_note"}
+    missing = required - set(raw)
+    unknown = set(raw) - allowed
+    if missing or unknown:
+        raise CapabilitiesError(f"{where}: missing {sorted(missing)}, unknown {sorted(unknown)}")
+    identifier = raw["id"]
+    if not isinstance(identifier, str) or not re.fullmatch(r"[a-z][a-z0-9-]*", identifier):
+        raise CapabilitiesError(f"{where}: id must be kebab-case, got {identifier!r}")
+    if identifier in seen:
+        raise CapabilitiesError(f"{where}: duplicate id {identifier!r}")
+    seen.add(identifier)
+    description = raw["description"]
+    if not isinstance(description, str) or not description.strip():
+        raise CapabilitiesError(f"{where}: description must be a non-empty string")
+    words = len(description.split())
+    if words > MAX_DESCRIPTION_WORDS:
+        raise CapabilitiesError(
+            f"{where}: description is {words} words; the limit is {MAX_DESCRIPTION_WORDS}"
+        )
+    if description.rstrip().endswith("!"):
+        raise CapabilitiesError(f"{where}: no exclamation marks (docs/STYLE.md)")
+    ways = raw["ways_in"]
+    if not isinstance(ways, Mapping) or set(ways) != set(WAYS_IN):
+        raise CapabilitiesError(f"{where}: ways_in must name exactly {list(WAYS_IN)}")
+    for way, value in ways.items():
+        if not isinstance(value, bool | str) or (isinstance(value, str) and not value.strip()):
+            raise CapabilitiesError(f"{where}: ways_in.{way} must be true, false or a short note")
+    if raw["since"] not in VERSIONS:
+        raise CapabilitiesError(f"{where}: since must be one of {sorted(VERSIONS)}")
+    page = raw["page"]
+    if not isinstance(page, str) or not re.fullmatch(r"[a-z0-9-]+(/[a-z0-9-]+)*", page):
+        raise CapabilitiesError(f"{where}: page must be a docs-site path like concepts/effect-keys")
+    claim = raw["claim"]
+    note = raw.get("claim_note")
+    if claim is None and not (isinstance(note, str) and note.strip()):
+        raise CapabilitiesError(f"{where}: a null claim needs a claim_note saying who adds the row")
+    if claim is not None and (not isinstance(claim, str) or not claim.strip()):
+        raise CapabilitiesError(f"{where}: claim must be a CLAIMS.md row's quoted text, or null")
+    if not isinstance(raw["guarantee"], bool):
+        raise CapabilitiesError(f"{where}: guarantee must be true or false")
+    if not isinstance(raw["name"], str) or not raw["name"].strip():
+        raise CapabilitiesError(f"{where}: name must be a non-empty string")
+    return Capability(
+        id=identifier,
+        name=raw["name"].strip(),
+        description=description.strip(),
+        guarantee=raw["guarantee"],
+        ways_in=dict(ways),
+        since=raw["since"],
+        page=page,
+        claim=claim,
+        claim_note=note,
+    )
+
+
+def _cell(value: bool | str) -> str:
+    if value is True:
+        return "yes"
+    if value is False:
+        return "—"
+    return value
+
+
+def render(fmt: str, capabilities: Sequence[Capability]) -> str:
+    if fmt == "readme":
+        return _render_readme(capabilities)
+    if fmt == "mdx":
+        return _render_mdx(capabilities)
+    if fmt == "text":
+        return _render_text(capabilities)
+    raise CapabilitiesError(f"unknown format {fmt!r}; one of {FORMATS}")
+
+
+def _render_readme(capabilities: Sequence[Capability]) -> str:
+    lines = [
+        f"<!-- {_OPEN_COMMENT.format(format='readme', what='table')} -->",
+        "| Guarantee | " + " | ".join(WAY_LABELS[way] for way in WAYS_IN) + " |",
+        "|---|" + "---|" * len(WAYS_IN),
+    ]
+    for entry in capabilities:
+        if not entry.guarantee:
+            continue
+        cells = " | ".join(_cell(entry.ways_in[way]) for way in WAYS_IN)
+        lines.append(f"| **{entry.name}** — {entry.description} | {cells} |")
+    lines.append("<!-- end generated -->")
+    return "\n".join(lines) + "\n"
+
+
+def _render_mdx(capabilities: Sequence[Capability]) -> str:
+    lines = [
+        "{/* " + _OPEN_COMMENT.format(format="mdx", what="grid") + " */}",
+        "<Columns cols={2}>",
+    ]
+    for entry in capabilities:
+        lines.append(f'  <Card title="{_attribute(entry.name)}" href="/{entry.page}">')
+        lines.append(f"    {entry.description} Since {entry.since}.")
+        lines.append("  </Card>")
+    lines.append("</Columns>")
+    lines.append("{/* end generated */}")
+    return "\n".join(lines) + "\n"
+
+
+def _render_text(capabilities: Sequence[Capability]) -> str:
+    lines = [_OPEN_COMMENT.format(format="text", what="list")]
+    for entry in capabilities:
+        lines.append(f"- {entry.name}: {entry.description}")
+    lines.append("end generated")
+    return "\n".join(lines) + "\n"
+
+
+def _attribute(value: str) -> str:
+    return value.replace("&", "&amp;").replace('"', "&quot;")
+
+
+def write(capabilities: Sequence[Capability], directory: Path = GENERATED) -> list[Path]:
+    directory.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for fmt in FORMATS:
+        target = directory / FILENAMES[fmt]
+        target.write_text(render(fmt, capabilities), encoding="utf-8")
+        written.append(target)
+    return written
+
+
+@dataclass(frozen=True)
+class Drift:
+    path: str
+    line: int | None
+    reason: str
+
+    def __str__(self) -> str:
+        where = f"{self.path}:{self.line}" if self.line is not None else self.path
+        return f"{where}: {self.reason}"
+
+
+def marker_blocks(text: str) -> list[tuple[int, str, str]]:
+    """Every (opening line number, format, embedded text) marker block in a page."""
+    lines = text.splitlines()
+    blocks: list[tuple[int, str, str]] = []
+    index = 0
+    while index < len(lines):
+        opened = _MARKER_OPEN.search(lines[index])
+        if opened is None:
+            index += 1
+            continue
+        start = index
+        fmt = opened.group("format")
+        index += 1
+        while index < len(lines) and not _MARKER_CLOSE.search(lines[index]):
+            index += 1
+        if index >= len(lines):
+            blocks.append((start + 1, fmt, ""))
+            break
+        blocks.append((start + 1, fmt, "\n".join(lines[start : index + 1]) + "\n"))
+        index += 1
+    return blocks
+
+
+def check(
+    capabilities: Sequence[Capability],
+    *,
+    directory: Path = GENERATED,
+    pages: Sequence[Path] | None = None,
+) -> list[Drift]:
+    drift: list[Drift] = []
+    for fmt in FORMATS:
+        target = directory / FILENAMES[fmt]
+        expected = render(fmt, capabilities)
+        if not target.exists():
+            drift.append(Drift(relative(target), None, "missing; run --write"))
+        elif target.read_text(encoding="utf-8") != expected:
+            drift.append(Drift(relative(target), None, "differs from the generator; run --write"))
+    if pages is None:
+        pages = documents(patterns=("README.md", "docs/**/*.md", "docs/**/*.mdx"))
+    for page in pages:
+        if page.parent == directory and page.name in FILENAMES.values():
+            continue
+        for line, fmt, embedded in marker_blocks(page.read_text(encoding="utf-8")):
+            if fmt not in FORMATS:
+                drift.append(Drift(relative(page), line, f"unknown format {fmt!r}"))
+            elif not embedded:
+                drift.append(Drift(relative(page), line, "marker block never closes"))
+            elif embedded != render(fmt, capabilities):
+                drift.append(
+                    Drift(
+                        relative(page),
+                        line,
+                        f"embedded {fmt} render differs from the generator; paste it fresh",
+                    )
+                )
+    return drift
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("format", nargs="?", choices=FORMATS, help="print one render")
+    parser.add_argument("--write", action="store_true", help="refresh docs/generated/")
+    parser.add_argument("--check", action="store_true", help="fail if a rendered copy drifted")
+    arguments = parser.parse_args(argv)
+    try:
+        capabilities = load()
+    except CapabilitiesError as exc:
+        print(f"capabilities: {exc}")
+        return 1
+    if arguments.format:
+        sys.stdout.write(render(arguments.format, capabilities))
+        return 0
+    if arguments.write:
+        for path in write(capabilities):
+            print(f"wrote {relative(path)}")
+    if arguments.check or not arguments.write:
+        drift = check(capabilities)
+        for item in drift:
+            print(f"DRIFT {item}")
+        print(f"capabilities: {len(capabilities)} entries, {len(drift)} drifted copy(ies)")
+        return 0 if not drift else 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/docs_audit/snippets.py
+++ b/tools/docs_audit/snippets.py
@@ -1,0 +1,264 @@
+"""Run every fenced block marked `runnable`, offline, and fail on the first sentence that lies.
+
+A code sample a reader pastes and watches fail is the most expensive sentence in the
+documentation, so a sample is either runnable and run here, or it carries no marker and makes
+no promise. The marker is a word on the fence's info string:
+
+    ```python runnable
+    ```bash runnable
+    ```yaml runnable
+
+Rules, stated once here and in `docs/STYLE.md`:
+
+- Every runnable block in one document runs in **one temporary directory**, in document order,
+  so a `yaml runnable` policy written early is the `ctrlrun.yaml` a later block reads.
+- A `python runnable` block is its own script. `python runnable continue` is appended to the
+  previous runnable Python blocks of the same document and the whole is run again, which is
+  how a page defines a function in one block and calls it in the next without repeating it.
+- A `bash runnable` block runs under `bash -euo pipefail`, with this interpreter's `bin/` on
+  `PATH` so `ctrlrun …` is the checkout's CLI.
+- A `yaml runnable` block is loaded with `Policy.from_yaml`, and with `Authority.from_yaml`
+  when it carries an `authority:` section, and is then written to `ctrlrun.yaml` — or to the
+  name given by a `file=<name>` token, which any block may carry.
+- **No network.** Every subprocess gets a `sitecustomize` that refuses sockets, name resolution
+  and connections, the same guard `tests/test_examples.py` puts under the examples. A snippet
+  that reaches for the network fails here rather than in a reader's terminal, where it would
+  fail differently.
+
+Exit status is the number of failures, capped at 1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from _files import DOCUMENT_PATTERNS, Fence, documents, fences, relative
+
+RUNNABLE = "runnable"
+LANGUAGES = frozenset({"python", "bash", "yaml"})
+TIMEOUT_SECONDS = 120
+
+#: Installed as `sitecustomize` on the subprocess's `PYTHONPATH`. Replacing the socket *type*
+#: with a function breaks anything that subclasses it — `ssl` does — so the refusal goes on
+#: the operations, exactly as `tests/test_examples.py` does it.
+NO_NETWORK = """\
+import socket
+
+_real = socket.socket
+
+
+class _Refusing(_real):
+    def connect(self, *args, **kwargs):
+        raise RuntimeError("a documentation snippet tried to connect; snippets run offline")
+
+    def connect_ex(self, *args, **kwargs):
+        raise RuntimeError("a documentation snippet tried to connect; snippets run offline")
+
+
+def _refuse(*args, **kwargs):
+    raise RuntimeError("a documentation snippet tried to resolve a name; snippets run offline")
+
+
+socket.socket = _Refusing
+socket.create_connection = _refuse
+socket.getaddrinfo = _refuse
+"""
+
+
+@dataclass(frozen=True)
+class Failure:
+    location: str
+    language: str
+    message: str
+
+    def __str__(self) -> str:
+        return f"{self.location} ({self.language}): {self.message}"
+
+
+@dataclass(frozen=True)
+class Outcome:
+    ran: int
+    failures: tuple[Failure, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.failures
+
+
+def runnable_fences(path: Path) -> list[Fence]:
+    text = path.read_text(encoding="utf-8")
+    return [
+        fence
+        for fence in fences(text, path)
+        if RUNNABLE in fence.tokens and fence.language in LANGUAGES
+    ]
+
+
+def run_document(path: Path, *, guard: Path | None = None) -> Outcome:
+    """Run every runnable block of one document, in order, in one temporary directory."""
+    blocks = runnable_fences(path)
+    if not blocks:
+        return Outcome(0, ())
+    with tempfile.TemporaryDirectory(prefix="docs-snippet-") as scratch:
+        workdir = Path(scratch) / "work"
+        workdir.mkdir()
+        if guard is None:
+            guard = Path(scratch) / "guard"
+            guard.mkdir()
+            (guard / "sitecustomize.py").write_text(NO_NETWORK, encoding="utf-8")
+        environment = _environment(guard)
+        failures: list[Failure] = []
+        python_so_far: list[str] = []
+        for fence in blocks:
+            if fence.language == "python":
+                if "continue" in fence.tokens:
+                    source = "\n".join([*python_so_far, fence.body])
+                else:
+                    python_so_far = []
+                    source = fence.body
+                python_so_far.append(fence.body)
+                failure = _run_python(fence, source, workdir, environment)
+            elif fence.language == "bash":
+                failure = _run_bash(fence, workdir, environment)
+            else:
+                failure = _load_yaml(fence, workdir)
+            if failure is not None:
+                failures.append(failure)
+        return Outcome(len(blocks), tuple(failures))
+
+
+def run_documents(paths: Iterable[Path]) -> Outcome:
+    ran = 0
+    failures: list[Failure] = []
+    with tempfile.TemporaryDirectory(prefix="docs-snippet-guard-") as scratch:
+        guard = Path(scratch)
+        (guard / "sitecustomize.py").write_text(NO_NETWORK, encoding="utf-8")
+        for path in paths:
+            outcome = run_document(path, guard=guard)
+            ran += outcome.ran
+            failures.extend(outcome.failures)
+    return Outcome(ran, tuple(failures))
+
+
+def _environment(guard: Path) -> dict[str, str]:
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(guard), environment.get("PYTHONPATH", "")) if part
+    )
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    environment["PATH"] = os.pathsep.join(
+        [str(Path(sys.executable).parent), environment.get("PATH", "")]
+    )
+    # A snippet decides its own policy and store; the operator's must not leak in.
+    for name in ("CTRLRUN_CONFIG", "CTRLRUN_STATE", "CTRLRUN_STORE_URL"):
+        environment.pop(name, None)
+    return environment
+
+
+def _file_token(fence: Fence, default: str) -> str:
+    for token in fence.tokens:
+        if token.startswith("file="):
+            return token[len("file=") :]
+    return default
+
+
+def _run_python(
+    fence: Fence, source: str, workdir: Path, environment: Mapping[str, str]
+) -> Failure | None:
+    script = workdir / _file_token(fence, f"snippet_{fence.line}.py")
+    script.write_text(source, encoding="utf-8")
+    return _run([sys.executable, str(script)], fence, workdir, environment)
+
+
+def _run_bash(fence: Fence, workdir: Path, environment: Mapping[str, str]) -> Failure | None:
+    script = workdir / _file_token(fence, f"snippet_{fence.line}.sh")
+    script.write_text(fence.body, encoding="utf-8")
+    return _run(["bash", "-euo", "pipefail", str(script)], fence, workdir, environment)
+
+
+def _run(
+    command: list[str], fence: Fence, workdir: Path, environment: Mapping[str, str]
+) -> Failure | None:
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=workdir,
+            env=dict(environment),
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return Failure(fence.location, fence.language, f"did not finish in {TIMEOUT_SECONDS}s")
+    except OSError as exc:
+        return Failure(fence.location, fence.language, f"could not start: {exc}")
+    if completed.returncode != 0:
+        tail = (completed.stderr or completed.stdout).strip().splitlines()[-8:]
+        return Failure(
+            fence.location,
+            fence.language,
+            f"exit {completed.returncode}\n    " + "\n    ".join(tail),
+        )
+    return None
+
+
+def _load_yaml(fence: Fence, workdir: Path) -> Failure | None:
+    import yaml
+
+    from ctrlrun import Authority, Policy
+    from ctrlrun.errors import CTRLRunError
+
+    try:
+        document = yaml.safe_load(fence.body)
+    except yaml.YAMLError as exc:
+        return Failure(fence.location, fence.language, f"not valid YAML: {exc}")
+    if not isinstance(document, Mapping):
+        return Failure(fence.location, fence.language, "a runnable YAML block is a document")
+    try:
+        if "actions" in document:
+            Policy.from_yaml(fence.body, source=fence.location)
+        if "authority" in document:
+            Authority.from_yaml(
+                fence.body, source=fence.location, standalone="actions" not in document
+            )
+        if "actions" not in document and "authority" not in document:
+            return Failure(
+                fence.location,
+                fence.language,
+                "neither a policy (`actions:`) nor an authority document (`authority:`)",
+            )
+    except CTRLRunError as exc:
+        return Failure(fence.location, fence.language, f"{type(exc).__name__}: {exc}")
+    (workdir / _file_token(fence, "ctrlrun.yaml")).write_text(fence.body, encoding="utf-8")
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("paths", nargs="*", type=Path, help="documents to run; default: all")
+    parser.add_argument("--list", action="store_true", help="list runnable blocks and exit")
+    arguments = parser.parse_args(argv)
+    paths = [p.resolve() for p in arguments.paths] or documents(patterns=DOCUMENT_PATTERNS)
+    if arguments.list:
+        for path in paths:
+            for fence in runnable_fences(path):
+                print(f"{fence.location} {fence.language} {' '.join(fence.tokens)}")
+        return 0
+    outcome = run_documents(paths)
+    for failure in outcome.failures:
+        print(f"FAIL {failure}")
+    scope = ", ".join(relative(p) for p in paths) if len(paths) <= 3 else f"{len(paths)} documents"
+    print(f"snippets: {outcome.ran} runnable block(s) in {scope}, {len(outcome.failures)} failed")
+    return 0 if outcome.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The first of the documentation sessions for the 0.6 launch. **No kernel code.** One PR: the information architecture, the style sheet, the capabilities source with its generator, and the three audit checks wired into CI.

## What is here

- **`docs/IA.md`** — the target site as a tree: every page with a one-line purpose and the query it should answer. The research it rests on is in the appendix with dates and sources: Mintlify's current `docs.json` schema (no `mint.json`), the decision to generate the Python API reference with griffe into our own MDX because Mintlify has no native docstring support, the top-level structure of the Temporal, Cerbos and Stripe docs, and what answer-engine optimisation concretely asks of a page (Google's guide against LLMrefs' practices).
- **`docs/STYLE.md`** — answer-first, second person, present tense, 900 words, no exclamation marks, `CTRLRun` spelled one way, every page ends with Next, and the contract for `runnable` fences.
- **`docs/capabilities.yaml`** — 25 entries, six marked `guarantee: true` (one per group of the verify catalogue). `tools/docs_audit/render_capabilities.py` renders it as the README matrix, the docs home `Columns`/`Card` grid and a plain-text list into `docs/generated/`. `--check` fails on any drifted file **and** on any marker block in a page that embeds a render. Every rendered copy opens with a "generated — edit the YAML" comment.
- **`tools/docs_audit/`** — `snippets.py` (runs every `python|bash|yaml runnable` fence offline, one temp dir per document, socket guard via `sitecustomize`, YAML through the real `Policy`/`Authority` loaders), `lint.py` with `lint-allowlist.txt` (positioning words in headline scope, claim words everywhere, two documents exempt by rule), `links.py` (relative links, root-relative docs paths, `github.com/CTRLRun/ctrlrun/blob/...` links, GitHub-slug anchors).
- **CI**: a `docs` job. The drift check is a hard failure. The three audit steps carry `continue-on-error: true` until the baseline below is cleared; each flag comes off individually when its step is green on `main`. The job is not yet a required status check; it should become one at the same time.
- **`tests/test_docs_audit.py`** — 48 tests, each guard shown catching the thing it exists to catch.

## Baseline against today's README and docs (2026-09-06)

| Check | Result | What the writing sessions owe |
|---|---|---|
| Runnable snippets | 0 runnable blocks; **67** `python`/`bash`/`yaml` fences across 21 documents carry no marker and are unverified | Mark every sample that can run and make it run, or delete it (sessions 1–5) |
| Forbidden words | 0 findings after the allowlist. Before it: 102, of which 97 were in `docs/SPEC-*.md` and `docs/ROADMAP.md` (excluded as the historical record) and 5 were negations now allowlisted by their negating phrase | Keep it at 0; every new allow entry carries its reason |
| Links and anchors | 0 broken | Keep it at 0 |
| Capabilities drift | 0 drifted copies | Edit the YAML, never a table |
| Claims behind capabilities | 6 of 25 entries have **no `CLAIMS.md` row** (`fail-closed`, `operator-cli`, `webhook-approvals`, `recovery`, `control-registry`, `data-scope`), each with a `claim_note` naming session 1 | Add the README sentence and its row |

The README's own baseline is the same as before this PR: it passes the lint only because its adapter section and its badge sentence are negations, and its 28 fences are all unverified.

## Mutation table

Each guard removed, the named test confirmed red, the guard restored. `PYTHONDONTWRITEBYTECODE=1`, `__pycache__` cleared before each run.

| Guard | Test | Result |
|---|---|---|
| snippets: socket guard on `PYTHONPATH` | `test_a_block_that_reaches_for_the_network_fails` | red |
| snippets: non-zero exit is a failure | `test_a_failing_python_block_is_reported_with_its_line`, `test_a_failing_bash_block_fails` | red, red |
| snippets: YAML through `Policy.from_yaml` | `test_a_yaml_block_is_loaded_by_the_real_policy_loader` | red |
| lint: headline scope | `test_a_positioning_word_in_a_heading_is_flagged` | red |
| lint: allowlist consulted | `test_the_allowlist_permits_a_matching_line_in_a_matching_file` | red |
| lint: the two rule-exempt documents | `test_the_two_documents_the_rule_exempts_are_skipped` | red |
| links: anchor must exist | `test_a_missing_anchor_is_broken` | red |
| links: file must exist | `test_a_relative_link_to_a_missing_file_is_broken`, `test_a_github_blob_url_into_this_repository_is_an_internal_link` | red, red |
| render: generated file compared | `test_a_hand_edit_to_a_generated_file_is_drift` | red |
| render: marker block compared | `test_a_marker_block_in_a_page_is_compared_with_the_render` | red |
| render: exactly six guarantees | `test_the_generator_refuses_a_count_of_guarantees_other_than_six` | red |

No subsumed guards: each row's test asserts the specific message or the specific path, not a status alone. The socket-guard row has its control (`test_the_network_guard_is_what_made_it_fail`) so a green is not the environment refusing on its own.

## Checks

`PYTHON=.venv/bin/python scripts/check.sh`: ruff format, ruff check, mypy --strict, 2432 passed, 45 skipped (Postgres and adapter suites, supplied by CI).
