### PR TITLE
Docs 4: the cookbook, twenty-one recipes, each a page and a directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,9 @@ jobs:
       - name: The Python API reference matches the docstrings
         run: python tools/docs_audit/render_api.py --check
 
+      - name: The cookbook directories are what their pages show
+        run: python tools/docs_audit/render_cookbook.py --check
+
       - name: Runnable snippets execute offline
         continue-on-error: true
         run: python tools/docs_audit/snippets.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -34,6 +34,8 @@ recursive-include tests *.md
 # fails on a fresh checkout, which is the failure `prune internal` exists to avoid.
 recursive-include examples *.py
 recursive-include examples *.yaml
+# The cookbook's verify recipe is a shell script; `tests/test_cookbook.py` runs it.
+recursive-include examples *.sh
 # And the READMEs. `examples/authority/` is two documents to *read*, so its README is the
 # example rather than a note beside one — and a test asserts what it says, which is how the
 # sdist job caught this line missing rather than the release did.

--- a/docs/concepts/observe-mode.mdx
+++ b/docs/concepts/observe-mode.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Observe mode"
-description: "mode: observe runs every real decision against real traffic and records what enforcement would have blocked, without blocking anything, so ctrlrun stats can show the cost of enforcing before you enforce. It executes; it is not a dry run."
+description: "mode: observe runs every real decision against real traffic and records what enforcement would have blocked, without blocking anything."
 ---
 
 Observe mode is one top-level line, `mode: observe`, that makes CTRLRun evaluate every action
@@ -30,13 +30,14 @@ Every receipt carries `would_have`: the decision enforce mode would have reached
 would have refused, the first reason, in the order enforce mode checks them, because enforce
 mode stops at the first. A duplicate effect is recorded as one and still runs. After a week:
 
-```console
-$ ctrlrun stats --since 7d
-observed actions            1,284
-would have been blocked        37
-  approval_required            29
-  policy_denied                 6
-  duplicate_effect              2
+```text
+actions                         1284
+would have been denied             6
+   rule[2]                         6
+would have needed approval        29
+would have been blocked            2
+   duplicate                       2
+ambiguous outcomes                 0
 ```
 
 The numbers are counted from `would_have.blocked_reason` and nothing else, from the local store,

--- a/docs/cookbook/credential-rotation-agent.mdx
+++ b/docs/cookbook/credential-rotation-agent.mdx
@@ -1,0 +1,119 @@
+---
+title: "A credential-rotation agent"
+description: "An agent rotates API keys: minting the new key runs on its own, revoking the old one waits for a human, and a lost reply is never repeated blindly."
+---
+
+An agent rotates service credentials on a schedule. Minting a new key is safe: nothing uses it
+yet. Revoking the old one is the step that breaks a client that has not switched over, so it
+waits for a person. And a mint whose reply was lost must not be minted again on a guess, because
+each mint leaves a live credential somewhere.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  secrets.create_key:
+    effect: "key:{service}:{rotation_id}"
+    decision: allow
+  secrets.revoke_key:
+    effect: "revoke:{service}:{key_id}"
+    decision: approve
+```
+
+## The code
+
+```python runnable file=main.py
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+live_keys: list[str] = ["key_old"]
+
+
+def mint(service: str, rotation_id: str, lose_reply: bool = False) -> str:
+    key_id = f"key_{rotation_id}"
+    live_keys.append(key_id)  # the provider has it from here on
+    if lose_reply:
+        raise TimeoutError("no response from the secrets manager after 30s")
+    return key_id
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect("secrets.create_key", effect="key:{service}:{rotation_id}", control=control)
+def create_key(service: str, rotation_id: str, lose_reply: bool = False) -> str:
+    return mint(service, rotation_id, lose_reply)
+
+
+@ctrlrun.protect("secrets.revoke_key", effect="revoke:{service}:{key_id}", control=control)
+def revoke_key(service: str, key_id: str) -> str:
+    live_keys.remove(key_id)
+    return "revoked"
+
+
+with ctrlrun.context(agent="rotation-agent"):
+    print("mint 2026-09:", create_key(service="billing-api", rotation_id="2026-09"))
+
+    try:
+        revoke_key(service="billing-api", key_id="key_old")
+    except ctrlrun.ApprovalRequired as pending:
+        print("revoke key_old: a human decides:", pending.request_id)
+    else:
+        raise SystemExit("a key was revoked without a human")
+
+    try:
+        create_key(service="billing-api", rotation_id="2026-10", lose_reply=True)
+    except TimeoutError:
+        print("mint 2026-10: reply lost")
+    try:
+        create_key(service="billing-api", rotation_id="2026-10")
+    except ctrlrun.AmbiguousEffect:
+        print("mint 2026-10 again: refused; a key may already exist")
+    else:
+        raise SystemExit("a second key was minted for one rotation")
+
+print("live keys at the provider:", live_keys)
+```
+
+## What the agent sees
+
+```text
+mint 2026-09: key_2026-09
+revoke key_old: a human decides: apr_…
+mint 2026-10: reply lost
+mint 2026-10 again: refused; a key may already exist
+live keys at the provider: ['key_old', 'key_2026-09', 'key_2026-10']
+```
+
+Three keys live, not four: the retry that would have minted a duplicate for the October
+rotation was refused. `key_old` is still live because the revocation is waiting for a person.
+
+## The receipt
+
+```bash runnable
+ctrlrun receipts --last 4
+ctrlrun effects --state ambiguous
+```
+
+## When an AMBIGUOUS appears
+
+List keys at the provider for the service. If a key for the rotation exists,
+`ctrlrun resolve key:billing-api:2026-10 --committed` and use it; if not, `--failed` and mint
+again. Never mint on the assumption that the first one did not happen: an orphaned live
+credential is the worst outcome here.
+
+## Next
+
+- [An IAM agent that can grant read but never admin](/cookbook/iam-agent).
+- [Resolve an AMBIGUOUS effect](/guides/resolve-an-ambiguous-effect) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/crm-update-agent.mdx
+++ b/docs/cookbook/crm-update-agent.mdx
@@ -1,0 +1,142 @@
+---
+title: "A CRM-update agent"
+description: "An agent updates customer records from conversations: a field update runs on its own, merging two records waits for a human, deleting a record is refused."
+---
+
+A support agent keeps the CRM current from conversations. Updating a phone number is cheap to
+undo. Merging two customer records is not, so it waits for a person. Deleting a record destroys
+the thing every receipt points at, so an agent never does it.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  crm.update_record:
+    effect: "crm:{record_id}:{field}:{revision}"
+    resource: "record:{record_id}"
+    decision: allow
+  crm.merge_records:
+    effect: "merge:{keep}:{drop}"
+    decision: approve
+  crm.delete_record:
+    decision: deny
+```
+
+## The code
+
+```python runnable file=main.py
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+records: dict[str, dict[str, str]] = {"c_1": {"phone": "+353 1 555 0100"}, "c_2": {}}
+writes = 0
+
+
+def crm_update(record_id: str, field: str, value: str) -> str:
+    global writes
+    writes += 1
+    records[record_id][field] = value
+    return "updated"
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect(
+    "crm.update_record",
+    effect="crm:{record_id}:{field}:{revision}",
+    resource="record:{record_id}",
+    control=control,
+)
+def update(record_id: str, field: str, value: str, revision: int) -> str:
+    return crm_update(record_id, field, value)
+
+
+@ctrlrun.protect("crm.merge_records", effect="merge:{keep}:{drop}", control=control)
+def merge(keep: str, drop: str) -> str:
+    return "merged"
+
+
+@ctrlrun.protect("crm.delete_record", control=control)
+def delete(record_id: str) -> str:
+    return "deleted"
+
+
+with ctrlrun.context(agent="support-agent"):
+    print(
+        "update phone:", update(record_id="c_1", field="phone", value="+353 1 555 0199", revision=7)
+    )
+
+    # A second worker handling the same conversation proposes the same revision.
+    try:
+        update(record_id="c_1", field="phone", value="+353 1 555 0199", revision=7)
+    except ctrlrun.DuplicateEffect:
+        print("same update from a second worker: refused, already applied")
+    else:
+        raise SystemExit("one revision was written twice")
+
+    # A later revision is a new effect and runs.
+    print(
+        "update phone, revision 8:",
+        update(record_id="c_1", field="phone", value="+353 1 555 0200", revision=8),
+    )
+
+    try:
+        merge(keep="c_1", drop="c_2")
+    except ctrlrun.ApprovalRequired as pending:
+        print("merge c_2 into c_1: a human decides:", pending.request_id)
+    else:
+        raise SystemExit("a merge ran without a human")
+
+    try:
+        delete(record_id="c_2")
+    except ctrlrun.ActionDenied:
+        print("delete c_2: refused")
+    else:
+        raise SystemExit("a record was deleted")
+
+print("CRM writes:", writes)
+```
+
+## What the agent sees
+
+```text
+update phone: updated
+same update from a second worker: refused, already applied
+update phone, revision 8: updated
+merge c_2 into c_1: a human decides: apr_…
+delete c_2: refused
+CRM writes: 2
+```
+
+The revision number in the effect key is what tells a duplicate from a change: the same
+revision twice is one effect; a new revision is a new one.
+
+## The receipt
+
+```bash runnable
+ctrlrun receipts --last 5
+```
+
+## When an AMBIGUOUS appears
+
+Read the record back. If the field holds the new value, `ctrlrun resolve
+crm:c_1:phone:8 --committed`; if not, `--failed`. For a merge whose reply was lost, check
+which record still exists before resolving: a merge is the one update here that cannot be
+undone by another update.
+
+## Next
+
+- [A data-deletion agent under a retention rule](/cookbook/data-deletion-agent).
+- [Effect keys](/concepts/effect-keys) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/customer-notification-agent.mdx
+++ b/docs/cookbook/customer-notification-agent.mdx
@@ -1,0 +1,117 @@
+---
+title: "A customer-notification agent"
+description: "An agent notifies customers about an incident: one effect per customer per incident, so a retry."
+---
+
+An incident agent notifies affected customers. Each customer should hear once, however many
+times the batch is retried or however many workers pick it up. A batch beyond a certain size is
+a person's decision, because a wrong message to ten thousand customers is not cheap to undo.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  notify.customer:
+    effect: "notify:{incident_id}:{customer_id}"
+    decision: allow
+  notify.batch:
+    effect: "batch:{incident_id}"
+    rules:
+      - when: { size_lte: 500 }
+        decision: allow
+      - decision: approve
+```
+
+## The code
+
+```python runnable file=main.py
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+delivered: list[str] = []
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect("notify.batch", effect="batch:{incident_id}", control=control)
+def start_batch(incident_id: str, size: int) -> str:
+    return "started"
+
+
+@ctrlrun.protect("notify.customer", effect="notify:{incident_id}:{customer_id}", control=control)
+def notify(incident_id: str, customer_id: str) -> str:
+    delivered.append(customer_id)
+    return "delivered"
+
+
+customers = ["c_1", "c_2", "c_3"]
+
+with ctrlrun.context(agent="incident-agent"):
+    print("batch of 3:", start_batch(incident_id="inc_7", size=3))
+    for customer in customers:
+        notify(incident_id="inc_7", customer_id=customer)
+    print("first pass delivered:", len(delivered))
+
+    # The batch is retried after a crash, and a second worker runs it at the same time.
+    skipped = 0
+    for customer in customers + customers:
+        try:
+            notify(incident_id="inc_7", customer_id=customer)
+        except ctrlrun.DuplicateEffect:
+            skipped += 1
+    print("retry and second worker: skipped", skipped, "already-notified customers")
+
+    try:
+        start_batch(incident_id="inc_8", size=12000)
+    except ctrlrun.ApprovalRequired as pending:
+        print("batch of 12,000: a human decides:", pending.request_id)
+    else:
+        raise SystemExit("a large batch started without a human")
+
+print("messages delivered:", len(delivered))
+```
+
+## What the agent sees
+
+```text
+batch of 3: started
+first pass delivered: 3
+retry and second worker: skipped 6 already-notified customers
+batch of 12,000: a human decides: apr_…
+messages delivered: 3
+```
+
+Three customers, three messages, after a retry and a racing worker. The effect key names the
+customer and the incident, so the same customer in a different incident is a new effect.
+
+## The receipt
+
+```bash runnable
+ctrlrun receipts --last 3
+ctrlrun effects
+```
+
+Ten receipts for the notifications: three committed, six blocked as duplicates, and the
+batch. `ctrlrun effects` lists one effect per customer.
+
+## When an AMBIGUOUS appears
+
+A notification whose reply was lost may have been delivered. Check the provider's delivery log
+for the customer, then `ctrlrun resolve notify:inc_7:c_N --committed` or `--failed`. If the
+provider accepts an idempotency key, pass the effect key as it, and the resolution is nearly
+always `--committed`.
+
+## Next
+
+- [An outbound-email agent](/cookbook/outbound-email-agent).
+- [Effect keys](/concepts/effect-keys) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/data-deletion-agent.mdx
+++ b/docs/cookbook/data-deletion-agent.mdx
@@ -1,0 +1,126 @@
+---
+title: "A data-deletion agent under a retention rule"
+description: "An agent handles deletion requests: records past retention are purged on their own, records inside retention wait for a human."
+---
+
+An agent processes deletion requests against customer data. A record past its retention
+period can go; a record still inside retention is a person's decision; a record under legal
+hold is not deleted by an agent at all. The policy sees only the arguments, so the executor
+passes the facts it decided on: how many days the record has been held, and whether a hold
+applies.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  records.purge:
+    effect: "purge:{record_id}"
+    resource: "record:{record_id}"
+    rules:
+      - when: { legal_hold_eq: true }
+        decision: deny
+      - when: { age_days_gte: 730 }
+        decision: allow
+      - decision: approve
+```
+
+## The code
+
+```python runnable file=main.py
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+purged: list[str] = []
+
+
+def purge_at_warehouse(record_id: str, lose_reply: bool = False) -> str:
+    purged.append(record_id)
+    if lose_reply:
+        raise TimeoutError("warehouse did not answer in 30s")
+    return "purged"
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect(
+    "records.purge", effect="purge:{record_id}", resource="record:{record_id}", control=control
+)
+def purge(record_id: str, age_days: int, legal_hold: bool, lose_reply: bool = False) -> str:
+    return purge_at_warehouse(record_id, lose_reply)
+
+
+with ctrlrun.context(agent="deletion-agent"):
+    print("r_100, 900 days old:", purge(record_id="r_100", age_days=900, legal_hold=False))
+
+    try:
+        purge(record_id="r_101", age_days=400, legal_hold=False)
+    except ctrlrun.ApprovalRequired as pending:
+        print("r_101, 400 days old: a human decides:", pending.request_id)
+    else:
+        raise SystemExit("a record inside retention was purged without a human")
+
+    try:
+        purge(record_id="r_102", age_days=900, legal_hold=True)
+    except ctrlrun.ActionDenied:
+        print("r_102, under legal hold: refused")
+    else:
+        raise SystemExit("a record under legal hold was purged")
+
+    try:
+        purge(record_id="r_103", age_days=900, legal_hold=False, lose_reply=True)
+    except TimeoutError:
+        print("r_103: reply lost")
+    try:
+        purge(record_id="r_103", age_days=900, legal_hold=False)
+    except ctrlrun.AmbiguousEffect:
+        print("r_103 again: refused until someone checks the warehouse")
+    else:
+        raise SystemExit("a purge of unknown outcome was repeated")
+
+print("purge calls at the warehouse:", purged)
+```
+
+## What the agent sees
+
+```text
+r_100, 900 days old: purged
+r_101, 400 days old: a human decides: apr_…
+r_102, under legal hold: refused
+r_103: reply lost
+r_103 again: refused until someone checks the warehouse
+purge calls at the warehouse: ['r_100', 'r_103']
+```
+
+The rule order matters: the legal-hold check is first, so a held record is refused whatever
+its age. Rules are first-match, and the receipt names which one decided.
+
+## The receipt
+
+```bash runnable
+ctrlrun receipts --last 4
+```
+
+## When an AMBIGUOUS appears
+
+A purge is the one action here you cannot repeat to be safe, because a second purge of a
+record that is gone may error in a way that looks like a failure, and a second purge of one
+that is not gone is what you wanted. Query the warehouse for `r_103`, then
+`ctrlrun resolve purge:r_103 --committed` or `--failed`, and let the agent's next attempt
+follow from that.
+
+## Next
+
+- [A CRM-update agent](/cookbook/crm-update-agent).
+- [Decisions](/concepts/decisions) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/database-migration-agent.mdx
+++ b/docs/cookbook/database-migration-agent.mdx
@@ -1,0 +1,126 @@
+---
+title: "A database-migration agent"
+description: "An agent runs schema migrations: forward migrations on staging run on their own, every production migration waits for a human, a rollback is refused."
+---
+
+An agent applies schema migrations from a migrations directory. Forward migrations on staging
+are routine; every production migration is a human decision; a rollback that drops data is
+not an agent action. The interesting case is the migration whose connection dropped: it may
+have applied, and the agent must not run it again on a guess.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  db.migrate:
+    effect: "migration:{database}:{version}"
+    rules:
+      - when: { database_eq: staging }
+        decision: allow
+      - decision: approve
+  db.rollback:
+    decision: deny
+```
+
+## The code
+
+```python runnable file=main.py
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+applied: dict[str, list[str]] = {"staging": [], "production": []}
+
+
+def run_migration(database: str, version: str, drop_connection: bool = False) -> str:
+    applied[database].append(version)  # the DDL ran
+    if drop_connection:
+        raise ConnectionResetError("connection reset by peer")  # ...and the reply was lost
+    return "applied"
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect("db.migrate", effect="migration:{database}:{version}", control=control)
+def migrate(database: str, version: str, drop_connection: bool = False) -> str:
+    return run_migration(database, version, drop_connection)
+
+
+@ctrlrun.protect("db.rollback", control=control)
+def rollback(database: str, version: str) -> str:
+    return "rolled back"
+
+
+with ctrlrun.context(agent="migration-agent"):
+    print("0042 on staging:", migrate(database="staging", version="0042"))
+
+    try:
+        migrate(database="production", version="0042")
+    except ctrlrun.ApprovalRequired as pending:
+        print("0042 on production: a human decides:", pending.request_id)
+    else:
+        raise SystemExit("a production migration ran without a human")
+
+    try:
+        rollback(database="production", version="0041")
+    except ctrlrun.ActionDenied:
+        print("rollback on production: refused")
+    else:
+        raise SystemExit("a rollback ran")
+
+    try:
+        migrate(database="staging", version="0043", drop_connection=True)
+    except ConnectionResetError:
+        print("0043 on staging: the connection dropped; outcome unknown")
+    try:
+        migrate(database="staging", version="0043")
+    except ctrlrun.AmbiguousEffect:
+        print("0043 on staging again: refused; a human checks the schema first")
+    else:
+        raise SystemExit("a migration of unknown outcome was re-run")
+
+print("migrations applied on staging:", applied["staging"])
+```
+
+## What the agent sees
+
+```text
+0042 on staging: applied
+0042 on production: a human decides: apr_…
+rollback on production: refused
+0043 on staging: the connection dropped; outcome unknown
+0043 on staging again: refused; a human checks the schema first
+migrations applied on staging: ['0042', '0043']
+```
+
+`0043` ran once. The agent's retry would have run it a second time; the effect key
+`migration:staging:0043` in the `AMBIGUOUS` state is what stopped it.
+
+## The receipt
+
+```bash runnable
+ctrlrun receipts --last 3
+ctrlrun effects --state ambiguous
+```
+
+## When an AMBIGUOUS appears
+
+Query the migrations table in the database itself: if `0043` is recorded,
+`ctrlrun resolve migration:staging:0043 --committed`; if not, `--failed`, and the agent's next
+attempt runs. A `reconcile` hook that runs that query is the automatic form.
+
+## Next
+
+- [A deploy agent](/cookbook/deploy-agent).
+- [Outcomes and AMBIGUOUS](/concepts/outcomes-and-ambiguous) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/deploy-agent.mdx
+++ b/docs/cookbook/deploy-agent.mdx
@@ -1,0 +1,129 @@
+---
+title: "A deploy agent"
+description: "An agent operates a Kubernetes cluster: a rollout restart runs on its own, applying to production waits for a human."
+---
+
+An on-call agent operates a cluster from incident tickets. Restarting a deployment is cheap to
+undo and should just happen; applying a manifest to production should wait for a person;
+deleting a namespace is not something an agent does, whatever the ticket says.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  k8s.rollout_restart:
+    effect: "restart:{cluster}:{deployment}"
+    decision: allow
+  k8s.apply:
+    effect: "apply:{cluster}:{manifest_hash}"
+    rules:
+      - when: { cluster_in: [staging, dev] }
+        decision: allow
+      - decision: approve
+  k8s.delete_namespace:
+    decision: deny
+```
+
+## The code
+
+```python runnable file=main.py
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+calls: list[str] = []
+
+
+def kubectl(*args: str) -> str:
+    calls.append(" ".join(args))
+    return "ok"
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect("k8s.rollout_restart", effect="restart:{cluster}:{deployment}", control=control)
+def restart(cluster: str, deployment: str) -> str:
+    return kubectl("rollout", "restart", f"deployment/{deployment}", "--context", cluster)
+
+
+@ctrlrun.protect("k8s.apply", effect="apply:{cluster}:{manifest_hash}", control=control)
+def apply(cluster: str, manifest_hash: str) -> str:
+    return kubectl("apply", "-f", manifest_hash, "--context", cluster)
+
+
+@ctrlrun.protect("k8s.delete_namespace", control=control)
+def delete_namespace(cluster: str, name: str) -> str:
+    return kubectl("delete", "namespace", name, "--context", cluster)
+
+
+with ctrlrun.context(agent="oncall-agent"):
+    print("restart checkout on prod:", restart(cluster="prod-eu", deployment="checkout"))
+    print("apply to staging:", apply(cluster="staging", manifest_hash="sha256:9c1f"))
+
+    try:
+        apply(cluster="prod-eu", manifest_hash="sha256:9c1f")
+    except ctrlrun.ApprovalRequired as pending:
+        print("apply to prod: a human decides:", pending.request_id)
+    else:
+        raise SystemExit("a production apply ran without a human")
+
+    try:
+        delete_namespace(cluster="prod-eu", name="checkout")
+    except ctrlrun.ActionDenied as refused:
+        print("delete namespace: refused,", refused.reason)
+    else:
+        raise SystemExit("a namespace delete ran")
+
+    # A second worker picks up the same ticket.
+    try:
+        restart(cluster="prod-eu", deployment="checkout")
+    except ctrlrun.DuplicateEffect:
+        print("second worker restarts checkout: refused, already done")
+    else:
+        raise SystemExit("the same restart ran twice")
+
+print("kubectl calls:", len(calls))
+```
+
+## What the agent sees
+
+```text
+restart checkout on prod: ok
+apply to staging: ok
+apply to prod: a human decides: apr_…
+delete namespace: refused, decision
+second worker restarts checkout: refused, already done
+kubectl calls: 2
+```
+
+## The receipt
+
+```bash runnable
+ctrlrun receipts --last 5
+```
+
+The `delete_namespace` receipt is `deny/blocked` with no effect key: the action has none,
+because it never runs. The duplicate restart is `allow/blocked` on `restart:prod-eu:checkout`.
+
+## When an AMBIGUOUS appears
+
+`kubectl apply` that timed out may have applied. Check the cluster (`kubectl diff`), then
+`ctrlrun resolve apply:prod-eu:sha256:… --committed` or `--failed`. The effect key is the
+manifest's hash, so a re-apply of the same manifest is the same effect and a changed manifest is
+a new one, which is what you want.
+
+## Next
+
+- [A database-migration agent](/cookbook/database-migration-agent).
+- [Effect keys](/concepts/effect-keys) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/iam-agent.mdx
+++ b/docs/cookbook/iam-agent.mdx
@@ -1,0 +1,126 @@
+---
+title: "An IAM agent that can grant read but never admin"
+description: "An access-request agent grants roles: read and viewer roles run on their own, anything else waits for a human."
+---
+
+An access-request agent grants roles from tickets. Read-only roles are routine, write roles
+need a person, and `admin` is never granted by an agent. The hazard is the one this recipe
+shows last: a human approves `reader` and the agent, re-planning or told to by a ticket's
+text, tries to execute `admin` with that approval.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  iam.grant_role:
+    effect: "grant:{principal}:{role}"
+    resource: "project:{project}"
+    rules:
+      - when: { role_eq: admin }
+        decision: deny
+      - when: { role_in: [reader, viewer] }
+        decision: allow
+      - decision: approve
+  iam.revoke_role:
+    effect: "revoke:{principal}:{role}"
+    decision: allow
+```
+
+## The code
+
+```python runnable file=main.py
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+bindings: list[tuple[str, str, str]] = []
+
+
+def bind(project: str, principal: str, role: str) -> str:
+    bindings.append((project, principal, role))
+    return "bound"
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect(
+    "iam.grant_role",
+    effect="grant:{principal}:{role}",
+    resource="project:{project}",
+    control=control,
+)
+def grant(project: str, principal: str, role: str) -> str:
+    return bind(project, principal, role)
+
+
+with ctrlrun.context(agent="access-agent"):
+    print(
+        "reader on billing:", grant(project="billing", principal="ana@example.com", role="reader")
+    )
+
+    try:
+        grant(project="billing", principal="ana@example.com", role="editor")
+    except ctrlrun.ApprovalRequired as pending:
+        print("editor on billing: a human decides:", pending.request_id)
+        request_id = pending.request_id
+    else:
+        raise SystemExit("editor was granted without a human")
+
+    store.grant_approval(request_id, "human:security")
+    with ctrlrun.with_approval(request_id):
+        try:
+            grant(project="billing", principal="ana@example.com", role="admin")
+        except ctrlrun.ActionDenied:
+            print("admin with the editor approval: refused; admin is never an agent action")
+        else:
+            raise SystemExit("admin was granted on an approval for editor")
+        print(
+            "editor with the editor approval:",
+            grant(project="billing", principal="ana@example.com", role="editor"),
+        )
+
+print("bindings:", bindings)
+```
+
+## What the agent sees
+
+```text
+reader on billing: bound
+editor on billing: a human decides: apr_…
+admin with the editor approval: refused; admin is never an agent action
+editor with the editor approval: bound
+bindings: [('billing', 'ana@example.com', 'reader'), ('billing', 'ana@example.com', 'editor')]
+```
+
+`admin` is refused by the policy before the approval is even considered. Had the policy allowed
+it with approval, the approval for `editor` would still not have matched: it is bound to the
+hash of `editor`, and `admin` hashes differently.
+
+## The receipt
+
+```bash runnable
+ctrlrun receipts --last 4
+```
+
+## When an AMBIGUOUS appears
+
+An IAM call that timed out may have bound the role. Read the binding back from the provider,
+then `ctrlrun resolve grant:ana@example.com:editor --committed` or `--failed`. Granting a role
+twice is usually idempotent at the provider, but the receipt should say what happened, not what
+was assumed.
+
+## Next
+
+- [A credential-rotation agent](/cookbook/credential-rotation-agent).
+- [Approval binding](/concepts/approval-binding) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/index.mdx
+++ b/docs/cookbook/index.mdx
@@ -1,0 +1,59 @@
+---
+title: "Cookbook"
+description: "One recipe per real situation: the policy, the code with a fake remote, what the agent sees when refused or asked, the receipt."
+---
+
+Each recipe is a situation an agent is put in, across money, infrastructure, permissions,
+records and communications, and shows the policy, the code against a stand-in remote, what the
+agent sees when it is refused or asked, the receipt, and what to do when an effect's outcome is
+unknown. Every runnable block runs offline in this repository's CI, and every recipe with code
+is also a directory under `examples/cookbook/` extracted from its page.
+
+## Money
+
+- [A refund agent with amount tiers](/cookbook/refund-agent)
+- [A payout agent with maker/checker via delegation](/cookbook/payout-maker-checker)
+
+## Infrastructure
+
+- [A deploy agent](/cookbook/deploy-agent)
+- [A database-migration agent](/cookbook/database-migration-agent)
+
+## Permissions
+
+- [An IAM agent that can grant read but never admin](/cookbook/iam-agent)
+- [A credential-rotation agent](/cookbook/credential-rotation-agent)
+
+## Records
+
+- [A CRM-update agent](/cookbook/crm-update-agent)
+- [A data-deletion agent under a retention rule](/cookbook/data-deletion-agent)
+
+## Communications
+
+- [An outbound-email agent with external-recipient approval](/cookbook/outbound-email-agent)
+- [A customer-notification agent](/cookbook/customer-notification-agent)
+
+## Multi-agent
+
+- [A manager agent delegating bounded authority to a worker](/cookbook/manager-and-worker)
+
+## Integrations
+
+- [Protect an existing MCP server in five minutes](/cookbook/protect-an-mcp-server)
+- [LangGraph with interrupt()](/cookbook/langgraph-interrupt)
+- [OpenAI Agents SDK tool approval](/cookbook/openai-agents-tool-approval)
+- [Approvals in Slack via webhook](/cookbook/slack-approvals)
+- [Receipts into OpenTelemetry](/cookbook/receipts-to-opentelemetry)
+
+## Operations
+
+- [Observe for a week, then enforce](/cookbook/observe-then-enforce)
+- [Resolve an ambiguous effect](/cookbook/resolve-an-ambiguous-effect)
+- [Reconcile against Stripe or Kubernetes automatically](/cookbook/reconcile-against-the-remote)
+- [Run verify in GitHub Actions](/cookbook/verify-in-github-actions)
+- [Move from SQLite to Postgres](/cookbook/sqlite-to-postgres)
+
+## Next
+
+- [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/langgraph-interrupt.mdx
+++ b/docs/cookbook/langgraph-interrupt.mdx
@@ -1,0 +1,98 @@
+---
+title: "LangGraph with interrupt()"
+description: "Route a refund's approval through LangGraph's own interrupt(): the operator builds the Control."
+---
+
+A LangGraph agent issues refunds from a node. When the policy says a human must approve, the
+request should surface as the graph's own interrupt, where your operators already answer, and
+the yes must not be reusable for a different amount. The adapter buys exactly that and nothing
+else; `@protect` alone already covers the node.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }
+        decision: allow
+      - decision: approve
+```
+
+## The code
+
+This is the adapter's own example. It needs `pip install ctrlrun-langgraph` and a LangGraph
+install, which the harness that runs the other recipes does not have; the adapter's tests run
+this shape against a real `langgraph` in this repository's CI, and the adapter's README carries
+the conformance results.
+
+```python
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import START, StateGraph
+from langgraph.types import Command
+
+from ctrlrun import Control, InterruptApprovalProvider, Policy, SQLiteStateStore, context, protect
+from ctrlrun_langgraph import LangGraphInterrupt
+
+store = SQLiteStateStore(".ctrlrun/state.db")
+control = Control(
+    Policy.from_file("ctrlrun.yaml"),
+    store,
+    approvals=InterruptApprovalProvider(store, LangGraphInterrupt(carries_approved_arguments=True)),
+)
+
+
+@protect("stripe.refund", effect="refund:{payment_id}", wait=True, control=control)
+def issue_refund(payment_id: str, amount: int) -> str:
+    return stripe.Refund.create(payment_intent=payment_id, amount=amount).status
+
+
+def refund_node(state: dict) -> dict:
+    with context(agent="refund-agent"):
+        return {"status": issue_refund(payment_id=state["payment_id"], amount=state["amount"])}
+
+
+graph = StateGraph(dict).add_node("refund", refund_node).add_edge(START, "refund").compile(
+    checkpointer=InMemorySaver()
+)
+config = {"configurable": {"thread_id": "ticket-4471"}}
+
+result = graph.invoke({"payment_id": "txn_2", "amount": 250000}, config)
+if "__interrupt__" in result:
+    pending = graph.get_state(config).tasks[0].interrupts[0].value
+    # `pending` is JSON: action, arguments, resource, principal, hash, expiry. Show it to a human.
+    result = graph.invoke(
+        Command(resume={"approved": True, "approver": "ada@example.com", "arguments": pending["arguments"]}),
+        config,
+    )
+print(result["status"])
+```
+
+## What the agent sees
+
+The €2,500 refund interrupts the graph with a payload naming the action and its arguments.
+Resuming with `approved: True` and the arguments the human saw runs it once. Resuming with
+different arguments is refused with `ApprovalMismatch`, the approval is left grantable, and
+nothing runs. Resuming with `approved: False` refuses and records who said no.
+
+## The receipt
+
+The receipt is the same shape as one from `ctrlrun approve`: `approve/committed`, approver
+`ada@example.com`. The node ran twice, once to ask and once on resume, so the log holds two
+`action_id`s and two approval requests for one refund; the `action_hash` is continuous, which is
+why the binding is about content and never about an id.
+
+## When an AMBIGUOUS appears
+
+If Stripe's reply is lost inside the resumed node, the effect is `AMBIGUOUS` and the graph's
+retry, or a re-run of the thread, is refused. Resolve it with `ctrlrun resolve refund:txn_2
+--committed` or `--failed`; the approval was spent on the execution, so a retry after `--failed`
+needs a new interrupt.
+
+## Next
+
+- [Use the LangGraph adapter](/guides/langgraph-adapter): prevention versus attribution, and where LangGraph shows through.
+- [Approval binding](/concepts/approval-binding) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/manager-and-worker.mdx
+++ b/docs/cookbook/manager-and-worker.mdx
@@ -1,0 +1,183 @@
+---
+title: "A manager agent delegating bounded authority to a worker"
+description: "A manager agent holds a delegable grant, hands a worker a narrower slice for one job, the worker cannot exceed or widen it."
+---
+
+A manager agent plans a job and hands parts of it to worker agents. Each worker should hold
+exactly the authority its part needs, for the time the job takes, and nothing the manager
+does not itself hold. When the job ends, one revocation should remove every worker's authority
+at once.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v3
+
+authority:
+  max_delegation_depth: 3
+  grants:
+    - id: ops-manager
+      subject: { agent: "ops-manager" }
+      actions: ["k8s.rollout_restart", "k8s.scale"]
+      resources: ["cluster:*"]
+      constraints: { replicas_gte: 0, replicas_lte: 50 }
+      environments: ["production"]
+      delegable: true
+      expires_at: "2027-01-01T00:00:00Z"
+
+actions:
+  k8s.rollout_restart:
+    effect: "restart:{cluster}:{deployment}"
+    resource: "cluster:{cluster}"
+    decision: allow
+  k8s.scale:
+    effect: "scale:{cluster}:{deployment}:{replicas}"
+    resource: "cluster:{cluster}"
+    decision: allow
+```
+
+## The code
+
+```python runnable file=main.py
+from pathlib import Path
+
+from ctrlrun import (
+    Action,
+    Authority,
+    AuthorityDenied,
+    AuthorityEscalation,
+    Control,
+    Policy,
+    Principal,
+    SQLiteStateStore,
+)
+from ctrlrun.authority import grant_from_yaml
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+MANAGER = Principal(agent="ops-manager")
+WORKER = Principal(agent="scale-worker")
+document = (HERE / "ctrlrun.yaml").read_text(encoding="utf-8")
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(
+    Policy.from_yaml(document, source="ctrlrun.yaml"),
+    store,
+    authority=Authority.from_yaml(document, source="ctrlrun.yaml"),
+    environment="production",
+)
+scaled: list[tuple[str, int]] = []
+
+
+def scale(who: Principal, cluster: str, deployment: str, replicas: int) -> None:
+    control.execute(
+        Action(
+            name="k8s.scale",
+            arguments={"cluster": cluster, "deployment": deployment, "replicas": replicas},
+            principal=who,
+            resource=f"cluster:{cluster}",
+        ),
+        lambda: scaled.append((deployment, replicas)),
+        f"scale:{cluster}:{deployment}:{replicas}",
+    )
+
+
+# The worker gets scaling only, on one cluster, up to 10 replicas, for a day.
+job = control.delegate(
+    "ops-manager",
+    grant_from_yaml("""
+subject: { agent: "scale-worker" }
+actions: ["k8s.scale"]
+resources: ["cluster:prod-eu"]
+constraints: { replicas_gte: 0, replicas_lte: 10 }
+environments: ["production"]
+expires_at: "2026-12-01T00:00:00Z"
+"""),
+    by=MANAGER,
+)
+print("worker's grant:", job.delegation_id)
+
+scale(WORKER, "prod-eu", "checkout", 6)
+print("worker scales checkout to 6 on prod-eu: done")
+
+try:
+    scale(WORKER, "prod-eu", "checkout", 40)
+except AuthorityDenied as refused:
+    print("worker scales to 40: refused,", refused.reason)
+else:
+    raise SystemExit("the worker exceeded its slice")
+
+try:
+    scale(WORKER, "prod-us", "checkout", 6)
+except AuthorityDenied as refused:
+    print("worker scales on prod-us: refused,", refused.reason)
+else:
+    raise SystemExit("the worker acted outside its cluster")
+
+try:
+    control.delegate(
+        "ops-manager",
+        grant_from_yaml("""
+subject: { agent: "scale-worker" }
+actions: ["k8s.scale"]
+resources: ["cluster:prod-eu"]
+environments: ["production"]
+expires_at: "2026-12-01T00:00:00Z"
+"""),
+        by=MANAGER,
+    )
+except AuthorityEscalation as refused:
+    print("a slice that omits constraints: refused,", refused.reason, refused.dimension)
+else:
+    raise SystemExit("an omitted dimension was inherited as unlimited")
+
+# The job is over.
+control.revoke(job.delegation_id, by="ops-manager")
+try:
+    scale(WORKER, "prod-eu", "checkout", 4)
+except AuthorityDenied as refused:
+    print("worker after revocation: refused,", refused.reason)
+else:
+    raise SystemExit("a revoked worker still acted")
+
+print("scaling calls:", scaled)
+store.close()
+```
+
+## What the agent sees
+
+```text
+worker's grant: dlg_…
+worker scales checkout to 6 on prod-eu: done
+worker scales to 40: refused, authority_constraint
+worker scales on prod-us: refused, no_authority
+a slice that omits constraints: refused, containment constraints
+worker after revocation: refused, authority_revoked
+scaling calls: [('checkout', 6)]
+```
+
+Omitting `constraints:` in the second delegation was refused, not inherited: a slice that
+names no replica limit would have authorized what the manager's own grant caps.
+
+## The receipt
+
+```bash runnable
+ctrlrun receipts --last 2
+```
+
+Every refusal is an `AUTHORITY_DENIED` event naming the grant it failed against; the delegation
+and the revocation are `DELEGATION_CREATED` and `DELEGATION_REVOKED`, with who did each.
+
+## When an AMBIGUOUS appears
+
+A scale call that timed out may have applied. Read the deployment's replica count, then
+`ctrlrun resolve scale:prod-eu:checkout:6 --committed` or `--failed`. A worker whose grant has
+since been revoked cannot retry either way; the resolution is the manager's or a human's.
+
+## Next
+
+- [A payout agent with maker/checker](/cookbook/payout-maker-checker).
+- [Authority and delegation](/concepts/authority-and-delegation) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/observe-then-enforce.mdx
+++ b/docs/cookbook/observe-then-enforce.mdx
@@ -1,0 +1,126 @@
+---
+title: "Observe for a week, then enforce"
+description: "Run the real policy in observe mode against real traffic, execute everything, record what enforcement would have blocked."
+---
+
+You have an agent in production and no idea what a policy would cost. Put the policy in
+front of it in observe mode: every action executes as before, every receipt says what enforce
+mode would have done, and after a week `ctrlrun stats` gives you the refusals and approval
+requests you would have fielded. Then change the one line.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v3
+mode: observe
+
+actions:
+  crm.update_record:
+    effect: "crm:{record_id}:{field}:{revision}"
+    decision: allow
+  email.send:
+    effect: "email:{message_id}"
+    rules:
+      - when: { to_domain_eq: "example.com" }
+        decision: allow
+      - decision: approve
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 500000 }
+        decision: approve
+      - decision: deny
+```
+
+## The code
+
+```python runnable file=main.py
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+executed: list[str] = []
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect("crm.update_record", effect="crm:{record_id}:{field}:{revision}", control=control)
+def update(record_id: str, field: str, value: str, revision: int) -> str:
+    executed.append("update")
+    return "updated"
+
+
+@ctrlrun.protect("email.send", effect="email:{message_id}", control=control)
+def send(message_id: str, to_domain: str) -> str:
+    executed.append("send")
+    return "sent"
+
+
+@ctrlrun.protect("stripe.refund", effect="refund:{payment_id}", control=control)
+def refund(payment_id: str, amount: int) -> str:
+    executed.append("refund")
+    return "refunded"
+
+
+# A week of traffic, compressed.
+with ctrlrun.context(agent="support-agent"):
+    update(record_id="c_1", field="phone", value="+353 1 555 0100", revision=3)
+    send(message_id="m_1", to_domain="example.com")
+    send(message_id="m_2", to_domain="gmail.com")  # would have needed a human
+    refund(payment_id="txn_1", amount=12000)
+    refund(payment_id="txn_2", amount=250000)  # would have needed a human
+    refund(payment_id="txn_3", amount=900000)  # would have been denied
+    refund(payment_id="txn_1", amount=12000)  # would have been a duplicate
+
+print("actions executed:", len(executed))
+if len(executed) != 7:
+    raise SystemExit("observe mode blocked something; it must execute everything")
+
+for receipt in store.receipts():
+    if receipt.would_have is not None and receipt.would_have.blocked_reason:
+        print(f"{receipt.action} would have been blocked: {receipt.would_have.blocked_reason}")
+```
+
+## What the agent sees
+
+```text
+actions executed: 7
+email.send would have been blocked: approval_required
+stripe.refund would have been blocked: approval_required
+stripe.refund would have been blocked: rule[2]
+stripe.refund would have been blocked: duplicate
+```
+
+Seven actions, seven executions. The mail to `gmail.com` went out; so did the €9,000 refund.
+Observe mode asks no human and stops nothing. It only writes down what it would have done.
+
+## The receipt
+
+```bash runnable
+ctrlrun stats
+```
+
+The numbers are counted from `would_have.blocked_reason` on the receipts in the local store,
+nothing else. Change `mode: observe` to `mode: enforce` and the same receipts become `BLOCKED`
+receipts and approval requests.
+
+## When an AMBIGUOUS appears
+
+Observe mode changes nothing about outcomes: a lost reply is `AMBIGUOUS` in observe mode too,
+and the record is written. What differs is that observe mode records that a retry *would* have
+been refused and lets it run, so resolve the effect before switching to enforce, or the first
+enforced retry is refused.
+
+## Next
+
+- [Roll out observe, then enforce](/guides/observe-to-enforce): the week, the numbers and the switch.
+- [Observe mode](/concepts/observe-mode) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/openai-agents-tool-approval.mdx
+++ b/docs/cookbook/openai-agents-tool-approval.mdx
@@ -1,0 +1,90 @@
+---
+title: "OpenAI Agents SDK tool approval"
+description: "Route a refund's approval through the OpenAI Agents SDK's own tool-approval interruption."
+---
+
+An Agents SDK agent has a refund tool. When the policy says a human must approve, the run
+should stop with the SDK's own `ToolApprovalItem`, where this SDK's users already answer, and
+a refusal must reach your code as an exception rather than the model as text to retry.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }
+        decision: allow
+      - decision: approve
+```
+
+## The code
+
+This is the adapter's own example. It needs `pip install ctrlrun-openai-agents` and the SDK,
+which the harness that runs the other recipes does not have; the adapter's tests run this shape
+against a real `openai-agents` in this repository's CI.
+
+```python
+from agents import Agent
+
+import ctrlrun_openai_agents as gate
+from ctrlrun import Control, InterruptApprovalProvider, Policy, SQLiteStateStore, protect
+from ctrlrun_openai_agents import AgentsInterrupt, protected_tool
+
+store = SQLiteStateStore(".ctrlrun/state.db")
+control = Control(Policy.from_file("ctrlrun.yaml"), store, approvals=InterruptApprovalProvider(store, AgentsInterrupt()))
+
+
+@protect("stripe.refund", effect="refund:{payment_id}", wait=True, control=control)
+def issue_refund(payment_id: str, amount: int) -> str:
+    return stripe.Refund.create(payment_intent=payment_id, amount=amount).status
+
+
+async def refund_tool(payment_id: str, amount: int) -> str:
+    """Issue a refund for a payment. Amounts are in integer minor units."""
+    return issue_refund(payment_id=payment_id, amount=amount)
+
+
+agent = Agent(name="refunds", tools=[protected_tool(control, "stripe.refund", refund_tool)])
+
+result = await gate.run(agent, "refund txn_2 by 2500 euros")
+if result.interruptions:
+    state = result.to_state()
+    for item in result.interruptions:
+        print("a human decides on", item.name, item.arguments)
+        state.approve(item)                     # or state.reject(item)
+    result = await gate.run(agent, state)
+print(result.final_output)
+```
+
+## What the agent sees
+
+The SDK asks before invoking, because `protected_tool` answers its `needs_approval` from the
+policy; the run returns with one interruption naming the tool and its arguments. After
+`state.approve(item)` the resumed run invokes the tool with exactly that call's arguments, and
+CTRLRun records `openai-agents:tool-approval` as the approver. A refusal by CTRLRun, a
+duplicate for instance, reaches your `except` as `DuplicateEffect` through `gate.run`, not the
+model as "please try again".
+
+## The receipt
+
+`approve/committed`. The binding across the interrupt is the SDK's, keyed by `call_id`, so the
+receipt attributes the approval and cannot re-check the arguments against the hash: that is
+attribution, and the adapter's README says so in that word. A rejection leaves no CTRLRun
+evidence at all, because the SDK never invokes a rejected tool; record it where you call
+`state.reject(item)`.
+
+## When an AMBIGUOUS appears
+
+The SDK's default would surface a lost reply to the model as text, and the measured behaviour
+is that the model retries until the refund lands three or four times. With `effect=` declared,
+the retry is refused with `AmbiguousEffect`, which `gate.run` returns as itself; resolve with
+`ctrlrun resolve refund:txn_2 --committed` or `--failed`.
+
+## Next
+
+- [Use the OpenAI Agents SDK adapter](/guides/openai-agents-adapter): where the SDK shows through, and `ApprovalNotAsked`.
+- [Three ways in](/get-started/three-ways-in) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/outbound-email-agent.mdx
+++ b/docs/cookbook/outbound-email-agent.mdx
@@ -1,0 +1,125 @@
+---
+title: "An outbound-email agent with external-recipient approval"
+description: "An agent sends email: messages inside the company go on their own, any message to an external domain waits for a human who sees the exact recipient."
+---
+
+An assistant drafts and sends email on a team's behalf. Internal mail is routine. Anything
+leaving the company waits for a person, who sees the exact recipient, and the approval is
+bound to that recipient: an agent that re-plans the address after the yes finds its approval
+matches nothing.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  email.send:
+    effect: "email:{message_id}"
+    rules:
+      - when: { to_domain_eq: "example.com" }
+        decision: allow
+      - decision: approve
+```
+
+## The code
+
+```python runnable file=main.py
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+sent: list[str] = []
+
+
+def smtp_send(message_id: str, to: str) -> str:
+    sent.append(to)
+    return "sent"
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect("email.send", effect="email:{message_id}", control=control)
+def send(message_id: str, to: str, to_domain: str, subject: str) -> str:
+    return smtp_send(message_id, to)
+
+
+with ctrlrun.context(agent="assistant"):
+    print(
+        "to a colleague:",
+        send(message_id="m_1", to="li@example.com", to_domain="example.com", subject="Q3 numbers"),
+    )
+
+    try:
+        send(message_id="m_2", to="press@partner.co", to_domain="partner.co", subject="Q3 numbers")
+    except ctrlrun.ApprovalRequired as pending:
+        print("to partner.co: a human decides:", pending.request_id)
+        request_id = pending.request_id
+    else:
+        raise SystemExit("external mail went out without a human")
+
+    store.grant_approval(request_id, "human:li@example.com")
+    with ctrlrun.with_approval(request_id):
+        # The agent re-plans the recipient after the yes.
+        try:
+            send(
+                message_id="m_2",
+                to="tips@journalist.example",
+                to_domain="journalist.example",
+                subject="Q3 numbers",
+            )
+        except ctrlrun.ApprovalMismatch:
+            print("to a different address with the same approval: refused")
+        else:
+            raise SystemExit("an approval for one recipient sent mail to another")
+        print(
+            "to partner.co, as approved:",
+            send(
+                message_id="m_2",
+                to="press@partner.co",
+                to_domain="partner.co",
+                subject="Q3 numbers",
+            ),
+        )
+
+print("messages sent:", sent)
+```
+
+## What the agent sees
+
+```text
+to a colleague: sent
+to partner.co: a human decides: apr_…
+to a different address with the same approval: refused
+to partner.co, as approved: sent
+messages sent: ['li@example.com', 'press@partner.co']
+```
+
+The approval hashed `to`, `to_domain`, `subject` and `message_id` together. Any of them changing
+after the yes is a different action.
+
+## The receipt
+
+```bash runnable
+ctrlrun receipts --last 4
+```
+
+## When an AMBIGUOUS appears
+
+An SMTP submission that timed out may have been accepted. Check the provider's message log for
+`m_N`, then `ctrlrun resolve email:m_N --committed` or `--failed`. The effect key is the message
+id, so a resend of the same message is one effect and a new message is a new one.
+
+## Next
+
+- [A customer-notification agent](/cookbook/customer-notification-agent).
+- [Approval binding](/concepts/approval-binding) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/payout-maker-checker.mdx
+++ b/docs/cookbook/payout-maker-checker.mdx
@@ -1,0 +1,201 @@
+---
+title: "A payout agent with maker/checker via delegation"
+description: "A treasury lead holds a delegable grant, delegates a narrower slice to a payout agent."
+---
+
+A payout agent moves money out of the platform on behalf of a treasury lead. The lead may
+delegate a bounded slice of that authority to the agent, the agent may never widen it, and
+every payout above the desk limit still needs a second person before it runs.
+
+## The policy
+
+Authority and policy are separate axes. The grant says the lead may propose payouts to
+€100,000 and may delegate; the policy says anything above €10,000 needs a human, whoever asks.
+
+```yaml runnable
+schema: ctrlrun.policy/v3
+
+authority:
+  grants:
+    - id: treasury-lead
+      subject: { agent: "treasury-lead", user: "mira@example.com" }
+      actions: ["bank.payout"]
+      resources: ["account:*"]
+      constraints: { amount_gte: 0, amount_lte: 10000000 }
+      environments: ["production"]
+      delegable: true
+      expires_at: "2027-01-01T00:00:00Z"
+
+actions:
+  bank.payout:
+    effect: "payout:{account}:{reference}"
+    resource: "account:{account}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 1000000 }
+        decision: allow
+      - decision: approve
+```
+
+## The code
+
+```python runnable file=main.py
+from pathlib import Path
+
+from ctrlrun import (
+    Action,
+    ApprovalRequired,
+    Authority,
+    AuthorityDenied,
+    AuthorityEscalation,
+    Control,
+    Policy,
+    Principal,
+    SQLiteStateStore,
+    with_approval,
+)
+from ctrlrun.authority import grant_from_yaml
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+LEAD = Principal(agent="treasury-lead", user="mira@example.com")
+AGENT = Principal(agent="payout-agent", user="mira@example.com")
+document = (HERE / "ctrlrun.yaml").read_text(encoding="utf-8")
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(
+    Policy.from_yaml(document, source="ctrlrun.yaml"),
+    store,
+    authority=Authority.from_yaml(document, source="ctrlrun.yaml"),
+    environment="production",
+)
+paid: list[tuple[str, int]] = []
+
+
+def payout(account: str, reference: str, amount: int) -> dict:
+    paid.append((reference, amount))
+    return {"reference": reference, "status": "sent"}
+
+
+def proposal(who: Principal, account: str, reference: str, amount: int) -> Action:
+    return Action(
+        name="bank.payout",
+        arguments={"account": account, "reference": reference, "amount": amount},
+        principal=who,
+        resource=f"account:{account}",
+    )
+
+
+# The lead hands the agent a €25,000 slice, itself delegable so the agent could pass a narrower
+# one on. Every dimension is stated: omission is rejected, never inherited.
+slice_ = grant_from_yaml("""
+subject: { agent: "payout-agent", user: "mira@example.com" }
+actions: ["bank.payout"]
+resources: ["account:ops-*"]
+constraints: { amount_gte: 0, amount_lte: 2500000 }
+environments: ["production"]
+delegable: true
+expires_at: "2026-12-31T00:00:00Z"
+""")
+delegation = control.delegate("treasury-lead", slice_, by=LEAD)
+print("delegated to the payout agent:", delegation.delegation_id)
+
+# €8,000: inside the slice, inside the autonomous band. Runs.
+control.execute(
+    proposal(AGENT, "ops-eu", "inv-1042", 800000),
+    lambda: payout("ops-eu", "inv-1042", 800000),
+    "payout:ops-eu:inv-1042",
+)
+print("€8,000 payout: sent")
+
+# €18,000: inside the slice, above the desk limit. A second person.
+try:
+    control.execute(
+        proposal(AGENT, "ops-eu", "inv-1043", 1800000),
+        lambda: payout("ops-eu", "inv-1043", 1800000),
+        "payout:ops-eu:inv-1043",
+    )
+except ApprovalRequired as pending:
+    print("€18,000 payout: a checker decides:", pending.request_id)
+    store.grant_approval(pending.request_id, "checker:sam@example.com")
+    with with_approval(pending.request_id):
+        control.execute(
+            proposal(AGENT, "ops-eu", "inv-1043", 1800000),
+            lambda: payout("ops-eu", "inv-1043", 1800000),
+            "payout:ops-eu:inv-1043",
+        )
+    print("€18,000 payout, checked: sent")
+else:
+    raise SystemExit("a payout above the desk limit ran without a checker")
+
+# €40,000: outside the slice. Authority refuses before the policy is asked.
+try:
+    control.execute(
+        proposal(AGENT, "ops-eu", "inv-1044", 4000000),
+        lambda: payout("ops-eu", "inv-1044", 4000000),
+        "payout:ops-eu:inv-1044",
+    )
+except AuthorityDenied as refused:
+    print("€40,000 payout: refused,", refused.reason)
+else:
+    raise SystemExit("a payout outside the delegated grant ran")
+
+# The agent tries to widen its own slice.
+try:
+    control.delegate(
+        delegation.delegation_id,
+        grant_from_yaml("""
+subject: { agent: "payout-agent", user: "mira@example.com" }
+actions: ["bank.payout"]
+resources: ["account:*"]
+constraints: { amount_gte: 0, amount_lte: 9000000 }
+environments: ["production"]
+expires_at: "2026-12-31T00:00:00Z"
+"""),
+        by=AGENT,
+    )
+except AuthorityEscalation as refused:
+    print("widening the slice: refused,", refused.reason, refused.dimension)
+else:
+    raise SystemExit("an agent widened its own authority")
+
+print("payouts sent:", len(paid))
+store.close()
+```
+
+## What the agent sees
+
+```text
+delegated to the payout agent: dlg_…
+€8,000 payout: sent
+€18,000 payout: a checker decides: apr_…
+€18,000 payout, checked: sent
+€40,000 payout: refused, authority_constraint
+widening the slice: refused, containment resources
+payouts sent: 2
+```
+
+The maker is the agent, the checker is whoever answers the approval, and the delegation is what
+bounds the maker. `ctrlrun revoke dlg_…` cuts it with one write.
+
+## The receipt
+
+```bash runnable
+ctrlrun receipts --last 3
+```
+
+Each receipt names the principal and, for the checked payout, the approver. The refusal for
+€40,000 is an `AUTHORITY_DENIED` event with no approval request behind it: authority runs first,
+and a denial there never leaves a pending request.
+
+## When an AMBIGUOUS appears
+
+A payout whose confirmation was lost is `AMBIGUOUS`. Ask the bank by reference, then
+`ctrlrun resolve payout:ops-eu:inv-N --committed` or `--failed`. Never re-send on a guess.
+
+## Next
+
+- [A manager agent delegating to a worker](/cookbook/manager-and-worker).
+- [Authority and delegation](/concepts/authority-and-delegation) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/protect-an-mcp-server.mdx
+++ b/docs/cookbook/protect-an-mcp-server.mdx
@@ -1,0 +1,162 @@
+---
+title: "Protect an existing MCP server in five minutes"
+description: "Put the gateway in front of an MCP server you already run: name its tools in a policy, start ctrlrun gateway."
+---
+
+You run an MCP server and an agent that calls it. In production the gateway is a process
+between them, started with one command; here the same gateway object is driven in process
+against a stand-in upstream, so the recipe runs offline and shows exactly what the agent gets
+back. [The gateway in five minutes](/mcp/gateway-in-5-minutes) has the production commands.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  mcp.ops.get_deployment:
+    decision: allow
+  mcp.ops.restart_deployment:
+    effect: "restart:{cluster}:{name}"
+    decision: allow
+  mcp.ops.delete_namespace:
+    effect: "namespace:{cluster}:{name}"
+    decision: approve
+```
+
+## The code
+
+```python runnable file=main.py
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ctrlrun import Control, Policy, SQLiteStateStore
+from ctrlrun.gateway.mcp import CURRENT_REVISION
+from ctrlrun.gateway.outcome import COMPLETE, UpstreamResult
+from ctrlrun.gateway.server import Gateway, GatewayConfig
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+upstream_calls: list[dict] = []
+
+
+def upstream(
+    body: bytes, headers: Mapping[str, str], *, fresh: bool
+) -> tuple[Any, bytes, int, dict[str, str]]:
+    """The MCP server, as the gateway sees it: a stand-in that answers every tools/call."""
+    request = json.loads(body)
+    upstream_calls.append(request)
+    reply = {
+        "jsonrpc": "2.0",
+        "id": request["id"],
+        "result": {"content": [{"type": "text", "text": "ok"}]},
+    }
+    return (
+        UpstreamResult(result_type=COMPLETE),
+        json.dumps(reply).encode(),
+        200,
+        {"content-type": "application/json"},
+    )
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+config = GatewayConfig(upstream="http://localhost:8000/mcp", alias="ops", principal="oncall-agent")
+gateway = Gateway(config, control, upstream)
+
+
+def call(tool: str, arguments: dict, rpc_id: int) -> dict:
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": rpc_id,
+            "method": "tools/call",
+            "params": {"name": tool, "arguments": arguments},
+        }
+    ).encode()
+    headers = {
+        "MCP-Protocol-Version": CURRENT_REVISION,
+        "Mcp-Method": "tools/call",
+        "Mcp-Name": tool,
+        "Content-Type": "application/json",
+    }
+    response = gateway.handle(body, headers)
+    return {"status": response.status, **json.loads(response.body)}
+
+
+first = call("restart_deployment", {"cluster": "prod-eu", "name": "checkout"}, 1)
+print("restart_deployment:", first["status"], first["result"]["content"][0]["text"])
+
+again = call("restart_deployment", {"cluster": "prod-eu", "name": "checkout"}, 2)
+print(
+    "the same restart again:",
+    again["status"],
+    again["error"]["code"],
+    again["error"]["data"]["error"],
+)
+if "error" not in again:
+    raise SystemExit("a duplicate restart reached the upstream")
+
+held = call("delete_namespace", {"cluster": "prod-eu", "name": "checkout"}, 3)
+print(
+    "delete_namespace:",
+    held["status"],
+    held["error"]["code"],
+    held["error"]["data"]["error"],
+    "request",
+    held["error"]["data"]["request_id"][:4] + "…",
+)
+if "error" not in held:
+    raise SystemExit("a namespace delete reached the upstream without a human")
+
+unknown = call("drop_database", {"name": "prod"}, 4)
+print(
+    "drop_database (not in the policy):",
+    unknown["status"],
+    unknown["error"]["code"],
+    unknown["error"]["data"]["error"],
+)
+
+print("calls that reached the upstream:", len(upstream_calls))
+store.close()
+```
+
+## What the agent sees
+
+```text
+restart_deployment: 200 ok
+the same restart again: 409 -41004 ctrlrun.duplicate_effect
+delete_namespace: 403 -41002 ctrlrun.approval_required request apr_…
+drop_database (not in the policy): 403 -41001 ctrlrun.denied
+calls that reached the upstream: 1
+```
+
+One call reached the server. The other three came back as JSON-RPC errors with codes a client
+can act on, never as tool results the model would read as text and retry.
+
+## The receipt
+
+```bash runnable
+ctrlrun receipts --last 4
+```
+
+Every `tools/call` has a receipt, refused ones too, named `mcp.ops.<tool>`.
+
+## When an AMBIGUOUS appears
+
+An upstream that commits and then drops the connection comes back as `-41010`,
+`ctrlrun.upstream_ambiguous`, and the identical call is refused with `-41005` until a human
+runs `ctrlrun resolve restart:prod-eu:checkout --committed` or `--failed`. For an upstream whose
+in-band error means it did nothing, set `mcp: {not_executed_on_error: true}` on the action and
+such errors become `FAILED` rather than unknown.
+
+## Next
+
+- [The gateway in five minutes](/mcp/gateway-in-5-minutes): the production commands and the full code table.
+- [Put the gateway in front of MCP](/guides/gateway-in-front-of-mcp) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/receipts-to-opentelemetry.mdx
+++ b/docs/cookbook/receipts-to-opentelemetry.mdx
@@ -1,0 +1,118 @@
+---
+title: "Receipts into OpenTelemetry"
+description: "Attach OTelEventSink to the Control and every action becomes one span with one event per step in your tracing backend."
+---
+
+Your team already looks at traces. Put every protected action there: one span per action,
+named for it, one span event per step, an error status for `failed` and `ambiguous`, and no
+argument values unless you opt in, because a trace backend is not the receipt store.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }
+        decision: allow
+      - decision: deny
+```
+
+## The code
+
+```python runnable file=main.py
+import contextlib
+from pathlib import Path
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+from ctrlrun.otel import OTelEventSink
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+exporter = InMemorySpanExporter()  # your OTLP exporter in production
+provider = TracerProvider()
+provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(
+    Policy.from_file(HERE / "ctrlrun.yaml"),
+    store,
+    sinks=[OTelEventSink(tracer_provider=provider)],
+)
+
+
+@ctrlrun.protect("stripe.refund", effect="refund:{payment_id}", control=control)
+def refund(payment_id: str, amount: int) -> str:
+    if payment_id == "txn_lost":
+        raise TimeoutError("no response from api.stripe.com")
+    return "refunded"
+
+
+with ctrlrun.context(agent="support-agent"):
+    refund(payment_id="txn_1", amount=12000)
+    try:
+        refund(payment_id="txn_2", amount=900000)
+    except ctrlrun.ActionDenied:
+        pass
+    else:
+        raise SystemExit("a €9,000 refund ran")
+    with contextlib.suppress(TimeoutError):
+        refund(payment_id="txn_lost", amount=12000)
+
+for span in exporter.get_finished_spans():
+    events = [event.name for event in span.events]
+    result = span.attributes.get("ctrlrun.result")
+    print(
+        f"{span.name}  status={span.status.status_code.name}  result={result}  events={len(events)}"
+    )
+    if any("12000" in str(value) for value in span.attributes.values()):
+        raise SystemExit("an argument value leaked into the span attributes")
+print("argument values in attributes: none")
+```
+
+## What the agent sees
+
+The agent sees nothing different; the sink never blocks and never changes an outcome. The
+trace backend sees:
+
+```text
+stripe.refund  status=OK  result=committed  events=5
+stripe.refund  status=UNSET  result=denied  events=3
+stripe.refund  status=ERROR  result=ambiguous  events=5
+argument values in attributes: none
+```
+
+A refusal is `UNSET`, not an error: CTRLRun doing its job is not a fault in the trace.
+
+## The receipt
+
+```bash runnable
+ctrlrun receipts --last 3
+```
+
+The receipts are still in the store and the JSONL file, chained; the spans carry the receipt
+id so a trace can be joined back to the evidence. Deleting a trace deletes nothing CTRLRun
+relies on.
+
+## When an AMBIGUOUS appears
+
+The span's status is `ERROR` and its result attribute is `ambiguous`, which is the alert to
+build: a span whose result is ambiguous is an effect waiting for `ctrlrun resolve`. The
+resolution is a later event, not a change to the span.
+
+## Next
+
+- [Export to OpenTelemetry](/guides/export-to-opentelemetry): the OTLP exporter and the gateway's `--otel`.
+- [Receipts and evidence](/concepts/receipts-and-evidence) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/reconcile-against-the-remote.mdx
+++ b/docs/cookbook/reconcile-against-the-remote.mdx
@@ -1,0 +1,147 @@
+---
+title: "Reconcile against Stripe or Kubernetes automatically"
+description: "A reconcile hook per action asks the remote what happened to an effect key, so a lost Stripe reply or a dropped kubectl connection resolves itself."
+---
+
+Two agents, two remotes that can be asked. Stripe can list refunds by payment; Kubernetes
+can be read for a deployment's state. A `reconcile` hook per action turns a lost reply into a
+question the remote answers, and the record moves only the way the answer points.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    decision: allow
+  k8s.scale:
+    effect: "scale:{cluster}:{deployment}:{replicas}"
+    decision: allow
+```
+
+## The code
+
+```python runnable file=main.py
+import contextlib
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+stripe_refunds: dict[str, int] = {}  # what Stripe holds
+replicas: dict[str, int] = {"checkout": 3}  # what the cluster holds
+calls: list[str] = []
+
+
+def stripe_refund(payment_id: str, amount: int) -> str:
+    calls.append(f"refund {payment_id}")
+    stripe_refunds[payment_id] = amount  # committed...
+    raise TimeoutError("no response from api.stripe.com")  # ...reply lost
+
+
+def kubectl_scale(deployment: str, count: int) -> str:
+    calls.append(f"scale {deployment}")
+    raise ConnectionResetError("connection reset by peer")  # never reached the API server
+
+
+def ask_stripe(effect_key: str) -> ctrlrun.ReconcileOutcome:
+    payment_id = effect_key.removeprefix("refund:")
+    return "committed" if payment_id in stripe_refunds else "not_executed"
+
+
+def ask_kubernetes(effect_key: str) -> ctrlrun.ReconcileOutcome:
+    _, _, deployment, count = effect_key.split(":")
+    return "committed" if replicas.get(deployment) == int(count) else "not_executed"
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect(
+    "stripe.refund",
+    effect="refund:{payment_id}",
+    reconcile=ask_stripe,
+    reconcile_eagerly=True,
+    control=control,
+)
+def refund(payment_id: str, amount: int) -> str:
+    return stripe_refund(payment_id, amount)
+
+
+@ctrlrun.protect(
+    "k8s.scale",
+    effect="scale:{cluster}:{deployment}:{replicas}",
+    reconcile=ask_kubernetes,
+    reconcile_eagerly=True,
+    control=control,
+)
+def scale(cluster: str, deployment: str, replicas: int) -> str:
+    return kubectl_scale(deployment, replicas)
+
+
+with ctrlrun.context(agent="ops-agent"):
+    try:
+        refund(payment_id="txn_9", amount=50000)
+    except TimeoutError:
+        print("refund txn_9: reply lost; the hook asked Stripe")
+    try:
+        refund(payment_id="txn_9", amount=50000)
+    except ctrlrun.DuplicateEffect:
+        print("refund txn_9 again: refused, Stripe has it")
+    else:
+        raise SystemExit("a refund Stripe already holds ran again")
+
+    try:
+        scale(cluster="prod-eu", deployment="checkout", replicas=6)
+    except ConnectionResetError:
+        print("scale checkout to 6: connection reset; the hook asked the cluster")
+    replicas["checkout"] = 6  # the retry succeeds this time
+    with contextlib.suppress(ConnectionResetError):
+        scale(cluster="prod-eu", deployment="checkout", replicas=6)
+    print("scale checkout to 6 again: permitted, the cluster had not applied it")
+
+print("remote calls:", calls)
+```
+
+## What the agent sees
+
+```text
+refund txn_9: reply lost; the hook asked Stripe
+refund txn_9 again: refused, Stripe has it
+scale checkout to 6: connection reset; the hook asked the cluster
+scale checkout to 6 again: permitted, the cluster had not applied it
+remote calls: ['refund txn_9', 'scale checkout', 'scale checkout']
+```
+
+Two lost replies, two different answers from two remotes, no human in either, and no guess in
+either: the hook that could not have answered would have returned `"unknown"` and left the
+record where it was.
+
+## The receipt
+
+```bash runnable
+ctrlrun receipts
+```
+
+Each reconciliation is a `RECONCILIATION_STARTED` and `RECONCILIATION_RESOLVED` pair with the
+answer, so the log says the record moved because Stripe was asked, not because someone assumed.
+
+## When an AMBIGUOUS appears
+
+With eager reconciliation it appears and is resolved in the same call. It stays only when the
+hook answers `"unknown"` or raises, which is the right outcome when the remote itself cannot be
+reached: then a person resolves it, and the hook's failure is in the events.
+
+## Next
+
+- [Reconcile automatically](/guides/reconcile-automatically): the three answers and when to run the hook.
+- [Outcomes and AMBIGUOUS](/concepts/outcomes-and-ambiguous) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/refund-agent.mdx
+++ b/docs/cookbook/refund-agent.mdx
@@ -1,0 +1,127 @@
+---
+title: "A refund agent with amount tiers"
+description: "A support agent refunds customers: small refunds run on their own, larger ones wait for a human, anything above a ceiling is refused."
+---
+
+A support agent issues refunds at Stripe from customer conversations. Small ones should run
+without a person, larger ones should wait for one, and nothing above a ceiling should run at
+all, whatever the customer said.
+
+## The policy
+
+Amounts are integer minor units. Both ends of each band are bound, because an upper bound alone
+lets a negative amount through, and a refund of a negative amount is a charge.
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    resource: "payment:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }       # up to €500.00: autonomous
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 500000 }      # up to €5,000.00: a human
+        decision: approve
+      - decision: deny
+```
+
+## The code
+
+```python runnable file=main.py
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):  # so the recipe repeats
+    (STATE / name).unlink(missing_ok=True)
+
+
+calls: list[tuple[str, int]] = []
+
+
+class FakeStripe:
+    def refund(self, payment_id: str, amount: int) -> dict:
+        calls.append((payment_id, amount))
+        return {"id": f"re_{payment_id}", "status": "succeeded"}
+
+
+stripe = FakeStripe()
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect("stripe.refund", effect="refund:{payment_id}", control=control)
+def refund(payment_id: str, amount: int) -> dict:
+    return stripe.refund(payment_id, amount)
+
+
+with ctrlrun.context(agent="support-agent"):
+    print("€120 refund:", refund(payment_id="txn_1", amount=12000)["status"])
+
+    try:
+        refund(payment_id="txn_2", amount=250000)
+    except ctrlrun.ApprovalRequired as pending:
+        print("€2,500 refund: a human decides:", pending.request_id)
+        store.grant_approval(pending.request_id, "human:ops")  # what `ctrlrun approve` does
+        with ctrlrun.with_approval(pending.request_id):
+            print("€2,500 refund, approved:", refund(payment_id="txn_2", amount=250000)["status"])
+    else:
+        raise SystemExit("a €2,500 refund ran without a human")
+
+    try:
+        refund(payment_id="txn_3", amount=2000000)
+    except ctrlrun.ActionDenied as refused:
+        print("€20,000 refund: refused,", refused.reason)
+    else:
+        raise SystemExit("a €20,000 refund ran")
+
+    try:
+        refund(payment_id="txn_1", amount=12000)
+    except ctrlrun.DuplicateEffect:
+        print("€120 refund again: refused as a duplicate")
+    else:
+        raise SystemExit("the same refund ran twice")
+
+print("remote refund calls:", len(calls))
+```
+
+## What the agent sees
+
+```text
+€120 refund: succeeded
+€2,500 refund: a human decides: apr_…
+€2,500 refund, approved: succeeded
+€20,000 refund: refused, rule[2]
+€120 refund again: refused as a duplicate
+remote refund calls: 2
+```
+
+Two calls reached Stripe. The refusal for €20,000 names the rule that decided it, and the
+duplicate names nothing but the effect key, `refund:txn_1`, which had already committed.
+
+## The receipt
+
+```bash runnable
+ctrlrun receipts --last 4
+```
+
+Four receipts: `allow/committed`, `approve/committed` with the approver, `deny/blocked`, and
+`allow/blocked` for the duplicate.
+
+## When an AMBIGUOUS appears
+
+A refund whose reply was lost is `AMBIGUOUS` and a retry is refused. Look up the payment in the
+Stripe dashboard, then `ctrlrun resolve refund:txn_N --committed` or `--failed`. A `reconcile`
+hook that queries `stripe.Refund.list(payment_intent=...)` does the same automatically:
+[Reconcile against the remote](/cookbook/reconcile-against-the-remote).
+
+## Next
+
+- [A payout agent with maker/checker](/cookbook/payout-maker-checker): the same money, two people.
+- [Approval binding](/concepts/approval-binding) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/resolve-an-ambiguous-effect.mdx
+++ b/docs/cookbook/resolve-an-ambiguous-effect.mdx
@@ -1,0 +1,126 @@
+---
+title: "Resolve an ambiguous effect"
+description: "An effect nobody knows the outcome of blocks its own retry; a human asks the remote, records the answer with ctrlrun resolve."
+---
+
+A worker died mid-call, or a reply was lost, and an effect sits at `AMBIGUOUS`. The agent's
+retry is refused, an alert fires, and someone has to look. This recipe makes two such effects,
+resolves one each way, and shows what the evidence says afterwards.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  dns.update_record:
+    effect: "dns:{zone}:{name}"
+    decision: allow
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    decision: allow
+```
+
+## The code
+
+```python runnable file=main.py
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, EffectState, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+remote_calls: list[str] = []
+
+
+@ctrlrun.protect("dns.update_record", effect="dns:{zone}:{name}", control=control)
+def update_record(zone: str, name: str, value: str) -> str:
+    remote_calls.append(f"dns {name}")
+    raise ConnectionResetError("connection reset by peer")
+
+
+@ctrlrun.protect("stripe.refund", effect="refund:{payment_id}", control=control)
+def refund(payment_id: str, amount: int) -> str:
+    remote_calls.append(f"refund {payment_id}")
+    if len(remote_calls) == 2:
+        raise TimeoutError("no response from api.stripe.com after 30s")
+    return "refunded"
+
+
+with ctrlrun.context(agent="ops-agent"):
+    for call in (
+        lambda: update_record(zone="example.com", name="api", value="203.0.113.7"),
+        lambda: refund(payment_id="txn_7", amount=50000),
+    ):
+        try:
+            call()
+        except (ConnectionResetError, TimeoutError) as lost:
+            print("the executor saw:", lost)
+
+    ambiguous = [record.effect_key for record in store.list_effects(EffectState.AMBIGUOUS)]
+    print("ambiguous effects:", ambiguous)
+
+    # A human asks the DNS provider: the record was updated. Asks Stripe: no refund exists.
+    # This is what `ctrlrun resolve <key> --committed` and `--failed` do.
+    store.resolve_effect("dns:example.com:api", EffectState.COMMITTED, "human:ops")
+    store.resolve_effect("refund:txn_7", EffectState.FAILED, "human:ops")
+
+    try:
+        update_record(zone="example.com", name="api", value="203.0.113.7")
+    except ctrlrun.DuplicateEffect:
+        print("DNS update again: refused, it committed")
+    else:
+        raise SystemExit("a committed update ran again")
+
+    print("refund again:", refund(payment_id="txn_7", amount=50000))
+
+for record in store.list_effects():
+    print(f"{record.effect_key}: {record.state.value}, resolved by {record.resolved_by}")
+print("remote calls:", remote_calls)
+```
+
+## What the agent sees
+
+```text
+the executor saw: connection reset by peer
+the executor saw: no response from api.stripe.com after 30s
+ambiguous effects: ['dns:example.com:api', 'refund:txn_7']
+DNS update again: refused, it committed
+refund again: refunded
+dns:example.com:api: committed, resolved by human:ops
+refund:txn_7: committed, resolved by None
+remote calls: ['dns api', 'refund txn_7', 'refund txn_7']
+```
+
+The refund that was resolved `--failed` was retried and committed on its own; its record no
+longer names a resolver, because the retry was the agent's action, not the human's. The DNS
+update, resolved `--committed`, refuses its retry as a duplicate.
+
+## The receipt
+
+```bash runnable
+ctrlrun effects
+ctrlrun receipts --last 2
+```
+
+From the shell, the same steps are `ctrlrun effects --state ambiguous`, then
+`ctrlrun resolve dns:example.com:api --committed` and `ctrlrun resolve refund:txn_7 --failed`,
+and `ctrlrun inspect <action_id>` shows the `EFFECT_RESOLVED` event with `resolved_by`.
+
+## When an AMBIGUOUS appears
+
+This recipe is what to do. Two rules: never resolve from memory or from a cache, ask the
+remote; and resolve `--failed` only when the remote is authoritative for the absence, because
+`--failed` licenses a second execution.
+
+## Next
+
+- [Reconcile against the remote](/cookbook/reconcile-against-the-remote): the same answer from a hook.
+- [Resolve an AMBIGUOUS effect](/guides/resolve-an-ambiguous-effect) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/slack-approvals.mdx
+++ b/docs/cookbook/slack-approvals.mdx
@@ -1,0 +1,132 @@
+---
+title: "Approvals in Slack via webhook"
+description: "The approval request goes out as one signed POST, a human answers in Slack, the answer comes back signed to the gateway's endpoint."
+---
+
+A refund above the desk limit should be answered in the channel where the support lead
+already lives. `WebhookApprovalProvider` sends the request to your Slack service as one signed
+POST; your service turns the button click into a signed POST back. This recipe runs the
+inbound half in process, with the real signing and the real handler, so what a Slack service
+must send is shown exactly.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }
+        decision: allow
+      - decision: approve
+```
+
+## The code
+
+```python runnable file=main.py
+import json
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+from ctrlrun.webhook import handle_inbound, sign
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+SECRET = "shared-with-the-slack-service"  # from $CTRLRUN_WEBHOOK_SECRET in production
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+refunds: list[int] = []
+
+
+@ctrlrun.protect("stripe.refund", effect="refund:{payment_id}", control=control)
+def refund(payment_id: str, amount: int) -> str:
+    refunds.append(amount)
+    return "refunded"
+
+
+with ctrlrun.context(agent="support-agent"):
+    try:
+        refund(payment_id="txn_5", amount=250000)
+    except ctrlrun.ApprovalRequired as pending:
+        request_id = pending.request_id
+        print("€2,500 refund: request", request_id[:4] + "…", "goes to Slack")
+    else:
+        raise SystemExit("a €2,500 refund ran without a human")
+
+    # What the Slack service POSTs to /ctrlrun/approvals/<request_id> when the lead clicks. It
+    # echoes the action hash it showed the human: an answer for a different hash is refused.
+    shown = store.get_approval(request_id).request.action_hash
+    answer = json.dumps(
+        {
+            "request_id": request_id,
+            "action_hash": shown,
+            "decision": "grant",
+            "approver": "slack:dana",
+        }
+    ).encode()
+    status, message = handle_inbound(store, request_id, answer, sign(answer, SECRET), secret=SECRET)
+    print("the lead approves in Slack:", status, message)
+
+    # A forged answer, signed with the wrong secret, changes nothing.
+    forged = json.dumps(
+        {
+            "request_id": request_id,
+            "action_hash": shown,
+            "decision": "grant",
+            "approver": "slack:nobody",
+        }
+    ).encode()
+    status, message = handle_inbound(
+        store, request_id, forged, sign(forged, "guess"), secret=SECRET
+    )
+    print("a forged answer:", status, message)
+    if status == 200:
+        raise SystemExit("a forged answer was accepted")
+
+    with ctrlrun.with_approval(request_id):
+        print("€2,500 refund, approved in Slack:", refund(payment_id="txn_5", amount=250000))
+
+print("refunds:", refunds)
+```
+
+## What the agent sees
+
+```text
+€2,500 refund: request apr_… goes to Slack
+the lead approves in Slack: 200 ok
+a forged answer: 400 the signature did not verify inside the replay window
+€2,500 refund, approved in Slack: refunded
+refunds: [250000]
+```
+
+The answer names the request, the hash the human saw, the decision and the approver; the approver is what the receipt records. The signature is an HMAC-SHA256 over
+`timestamp.body` on the exact bytes, and a timestamp outside the five-minute window is refused
+even with the right secret.
+
+## The receipt
+
+```bash runnable
+ctrlrun receipts --last 1
+```
+
+`approve/committed`, approver `slack:dana`. The same shape as an approval given with
+`ctrlrun approve`, because it went through the same call.
+
+## When an AMBIGUOUS appears
+
+Approvals never make an effect ambiguous; the remote does. If the approved refund's reply is
+lost, the effect is `AMBIGUOUS` and the approval is already spent: resolve the effect with
+`ctrlrun resolve refund:txn_5 --committed` or `--failed`. On `--failed` a retry needs a new
+approval, because the old one authorized one execution.
+
+## Next
+
+- [Approve in Slack](/guides/approvals-in-slack): the outbound half, the payload and the flags.
+- [Approval binding](/concepts/approval-binding) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/sqlite-to-postgres.mdx
+++ b/docs/cookbook/sqlite-to-postgres.mdx
@@ -1,0 +1,109 @@
+---
+title: "Move from SQLite to Postgres"
+description: "One line changes: the store. The code reads CTRLRUN_STORE_URL and builds a PostgresStateStore when it names a database, a SQLiteStateStore otherwise."
+---
+
+The agent has outgrown one host. Reservation on SQLite is a write lock on a local file; two
+hosts need a store they share. The change is the store constructor, and nothing else: same
+policy, same decorator, same receipts, same guarantees, graded on Postgres by the same suite
+that grades SQLite.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    decision: allow
+```
+
+## The code
+
+This script runs on SQLite offline and on Postgres when `CTRLRUN_STORE_URL` names one; the
+part that changes is `open_store`.
+
+```python runnable file=main.py
+import os
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore, StateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+
+def open_store() -> StateStore:
+    url = os.environ.get("CTRLRUN_STORE_URL")
+    if url and url.startswith(("postgresql://", "postgres://")):
+        from ctrlrun.postgres import PostgresStateStore  # pip install "ctrlrun[postgres]"
+
+        return PostgresStateStore(url, schema="ctrlrun")  # migrates at open, forward only
+    return SQLiteStateStore(STATE / "state.db")
+
+
+store = open_store()
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+refunds: list[str] = []
+
+
+@ctrlrun.protect("stripe.refund", effect="refund:{payment_id}", control=control)
+def refund(payment_id: str, amount: int) -> str:
+    refunds.append(payment_id)
+    return "refunded"
+
+
+with ctrlrun.context(agent="refund-agent"):
+    print("store:", type(store).__name__)
+    print("refund txn_1:", refund(payment_id="txn_1", amount=12000))
+    try:
+        refund(payment_id="txn_1", amount=12000)  # a second host, same effect
+    except ctrlrun.DuplicateEffect:
+        print("refund txn_1 from another host: refused")
+    else:
+        raise SystemExit("one effect committed twice")
+
+print("remote refund calls:", len(refunds))
+store.close()
+```
+
+## What the agent sees
+
+```text
+store: SQLiteStateStore
+refund txn_1: refunded
+refund txn_1 from another host: refused
+remote refund calls: 1
+```
+
+With `CTRLRUN_STORE_URL=postgresql://ctrlrun@db.internal/ctrlrun` the first line reads
+`PostgresStateStore` and the rest is identical, and now it holds across hosts: the refusal
+comes from a unique index on the effect key and compare-and-set updates whose row counts are
+checked, instead of SQLite's file lock.
+
+## The receipt
+
+```bash runnable
+ctrlrun receipts --last 2
+```
+
+On Postgres the same command reads the shared store when `CTRLRUN_STORE_URL` is set, or with
+`--store-url 'postgresql://db.internal/ctrlrun?ctrlrun_schema=ctrlrun'`. A read command
+migrates nothing and creates nothing.
+
+## When an AMBIGUOUS appears
+
+One new case: a connection lost during `COMMIT`. Postgres very often did commit, so the store
+treats it as unknown and re-reads the row to find out which; only if the re-read fails does it
+refuse to proceed. Your executor's lost replies are handled as before. Resolve them with
+`ctrlrun resolve --store-url …` from any host.
+
+## Next
+
+- [Run on Postgres](/guides/run-on-postgres): the schema, the grants, failover.
+- [Effect keys](/concepts/effect-keys) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/cookbook/verify-in-github-actions.mdx
+++ b/docs/cookbook/verify-in-github-actions.mdx
@@ -1,0 +1,104 @@
+---
+title: "Run verify in GitHub Actions"
+description: "Run ctrlrun verify against your policy on every push with the CTRLRun action: the workflow, the report it produces, the N/A line, the exit codes."
+---
+
+Your policy lives in the repository with the agent. Every push should prove the guarantees it
+declares still hold against it, in a scratch store, with no network, and fail the build if one
+does not. That is one workflow step.
+
+## The policy
+
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }
+        decision: allow
+      - decision: approve
+  k8s.delete_namespace:
+    effect: "namespace:{cluster}:{name}"
+    decision: approve
+```
+
+## The code
+
+Locally, and in the recipe's directory, the check is one command:
+
+```bash runnable file=run.sh
+ctrlrun verify
+ctrlrun verify --json > verify-report.json
+python -c "import json; s = json.load(open('verify-report.json'))['summary']; print('applicable', s['applicable'], 'passed', s['passed'], 'not applicable', s['not_applicable'])"
+rm -f verify-report.json
+```
+
+In CI, the workflow:
+
+```yaml
+name: CTRLRun verify
+
+on: [push, pull_request]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: CTRLRun/ctrlrun@main
+        with:
+          policy: ctrlrun.yaml
+```
+
+Pin `CTRLRun/ctrlrun` to a release tag once you rely on it.
+
+## What the agent sees
+
+The agent sees nothing; this is the operator's check. The build sees:
+
+```text
+CTRLRun verify — ctrlrun 0.6.0, catalogue ctrlrun.guarantees/v2
+policy     ctrlrun.yaml (ctrlrun.policy/v2, mode: enforce)
+authority  none
+store      sqlite, scratch (created and destroyed for this run)
+
+G1   mutated approval refused         PASS  stripe.refund
+G2   replayed approval refused        PASS  stripe.refund
+G3   duplicate effect refused         PASS  stripe.refund
+G4   one winner under concurrency     PASS  stripe.refund (8 processes)
+G5   ambiguous blocks a blind retry   PASS  stripe.refund
+G6   unknown action refused           PASS
+G7   no principal refused             PASS  stripe.refund
+G8   expired authority refused        N/A   no authority section
+G9   delegation cannot escalate       N/A   no authority section
+G10  unknown exception is ambiguous   PASS  stripe.refund
+G11  an altered receipt is detected   PASS  stripe.refund
+
+9/9 declared guarantees pass. 2 not applicable: G8, G9.
+applicable 9 passed 9 not applicable 2
+```
+
+Two guarantees are not applicable because the policy has no `authority:` section; they are
+listed with the reason and excluded from the denominator. Green means nothing that could be
+checked was wrong.
+
+## The receipt
+
+The report is the receipt: `--json` writes a `ctrlrun.verify/v1` document and `--junit` a
+JUnit file, and the action uploads both with the badge JSON as one artifact. Exit 0 means every
+applicable guarantee passed; 1 a failure; 2 a refused or unusable configuration, including
+`mode: observe` and a policy in which nothing can be exercised; 3 an internal error.
+
+## When an AMBIGUOUS appears
+
+Verify's G5 and G10 make an ambiguous effect on purpose, in the scratch store, and assert that a
+blind retry is refused. Your store is never opened, so nothing here can leave a real effect
+ambiguous. An `AMBIGUOUS` in your own store is the agent's, and the
+[resolve recipe](/cookbook/resolve-an-ambiguous-effect) is for it.
+
+## Next
+
+- [Verify in CI](/guides/verify-in-ci): inputs, outputs and publishing the badge.
+- [Exit codes](/reference/exit-codes) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -84,6 +84,34 @@
               "guides/langgraph-adapter",
               "guides/openai-agents-adapter"
             ]
+          },
+          {
+            "group": "Cookbook",
+            "pages": [
+              "cookbook/index",
+              "cookbook/credential-rotation-agent",
+              "cookbook/crm-update-agent",
+              "cookbook/customer-notification-agent",
+              "cookbook/data-deletion-agent",
+              "cookbook/database-migration-agent",
+              "cookbook/deploy-agent",
+              "cookbook/iam-agent",
+              "cookbook/langgraph-interrupt",
+              "cookbook/manager-and-worker",
+              "cookbook/observe-then-enforce",
+              "cookbook/openai-agents-tool-approval",
+              "cookbook/outbound-email-agent",
+              "cookbook/payout-maker-checker",
+              "cookbook/protect-an-mcp-server",
+              "cookbook/receipts-to-opentelemetry",
+              "cookbook/reconcile-against-the-remote",
+              "cookbook/refund-agent",
+              "cookbook/resolve-an-ambiguous-effect",
+              "cookbook/slack-approvals",
+              "cookbook/sqlite-to-postgres",
+              "cookbook/verify-in-github-actions"
+            ],
+            "expanded": false
           }
         ]
       },

--- a/docs/guides/observe-to-enforce.mdx
+++ b/docs/guides/observe-to-enforce.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Roll out observe, then enforce"
-description: "Put mode: observe at the top of the policy, run real traffic for a week, read ctrlrun stats to see what enforcement would have blocked and why, fix the policy, then switch the line to enforce."
+description: "Put mode: observe at the top of the policy, run real traffic for a week, read ctrlrun stats to see what enforcement would have blocked and why."
 ---
 
 Start with `mode: observe`: every action is decided exactly as enforce mode would decide it,
@@ -85,11 +85,17 @@ the gateway in front of them. The blocks below simulate a week in a few calls.
     ```
 
     ```text
-    observed actions              7
-    would have been blocked       4
-      approval_required           2
-      policy_denied               1
-      duplicate_effect            1
+    CTRLRun — 2026-09-06T10:55:05.474Z .. 2026-09-06T10:55:05.476Z   (observe mode)
+
+    actions                            7
+    would have been denied             1
+       rule[2]                         1
+    would have needed approval         2
+    would have been blocked            1
+       duplicate                       1
+    ambiguous outcomes                 0
+
+    Actions still awaiting a human have no receipt yet and are not counted.
     ```
 
     Counted from the local store and nothing else: no network, no upload. `--since 7d` narrows
@@ -97,11 +103,11 @@ the gateway in front of them. The blocks below simulate a week in a few calls.
   </Step>
 
   <Step title="Fix the policy, not the count">
-    Each `approval_required` is a real approval request you will field once you enforce. If the
-    rate is wrong, the band is wrong: raise the autonomous limit for the action, or add a rule
-    for the case that dominates. Each `policy_denied` is an action your agent performs today
-    that will stop; decide whether that is the point. `duplicate_effect` is a retry loop you
-    did not know about.
+    Each *would have needed approval* is a real approval request you will field once you
+    enforce. If the rate is wrong, the band is wrong: raise the autonomous limit for the action,
+    or add a rule for the case that dominates. Each *would have been denied* is an action your
+    agent performs today that will stop, named by the rule; decide whether that is the point.
+    A *duplicate* is a retry loop you did not know about.
   </Step>
 
   <Step title="Enforce">

--- a/examples/cookbook/credential-rotation-agent/ctrlrun.yaml
+++ b/examples/cookbook/credential-rotation-agent/ctrlrun.yaml
@@ -1,0 +1,11 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/credential-rotation-agent.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v2
+
+actions:
+  secrets.create_key:
+    effect: "key:{service}:{rotation_id}"
+    decision: allow
+  secrets.revoke_key:
+    effect: "revoke:{service}:{key_id}"
+    decision: approve

--- a/examples/cookbook/credential-rotation-agent/main.py
+++ b/examples/cookbook/credential-rotation-agent/main.py
@@ -1,0 +1,61 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/credential-rotation-agent.mdx — edit the page, never this file.
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+live_keys: list[str] = ["key_old"]
+
+
+def mint(service: str, rotation_id: str, lose_reply: bool = False) -> str:
+    key_id = f"key_{rotation_id}"
+    live_keys.append(key_id)  # the provider has it from here on
+    if lose_reply:
+        raise TimeoutError("no response from the secrets manager after 30s")
+    return key_id
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect("secrets.create_key", effect="key:{service}:{rotation_id}", control=control)
+def create_key(service: str, rotation_id: str, lose_reply: bool = False) -> str:
+    return mint(service, rotation_id, lose_reply)
+
+
+@ctrlrun.protect("secrets.revoke_key", effect="revoke:{service}:{key_id}", control=control)
+def revoke_key(service: str, key_id: str) -> str:
+    live_keys.remove(key_id)
+    return "revoked"
+
+
+with ctrlrun.context(agent="rotation-agent"):
+    print("mint 2026-09:", create_key(service="billing-api", rotation_id="2026-09"))
+
+    try:
+        revoke_key(service="billing-api", key_id="key_old")
+    except ctrlrun.ApprovalRequired as pending:
+        print("revoke key_old: a human decides:", pending.request_id)
+    else:
+        raise SystemExit("a key was revoked without a human")
+
+    try:
+        create_key(service="billing-api", rotation_id="2026-10", lose_reply=True)
+    except TimeoutError:
+        print("mint 2026-10: reply lost")
+    try:
+        create_key(service="billing-api", rotation_id="2026-10")
+    except ctrlrun.AmbiguousEffect:
+        print("mint 2026-10 again: refused; a key may already exist")
+    else:
+        raise SystemExit("a second key was minted for one rotation")
+
+print("live keys at the provider:", live_keys)

--- a/examples/cookbook/crm-update-agent/ctrlrun.yaml
+++ b/examples/cookbook/crm-update-agent/ctrlrun.yaml
@@ -1,0 +1,14 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/crm-update-agent.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v2
+
+actions:
+  crm.update_record:
+    effect: "crm:{record_id}:{field}:{revision}"
+    resource: "record:{record_id}"
+    decision: allow
+  crm.merge_records:
+    effect: "merge:{keep}:{drop}"
+    decision: approve
+  crm.delete_record:
+    decision: deny

--- a/examples/cookbook/crm-update-agent/main.py
+++ b/examples/cookbook/crm-update-agent/main.py
@@ -1,0 +1,82 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/crm-update-agent.mdx — edit the page, never this file.
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+records: dict[str, dict[str, str]] = {"c_1": {"phone": "+353 1 555 0100"}, "c_2": {}}
+writes = 0
+
+
+def crm_update(record_id: str, field: str, value: str) -> str:
+    global writes
+    writes += 1
+    records[record_id][field] = value
+    return "updated"
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect(
+    "crm.update_record",
+    effect="crm:{record_id}:{field}:{revision}",
+    resource="record:{record_id}",
+    control=control,
+)
+def update(record_id: str, field: str, value: str, revision: int) -> str:
+    return crm_update(record_id, field, value)
+
+
+@ctrlrun.protect("crm.merge_records", effect="merge:{keep}:{drop}", control=control)
+def merge(keep: str, drop: str) -> str:
+    return "merged"
+
+
+@ctrlrun.protect("crm.delete_record", control=control)
+def delete(record_id: str) -> str:
+    return "deleted"
+
+
+with ctrlrun.context(agent="support-agent"):
+    print(
+        "update phone:", update(record_id="c_1", field="phone", value="+353 1 555 0199", revision=7)
+    )
+
+    # A second worker handling the same conversation proposes the same revision.
+    try:
+        update(record_id="c_1", field="phone", value="+353 1 555 0199", revision=7)
+    except ctrlrun.DuplicateEffect:
+        print("same update from a second worker: refused, already applied")
+    else:
+        raise SystemExit("one revision was written twice")
+
+    # A later revision is a new effect and runs.
+    print(
+        "update phone, revision 8:",
+        update(record_id="c_1", field="phone", value="+353 1 555 0200", revision=8),
+    )
+
+    try:
+        merge(keep="c_1", drop="c_2")
+    except ctrlrun.ApprovalRequired as pending:
+        print("merge c_2 into c_1: a human decides:", pending.request_id)
+    else:
+        raise SystemExit("a merge ran without a human")
+
+    try:
+        delete(record_id="c_2")
+    except ctrlrun.ActionDenied:
+        print("delete c_2: refused")
+    else:
+        raise SystemExit("a record was deleted")
+
+print("CRM writes:", writes)

--- a/examples/cookbook/customer-notification-agent/ctrlrun.yaml
+++ b/examples/cookbook/customer-notification-agent/ctrlrun.yaml
@@ -1,0 +1,14 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/customer-notification-agent.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v2
+
+actions:
+  notify.customer:
+    effect: "notify:{incident_id}:{customer_id}"
+    decision: allow
+  notify.batch:
+    effect: "batch:{incident_id}"
+    rules:
+      - when: { size_lte: 500 }
+        decision: allow
+      - decision: approve

--- a/examples/cookbook/customer-notification-agent/main.py
+++ b/examples/cookbook/customer-notification-agent/main.py
@@ -1,0 +1,54 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/customer-notification-agent.mdx — edit the page, never this file.
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+delivered: list[str] = []
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect("notify.batch", effect="batch:{incident_id}", control=control)
+def start_batch(incident_id: str, size: int) -> str:
+    return "started"
+
+
+@ctrlrun.protect("notify.customer", effect="notify:{incident_id}:{customer_id}", control=control)
+def notify(incident_id: str, customer_id: str) -> str:
+    delivered.append(customer_id)
+    return "delivered"
+
+
+customers = ["c_1", "c_2", "c_3"]
+
+with ctrlrun.context(agent="incident-agent"):
+    print("batch of 3:", start_batch(incident_id="inc_7", size=3))
+    for customer in customers:
+        notify(incident_id="inc_7", customer_id=customer)
+    print("first pass delivered:", len(delivered))
+
+    # The batch is retried after a crash, and a second worker runs it at the same time.
+    skipped = 0
+    for customer in customers + customers:
+        try:
+            notify(incident_id="inc_7", customer_id=customer)
+        except ctrlrun.DuplicateEffect:
+            skipped += 1
+    print("retry and second worker: skipped", skipped, "already-notified customers")
+
+    try:
+        start_batch(incident_id="inc_8", size=12000)
+    except ctrlrun.ApprovalRequired as pending:
+        print("batch of 12,000: a human decides:", pending.request_id)
+    else:
+        raise SystemExit("a large batch started without a human")
+
+print("messages delivered:", len(delivered))

--- a/examples/cookbook/data-deletion-agent/ctrlrun.yaml
+++ b/examples/cookbook/data-deletion-agent/ctrlrun.yaml
@@ -1,0 +1,14 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/data-deletion-agent.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v2
+
+actions:
+  records.purge:
+    effect: "purge:{record_id}"
+    resource: "record:{record_id}"
+    rules:
+      - when: { legal_hold_eq: true }
+        decision: deny
+      - when: { age_days_gte: 730 }
+        decision: allow
+      - decision: approve

--- a/examples/cookbook/data-deletion-agent/main.py
+++ b/examples/cookbook/data-deletion-agent/main.py
@@ -1,0 +1,63 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/data-deletion-agent.mdx — edit the page, never this file.
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+purged: list[str] = []
+
+
+def purge_at_warehouse(record_id: str, lose_reply: bool = False) -> str:
+    purged.append(record_id)
+    if lose_reply:
+        raise TimeoutError("warehouse did not answer in 30s")
+    return "purged"
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect(
+    "records.purge", effect="purge:{record_id}", resource="record:{record_id}", control=control
+)
+def purge(record_id: str, age_days: int, legal_hold: bool, lose_reply: bool = False) -> str:
+    return purge_at_warehouse(record_id, lose_reply)
+
+
+with ctrlrun.context(agent="deletion-agent"):
+    print("r_100, 900 days old:", purge(record_id="r_100", age_days=900, legal_hold=False))
+
+    try:
+        purge(record_id="r_101", age_days=400, legal_hold=False)
+    except ctrlrun.ApprovalRequired as pending:
+        print("r_101, 400 days old: a human decides:", pending.request_id)
+    else:
+        raise SystemExit("a record inside retention was purged without a human")
+
+    try:
+        purge(record_id="r_102", age_days=900, legal_hold=True)
+    except ctrlrun.ActionDenied:
+        print("r_102, under legal hold: refused")
+    else:
+        raise SystemExit("a record under legal hold was purged")
+
+    try:
+        purge(record_id="r_103", age_days=900, legal_hold=False, lose_reply=True)
+    except TimeoutError:
+        print("r_103: reply lost")
+    try:
+        purge(record_id="r_103", age_days=900, legal_hold=False)
+    except ctrlrun.AmbiguousEffect:
+        print("r_103 again: refused until someone checks the warehouse")
+    else:
+        raise SystemExit("a purge of unknown outcome was repeated")
+
+print("purge calls at the warehouse:", purged)

--- a/examples/cookbook/database-migration-agent/ctrlrun.yaml
+++ b/examples/cookbook/database-migration-agent/ctrlrun.yaml
@@ -1,0 +1,13 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/database-migration-agent.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v2
+
+actions:
+  db.migrate:
+    effect: "migration:{database}:{version}"
+    rules:
+      - when: { database_eq: staging }
+        decision: allow
+      - decision: approve
+  db.rollback:
+    decision: deny

--- a/examples/cookbook/database-migration-agent/main.py
+++ b/examples/cookbook/database-migration-agent/main.py
@@ -1,0 +1,66 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/database-migration-agent.mdx — edit the page, never this file.
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+applied: dict[str, list[str]] = {"staging": [], "production": []}
+
+
+def run_migration(database: str, version: str, drop_connection: bool = False) -> str:
+    applied[database].append(version)  # the DDL ran
+    if drop_connection:
+        raise ConnectionResetError("connection reset by peer")  # ...and the reply was lost
+    return "applied"
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect("db.migrate", effect="migration:{database}:{version}", control=control)
+def migrate(database: str, version: str, drop_connection: bool = False) -> str:
+    return run_migration(database, version, drop_connection)
+
+
+@ctrlrun.protect("db.rollback", control=control)
+def rollback(database: str, version: str) -> str:
+    return "rolled back"
+
+
+with ctrlrun.context(agent="migration-agent"):
+    print("0042 on staging:", migrate(database="staging", version="0042"))
+
+    try:
+        migrate(database="production", version="0042")
+    except ctrlrun.ApprovalRequired as pending:
+        print("0042 on production: a human decides:", pending.request_id)
+    else:
+        raise SystemExit("a production migration ran without a human")
+
+    try:
+        rollback(database="production", version="0041")
+    except ctrlrun.ActionDenied:
+        print("rollback on production: refused")
+    else:
+        raise SystemExit("a rollback ran")
+
+    try:
+        migrate(database="staging", version="0043", drop_connection=True)
+    except ConnectionResetError:
+        print("0043 on staging: the connection dropped; outcome unknown")
+    try:
+        migrate(database="staging", version="0043")
+    except ctrlrun.AmbiguousEffect:
+        print("0043 on staging again: refused; a human checks the schema first")
+    else:
+        raise SystemExit("a migration of unknown outcome was re-run")
+
+print("migrations applied on staging:", applied["staging"])

--- a/examples/cookbook/deploy-agent/ctrlrun.yaml
+++ b/examples/cookbook/deploy-agent/ctrlrun.yaml
@@ -1,0 +1,16 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/deploy-agent.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v2
+
+actions:
+  k8s.rollout_restart:
+    effect: "restart:{cluster}:{deployment}"
+    decision: allow
+  k8s.apply:
+    effect: "apply:{cluster}:{manifest_hash}"
+    rules:
+      - when: { cluster_in: [staging, dev] }
+        decision: allow
+      - decision: approve
+  k8s.delete_namespace:
+    decision: deny

--- a/examples/cookbook/deploy-agent/main.py
+++ b/examples/cookbook/deploy-agent/main.py
@@ -1,0 +1,67 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/deploy-agent.mdx — edit the page, never this file.
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+calls: list[str] = []
+
+
+def kubectl(*args: str) -> str:
+    calls.append(" ".join(args))
+    return "ok"
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect("k8s.rollout_restart", effect="restart:{cluster}:{deployment}", control=control)
+def restart(cluster: str, deployment: str) -> str:
+    return kubectl("rollout", "restart", f"deployment/{deployment}", "--context", cluster)
+
+
+@ctrlrun.protect("k8s.apply", effect="apply:{cluster}:{manifest_hash}", control=control)
+def apply(cluster: str, manifest_hash: str) -> str:
+    return kubectl("apply", "-f", manifest_hash, "--context", cluster)
+
+
+@ctrlrun.protect("k8s.delete_namespace", control=control)
+def delete_namespace(cluster: str, name: str) -> str:
+    return kubectl("delete", "namespace", name, "--context", cluster)
+
+
+with ctrlrun.context(agent="oncall-agent"):
+    print("restart checkout on prod:", restart(cluster="prod-eu", deployment="checkout"))
+    print("apply to staging:", apply(cluster="staging", manifest_hash="sha256:9c1f"))
+
+    try:
+        apply(cluster="prod-eu", manifest_hash="sha256:9c1f")
+    except ctrlrun.ApprovalRequired as pending:
+        print("apply to prod: a human decides:", pending.request_id)
+    else:
+        raise SystemExit("a production apply ran without a human")
+
+    try:
+        delete_namespace(cluster="prod-eu", name="checkout")
+    except ctrlrun.ActionDenied as refused:
+        print("delete namespace: refused,", refused.reason)
+    else:
+        raise SystemExit("a namespace delete ran")
+
+    # A second worker picks up the same ticket.
+    try:
+        restart(cluster="prod-eu", deployment="checkout")
+    except ctrlrun.DuplicateEffect:
+        print("second worker restarts checkout: refused, already done")
+    else:
+        raise SystemExit("the same restart ran twice")
+
+print("kubectl calls:", len(calls))

--- a/examples/cookbook/iam-agent/ctrlrun.yaml
+++ b/examples/cookbook/iam-agent/ctrlrun.yaml
@@ -1,0 +1,17 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/iam-agent.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v2
+
+actions:
+  iam.grant_role:
+    effect: "grant:{principal}:{role}"
+    resource: "project:{project}"
+    rules:
+      - when: { role_eq: admin }
+        decision: deny
+      - when: { role_in: [reader, viewer] }
+        decision: allow
+      - decision: approve
+  iam.revoke_role:
+    effect: "revoke:{principal}:{role}"
+    decision: allow

--- a/examples/cookbook/iam-agent/main.py
+++ b/examples/cookbook/iam-agent/main.py
@@ -1,0 +1,62 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/iam-agent.mdx — edit the page, never this file.
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+bindings: list[tuple[str, str, str]] = []
+
+
+def bind(project: str, principal: str, role: str) -> str:
+    bindings.append((project, principal, role))
+    return "bound"
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect(
+    "iam.grant_role",
+    effect="grant:{principal}:{role}",
+    resource="project:{project}",
+    control=control,
+)
+def grant(project: str, principal: str, role: str) -> str:
+    return bind(project, principal, role)
+
+
+with ctrlrun.context(agent="access-agent"):
+    print(
+        "reader on billing:", grant(project="billing", principal="ana@example.com", role="reader")
+    )
+
+    try:
+        grant(project="billing", principal="ana@example.com", role="editor")
+    except ctrlrun.ApprovalRequired as pending:
+        print("editor on billing: a human decides:", pending.request_id)
+        request_id = pending.request_id
+    else:
+        raise SystemExit("editor was granted without a human")
+
+    store.grant_approval(request_id, "human:security")
+    with ctrlrun.with_approval(request_id):
+        try:
+            grant(project="billing", principal="ana@example.com", role="admin")
+        except ctrlrun.ActionDenied:
+            print("admin with the editor approval: refused; admin is never an agent action")
+        else:
+            raise SystemExit("admin was granted on an approval for editor")
+        print(
+            "editor with the editor approval:",
+            grant(project="billing", principal="ana@example.com", role="editor"),
+        )
+
+print("bindings:", bindings)

--- a/examples/cookbook/manager-and-worker/ctrlrun.yaml
+++ b/examples/cookbook/manager-and-worker/ctrlrun.yaml
@@ -1,0 +1,25 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/manager-and-worker.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v3
+
+authority:
+  max_delegation_depth: 3
+  grants:
+    - id: ops-manager
+      subject: { agent: "ops-manager" }
+      actions: ["k8s.rollout_restart", "k8s.scale"]
+      resources: ["cluster:*"]
+      constraints: { replicas_gte: 0, replicas_lte: 50 }
+      environments: ["production"]
+      delegable: true
+      expires_at: "2027-01-01T00:00:00Z"
+
+actions:
+  k8s.rollout_restart:
+    effect: "restart:{cluster}:{deployment}"
+    resource: "cluster:{cluster}"
+    decision: allow
+  k8s.scale:
+    effect: "scale:{cluster}:{deployment}:{replicas}"
+    resource: "cluster:{cluster}"
+    decision: allow

--- a/examples/cookbook/manager-and-worker/main.py
+++ b/examples/cookbook/manager-and-worker/main.py
@@ -1,0 +1,108 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/manager-and-worker.mdx — edit the page, never this file.
+from pathlib import Path
+
+from ctrlrun import (
+    Action,
+    Authority,
+    AuthorityDenied,
+    AuthorityEscalation,
+    Control,
+    Policy,
+    Principal,
+    SQLiteStateStore,
+)
+from ctrlrun.authority import grant_from_yaml
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+MANAGER = Principal(agent="ops-manager")
+WORKER = Principal(agent="scale-worker")
+document = (HERE / "ctrlrun.yaml").read_text(encoding="utf-8")
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(
+    Policy.from_yaml(document, source="ctrlrun.yaml"),
+    store,
+    authority=Authority.from_yaml(document, source="ctrlrun.yaml"),
+    environment="production",
+)
+scaled: list[tuple[str, int]] = []
+
+
+def scale(who: Principal, cluster: str, deployment: str, replicas: int) -> None:
+    control.execute(
+        Action(
+            name="k8s.scale",
+            arguments={"cluster": cluster, "deployment": deployment, "replicas": replicas},
+            principal=who,
+            resource=f"cluster:{cluster}",
+        ),
+        lambda: scaled.append((deployment, replicas)),
+        f"scale:{cluster}:{deployment}:{replicas}",
+    )
+
+
+# The worker gets scaling only, on one cluster, up to 10 replicas, for a day.
+job = control.delegate(
+    "ops-manager",
+    grant_from_yaml("""
+subject: { agent: "scale-worker" }
+actions: ["k8s.scale"]
+resources: ["cluster:prod-eu"]
+constraints: { replicas_gte: 0, replicas_lte: 10 }
+environments: ["production"]
+expires_at: "2026-12-01T00:00:00Z"
+"""),
+    by=MANAGER,
+)
+print("worker's grant:", job.delegation_id)
+
+scale(WORKER, "prod-eu", "checkout", 6)
+print("worker scales checkout to 6 on prod-eu: done")
+
+try:
+    scale(WORKER, "prod-eu", "checkout", 40)
+except AuthorityDenied as refused:
+    print("worker scales to 40: refused,", refused.reason)
+else:
+    raise SystemExit("the worker exceeded its slice")
+
+try:
+    scale(WORKER, "prod-us", "checkout", 6)
+except AuthorityDenied as refused:
+    print("worker scales on prod-us: refused,", refused.reason)
+else:
+    raise SystemExit("the worker acted outside its cluster")
+
+try:
+    control.delegate(
+        "ops-manager",
+        grant_from_yaml("""
+subject: { agent: "scale-worker" }
+actions: ["k8s.scale"]
+resources: ["cluster:prod-eu"]
+environments: ["production"]
+expires_at: "2026-12-01T00:00:00Z"
+"""),
+        by=MANAGER,
+    )
+except AuthorityEscalation as refused:
+    print("a slice that omits constraints: refused,", refused.reason, refused.dimension)
+else:
+    raise SystemExit("an omitted dimension was inherited as unlimited")
+
+# The job is over.
+control.revoke(job.delegation_id, by="ops-manager")
+try:
+    scale(WORKER, "prod-eu", "checkout", 4)
+except AuthorityDenied as refused:
+    print("worker after revocation: refused,", refused.reason)
+else:
+    raise SystemExit("a revoked worker still acted")
+
+print("scaling calls:", scaled)
+store.close()

--- a/examples/cookbook/observe-then-enforce/ctrlrun.yaml
+++ b/examples/cookbook/observe-then-enforce/ctrlrun.yaml
@@ -1,0 +1,23 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/observe-then-enforce.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v3
+mode: observe
+
+actions:
+  crm.update_record:
+    effect: "crm:{record_id}:{field}:{revision}"
+    decision: allow
+  email.send:
+    effect: "email:{message_id}"
+    rules:
+      - when: { to_domain_eq: "example.com" }
+        decision: allow
+      - decision: approve
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 500000 }
+        decision: approve
+      - decision: deny

--- a/examples/cookbook/observe-then-enforce/main.py
+++ b/examples/cookbook/observe-then-enforce/main.py
@@ -1,0 +1,53 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/observe-then-enforce.mdx — edit the page, never this file.
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+executed: list[str] = []
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect("crm.update_record", effect="crm:{record_id}:{field}:{revision}", control=control)
+def update(record_id: str, field: str, value: str, revision: int) -> str:
+    executed.append("update")
+    return "updated"
+
+
+@ctrlrun.protect("email.send", effect="email:{message_id}", control=control)
+def send(message_id: str, to_domain: str) -> str:
+    executed.append("send")
+    return "sent"
+
+
+@ctrlrun.protect("stripe.refund", effect="refund:{payment_id}", control=control)
+def refund(payment_id: str, amount: int) -> str:
+    executed.append("refund")
+    return "refunded"
+
+
+# A week of traffic, compressed.
+with ctrlrun.context(agent="support-agent"):
+    update(record_id="c_1", field="phone", value="+353 1 555 0100", revision=3)
+    send(message_id="m_1", to_domain="example.com")
+    send(message_id="m_2", to_domain="gmail.com")  # would have needed a human
+    refund(payment_id="txn_1", amount=12000)
+    refund(payment_id="txn_2", amount=250000)  # would have needed a human
+    refund(payment_id="txn_3", amount=900000)  # would have been denied
+    refund(payment_id="txn_1", amount=12000)  # would have been a duplicate
+
+print("actions executed:", len(executed))
+if len(executed) != 7:
+    raise SystemExit("observe mode blocked something; it must execute everything")
+
+for receipt in store.receipts():
+    if receipt.would_have is not None and receipt.would_have.blocked_reason:
+        print(f"{receipt.action} would have been blocked: {receipt.would_have.blocked_reason}")

--- a/examples/cookbook/outbound-email-agent/ctrlrun.yaml
+++ b/examples/cookbook/outbound-email-agent/ctrlrun.yaml
@@ -1,0 +1,11 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/outbound-email-agent.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v2
+
+actions:
+  email.send:
+    effect: "email:{message_id}"
+    rules:
+      - when: { to_domain_eq: "example.com" }
+        decision: allow
+      - decision: approve

--- a/examples/cookbook/outbound-email-agent/main.py
+++ b/examples/cookbook/outbound-email-agent/main.py
@@ -1,0 +1,69 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/outbound-email-agent.mdx — edit the page, never this file.
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+sent: list[str] = []
+
+
+def smtp_send(message_id: str, to: str) -> str:
+    sent.append(to)
+    return "sent"
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect("email.send", effect="email:{message_id}", control=control)
+def send(message_id: str, to: str, to_domain: str, subject: str) -> str:
+    return smtp_send(message_id, to)
+
+
+with ctrlrun.context(agent="assistant"):
+    print(
+        "to a colleague:",
+        send(message_id="m_1", to="li@example.com", to_domain="example.com", subject="Q3 numbers"),
+    )
+
+    try:
+        send(message_id="m_2", to="press@partner.co", to_domain="partner.co", subject="Q3 numbers")
+    except ctrlrun.ApprovalRequired as pending:
+        print("to partner.co: a human decides:", pending.request_id)
+        request_id = pending.request_id
+    else:
+        raise SystemExit("external mail went out without a human")
+
+    store.grant_approval(request_id, "human:li@example.com")
+    with ctrlrun.with_approval(request_id):
+        # The agent re-plans the recipient after the yes.
+        try:
+            send(
+                message_id="m_2",
+                to="tips@journalist.example",
+                to_domain="journalist.example",
+                subject="Q3 numbers",
+            )
+        except ctrlrun.ApprovalMismatch:
+            print("to a different address with the same approval: refused")
+        else:
+            raise SystemExit("an approval for one recipient sent mail to another")
+        print(
+            "to partner.co, as approved:",
+            send(
+                message_id="m_2",
+                to="press@partner.co",
+                to_domain="partner.co",
+                subject="Q3 numbers",
+            ),
+        )
+
+print("messages sent:", sent)

--- a/examples/cookbook/payout-maker-checker/ctrlrun.yaml
+++ b/examples/cookbook/payout-maker-checker/ctrlrun.yaml
@@ -1,0 +1,23 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/payout-maker-checker.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v3
+
+authority:
+  grants:
+    - id: treasury-lead
+      subject: { agent: "treasury-lead", user: "mira@example.com" }
+      actions: ["bank.payout"]
+      resources: ["account:*"]
+      constraints: { amount_gte: 0, amount_lte: 10000000 }
+      environments: ["production"]
+      delegable: true
+      expires_at: "2027-01-01T00:00:00Z"
+
+actions:
+  bank.payout:
+    effect: "payout:{account}:{reference}"
+    resource: "account:{account}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 1000000 }
+        decision: allow
+      - decision: approve

--- a/examples/cookbook/payout-maker-checker/main.py
+++ b/examples/cookbook/payout-maker-checker/main.py
@@ -1,0 +1,126 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/payout-maker-checker.mdx — edit the page, never this file.
+from pathlib import Path
+
+from ctrlrun import (
+    Action,
+    ApprovalRequired,
+    Authority,
+    AuthorityDenied,
+    AuthorityEscalation,
+    Control,
+    Policy,
+    Principal,
+    SQLiteStateStore,
+    with_approval,
+)
+from ctrlrun.authority import grant_from_yaml
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+LEAD = Principal(agent="treasury-lead", user="mira@example.com")
+AGENT = Principal(agent="payout-agent", user="mira@example.com")
+document = (HERE / "ctrlrun.yaml").read_text(encoding="utf-8")
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(
+    Policy.from_yaml(document, source="ctrlrun.yaml"),
+    store,
+    authority=Authority.from_yaml(document, source="ctrlrun.yaml"),
+    environment="production",
+)
+paid: list[tuple[str, int]] = []
+
+
+def payout(account: str, reference: str, amount: int) -> dict:
+    paid.append((reference, amount))
+    return {"reference": reference, "status": "sent"}
+
+
+def proposal(who: Principal, account: str, reference: str, amount: int) -> Action:
+    return Action(
+        name="bank.payout",
+        arguments={"account": account, "reference": reference, "amount": amount},
+        principal=who,
+        resource=f"account:{account}",
+    )
+
+
+# The lead hands the agent a €25,000 slice, itself delegable so the agent could pass a narrower
+# one on. Every dimension is stated: omission is rejected, never inherited.
+slice_ = grant_from_yaml("""
+subject: { agent: "payout-agent", user: "mira@example.com" }
+actions: ["bank.payout"]
+resources: ["account:ops-*"]
+constraints: { amount_gte: 0, amount_lte: 2500000 }
+environments: ["production"]
+delegable: true
+expires_at: "2026-12-31T00:00:00Z"
+""")
+delegation = control.delegate("treasury-lead", slice_, by=LEAD)
+print("delegated to the payout agent:", delegation.delegation_id)
+
+# €8,000: inside the slice, inside the autonomous band. Runs.
+control.execute(
+    proposal(AGENT, "ops-eu", "inv-1042", 800000),
+    lambda: payout("ops-eu", "inv-1042", 800000),
+    "payout:ops-eu:inv-1042",
+)
+print("€8,000 payout: sent")
+
+# €18,000: inside the slice, above the desk limit. A second person.
+try:
+    control.execute(
+        proposal(AGENT, "ops-eu", "inv-1043", 1800000),
+        lambda: payout("ops-eu", "inv-1043", 1800000),
+        "payout:ops-eu:inv-1043",
+    )
+except ApprovalRequired as pending:
+    print("€18,000 payout: a checker decides:", pending.request_id)
+    store.grant_approval(pending.request_id, "checker:sam@example.com")
+    with with_approval(pending.request_id):
+        control.execute(
+            proposal(AGENT, "ops-eu", "inv-1043", 1800000),
+            lambda: payout("ops-eu", "inv-1043", 1800000),
+            "payout:ops-eu:inv-1043",
+        )
+    print("€18,000 payout, checked: sent")
+else:
+    raise SystemExit("a payout above the desk limit ran without a checker")
+
+# €40,000: outside the slice. Authority refuses before the policy is asked.
+try:
+    control.execute(
+        proposal(AGENT, "ops-eu", "inv-1044", 4000000),
+        lambda: payout("ops-eu", "inv-1044", 4000000),
+        "payout:ops-eu:inv-1044",
+    )
+except AuthorityDenied as refused:
+    print("€40,000 payout: refused,", refused.reason)
+else:
+    raise SystemExit("a payout outside the delegated grant ran")
+
+# The agent tries to widen its own slice.
+try:
+    control.delegate(
+        delegation.delegation_id,
+        grant_from_yaml("""
+subject: { agent: "payout-agent", user: "mira@example.com" }
+actions: ["bank.payout"]
+resources: ["account:*"]
+constraints: { amount_gte: 0, amount_lte: 9000000 }
+environments: ["production"]
+expires_at: "2026-12-31T00:00:00Z"
+"""),
+        by=AGENT,
+    )
+except AuthorityEscalation as refused:
+    print("widening the slice: refused,", refused.reason, refused.dimension)
+else:
+    raise SystemExit("an agent widened its own authority")
+
+print("payouts sent:", len(paid))
+store.close()

--- a/examples/cookbook/protect-an-mcp-server/ctrlrun.yaml
+++ b/examples/cookbook/protect-an-mcp-server/ctrlrun.yaml
@@ -1,0 +1,13 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/protect-an-mcp-server.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v2
+
+actions:
+  mcp.ops.get_deployment:
+    decision: allow
+  mcp.ops.restart_deployment:
+    effect: "restart:{cluster}:{name}"
+    decision: allow
+  mcp.ops.delete_namespace:
+    effect: "namespace:{cluster}:{name}"
+    decision: approve

--- a/examples/cookbook/protect-an-mcp-server/main.py
+++ b/examples/cookbook/protect-an-mcp-server/main.py
@@ -1,0 +1,100 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/protect-an-mcp-server.mdx — edit the page, never this file.
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ctrlrun import Control, Policy, SQLiteStateStore
+from ctrlrun.gateway.mcp import CURRENT_REVISION
+from ctrlrun.gateway.outcome import COMPLETE, UpstreamResult
+from ctrlrun.gateway.server import Gateway, GatewayConfig
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+upstream_calls: list[dict] = []
+
+
+def upstream(
+    body: bytes, headers: Mapping[str, str], *, fresh: bool
+) -> tuple[Any, bytes, int, dict[str, str]]:
+    """The MCP server, as the gateway sees it: a stand-in that answers every tools/call."""
+    request = json.loads(body)
+    upstream_calls.append(request)
+    reply = {
+        "jsonrpc": "2.0",
+        "id": request["id"],
+        "result": {"content": [{"type": "text", "text": "ok"}]},
+    }
+    return (
+        UpstreamResult(result_type=COMPLETE),
+        json.dumps(reply).encode(),
+        200,
+        {"content-type": "application/json"},
+    )
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+config = GatewayConfig(upstream="http://localhost:8000/mcp", alias="ops", principal="oncall-agent")
+gateway = Gateway(config, control, upstream)
+
+
+def call(tool: str, arguments: dict, rpc_id: int) -> dict:
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": rpc_id,
+            "method": "tools/call",
+            "params": {"name": tool, "arguments": arguments},
+        }
+    ).encode()
+    headers = {
+        "MCP-Protocol-Version": CURRENT_REVISION,
+        "Mcp-Method": "tools/call",
+        "Mcp-Name": tool,
+        "Content-Type": "application/json",
+    }
+    response = gateway.handle(body, headers)
+    return {"status": response.status, **json.loads(response.body)}
+
+
+first = call("restart_deployment", {"cluster": "prod-eu", "name": "checkout"}, 1)
+print("restart_deployment:", first["status"], first["result"]["content"][0]["text"])
+
+again = call("restart_deployment", {"cluster": "prod-eu", "name": "checkout"}, 2)
+print(
+    "the same restart again:",
+    again["status"],
+    again["error"]["code"],
+    again["error"]["data"]["error"],
+)
+if "error" not in again:
+    raise SystemExit("a duplicate restart reached the upstream")
+
+held = call("delete_namespace", {"cluster": "prod-eu", "name": "checkout"}, 3)
+print(
+    "delete_namespace:",
+    held["status"],
+    held["error"]["code"],
+    held["error"]["data"]["error"],
+    "request",
+    held["error"]["data"]["request_id"][:4] + "…",
+)
+if "error" not in held:
+    raise SystemExit("a namespace delete reached the upstream without a human")
+
+unknown = call("drop_database", {"name": "prod"}, 4)
+print(
+    "drop_database (not in the policy):",
+    unknown["status"],
+    unknown["error"]["code"],
+    unknown["error"]["data"]["error"],
+)
+
+print("calls that reached the upstream:", len(upstream_calls))
+store.close()

--- a/examples/cookbook/receipts-to-opentelemetry/ctrlrun.yaml
+++ b/examples/cookbook/receipts-to-opentelemetry/ctrlrun.yaml
@@ -1,0 +1,11 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/receipts-to-opentelemetry.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v2
+
+actions:
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }
+        decision: allow
+      - decision: deny

--- a/examples/cookbook/receipts-to-opentelemetry/main.py
+++ b/examples/cookbook/receipts-to-opentelemetry/main.py
@@ -1,0 +1,58 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/receipts-to-opentelemetry.mdx — edit the page, never this file.
+import contextlib
+from pathlib import Path
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+from ctrlrun.otel import OTelEventSink
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+exporter = InMemorySpanExporter()  # your OTLP exporter in production
+provider = TracerProvider()
+provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(
+    Policy.from_file(HERE / "ctrlrun.yaml"),
+    store,
+    sinks=[OTelEventSink(tracer_provider=provider)],
+)
+
+
+@ctrlrun.protect("stripe.refund", effect="refund:{payment_id}", control=control)
+def refund(payment_id: str, amount: int) -> str:
+    if payment_id == "txn_lost":
+        raise TimeoutError("no response from api.stripe.com")
+    return "refunded"
+
+
+with ctrlrun.context(agent="support-agent"):
+    refund(payment_id="txn_1", amount=12000)
+    try:
+        refund(payment_id="txn_2", amount=900000)
+    except ctrlrun.ActionDenied:
+        pass
+    else:
+        raise SystemExit("a €9,000 refund ran")
+    with contextlib.suppress(TimeoutError):
+        refund(payment_id="txn_lost", amount=12000)
+
+for span in exporter.get_finished_spans():
+    events = [event.name for event in span.events]
+    result = span.attributes.get("ctrlrun.result")
+    print(
+        f"{span.name}  status={span.status.status_code.name}  result={result}  events={len(events)}"
+    )
+    if any("12000" in str(value) for value in span.attributes.values()):
+        raise SystemExit("an argument value leaked into the span attributes")
+print("argument values in attributes: none")

--- a/examples/cookbook/reconcile-against-the-remote/ctrlrun.yaml
+++ b/examples/cookbook/reconcile-against-the-remote/ctrlrun.yaml
@@ -1,0 +1,11 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/reconcile-against-the-remote.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v2
+
+actions:
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    decision: allow
+  k8s.scale:
+    effect: "scale:{cluster}:{deployment}:{replicas}"
+    decision: allow

--- a/examples/cookbook/reconcile-against-the-remote/main.py
+++ b/examples/cookbook/reconcile-against-the-remote/main.py
@@ -1,0 +1,88 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/reconcile-against-the-remote.mdx — edit the page, never this file.
+import contextlib
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+stripe_refunds: dict[str, int] = {}  # what Stripe holds
+replicas: dict[str, int] = {"checkout": 3}  # what the cluster holds
+calls: list[str] = []
+
+
+def stripe_refund(payment_id: str, amount: int) -> str:
+    calls.append(f"refund {payment_id}")
+    stripe_refunds[payment_id] = amount  # committed...
+    raise TimeoutError("no response from api.stripe.com")  # ...reply lost
+
+
+def kubectl_scale(deployment: str, count: int) -> str:
+    calls.append(f"scale {deployment}")
+    raise ConnectionResetError("connection reset by peer")  # never reached the API server
+
+
+def ask_stripe(effect_key: str) -> ctrlrun.ReconcileOutcome:
+    payment_id = effect_key.removeprefix("refund:")
+    return "committed" if payment_id in stripe_refunds else "not_executed"
+
+
+def ask_kubernetes(effect_key: str) -> ctrlrun.ReconcileOutcome:
+    _, _, deployment, count = effect_key.split(":")
+    return "committed" if replicas.get(deployment) == int(count) else "not_executed"
+
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect(
+    "stripe.refund",
+    effect="refund:{payment_id}",
+    reconcile=ask_stripe,
+    reconcile_eagerly=True,
+    control=control,
+)
+def refund(payment_id: str, amount: int) -> str:
+    return stripe_refund(payment_id, amount)
+
+
+@ctrlrun.protect(
+    "k8s.scale",
+    effect="scale:{cluster}:{deployment}:{replicas}",
+    reconcile=ask_kubernetes,
+    reconcile_eagerly=True,
+    control=control,
+)
+def scale(cluster: str, deployment: str, replicas: int) -> str:
+    return kubectl_scale(deployment, replicas)
+
+
+with ctrlrun.context(agent="ops-agent"):
+    try:
+        refund(payment_id="txn_9", amount=50000)
+    except TimeoutError:
+        print("refund txn_9: reply lost; the hook asked Stripe")
+    try:
+        refund(payment_id="txn_9", amount=50000)
+    except ctrlrun.DuplicateEffect:
+        print("refund txn_9 again: refused, Stripe has it")
+    else:
+        raise SystemExit("a refund Stripe already holds ran again")
+
+    try:
+        scale(cluster="prod-eu", deployment="checkout", replicas=6)
+    except ConnectionResetError:
+        print("scale checkout to 6: connection reset; the hook asked the cluster")
+    replicas["checkout"] = 6  # the retry succeeds this time
+    with contextlib.suppress(ConnectionResetError):
+        scale(cluster="prod-eu", deployment="checkout", replicas=6)
+    print("scale checkout to 6 again: permitted, the cluster had not applied it")
+
+print("remote calls:", calls)

--- a/examples/cookbook/refund-agent/ctrlrun.yaml
+++ b/examples/cookbook/refund-agent/ctrlrun.yaml
@@ -1,0 +1,14 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/refund-agent.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v2
+
+actions:
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    resource: "payment:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }       # up to €500.00: autonomous
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 500000 }      # up to €5,000.00: a human
+        decision: approve
+      - decision: deny

--- a/examples/cookbook/refund-agent/main.py
+++ b/examples/cookbook/refund-agent/main.py
@@ -1,0 +1,61 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/refund-agent.mdx — edit the page, never this file.
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):  # so the recipe repeats
+    (STATE / name).unlink(missing_ok=True)
+
+
+calls: list[tuple[str, int]] = []
+
+
+class FakeStripe:
+    def refund(self, payment_id: str, amount: int) -> dict:
+        calls.append((payment_id, amount))
+        return {"id": f"re_{payment_id}", "status": "succeeded"}
+
+
+stripe = FakeStripe()
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+
+
+@ctrlrun.protect("stripe.refund", effect="refund:{payment_id}", control=control)
+def refund(payment_id: str, amount: int) -> dict:
+    return stripe.refund(payment_id, amount)
+
+
+with ctrlrun.context(agent="support-agent"):
+    print("€120 refund:", refund(payment_id="txn_1", amount=12000)["status"])
+
+    try:
+        refund(payment_id="txn_2", amount=250000)
+    except ctrlrun.ApprovalRequired as pending:
+        print("€2,500 refund: a human decides:", pending.request_id)
+        store.grant_approval(pending.request_id, "human:ops")  # what `ctrlrun approve` does
+        with ctrlrun.with_approval(pending.request_id):
+            print("€2,500 refund, approved:", refund(payment_id="txn_2", amount=250000)["status"])
+    else:
+        raise SystemExit("a €2,500 refund ran without a human")
+
+    try:
+        refund(payment_id="txn_3", amount=2000000)
+    except ctrlrun.ActionDenied as refused:
+        print("€20,000 refund: refused,", refused.reason)
+    else:
+        raise SystemExit("a €20,000 refund ran")
+
+    try:
+        refund(payment_id="txn_1", amount=12000)
+    except ctrlrun.DuplicateEffect:
+        print("€120 refund again: refused as a duplicate")
+    else:
+        raise SystemExit("the same refund ran twice")
+
+print("remote refund calls:", len(calls))

--- a/examples/cookbook/resolve-an-ambiguous-effect/ctrlrun.yaml
+++ b/examples/cookbook/resolve-an-ambiguous-effect/ctrlrun.yaml
@@ -1,0 +1,11 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/resolve-an-ambiguous-effect.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v2
+
+actions:
+  dns.update_record:
+    effect: "dns:{zone}:{name}"
+    decision: allow
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    decision: allow

--- a/examples/cookbook/resolve-an-ambiguous-effect/main.py
+++ b/examples/cookbook/resolve-an-ambiguous-effect/main.py
@@ -1,0 +1,62 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/resolve-an-ambiguous-effect.mdx — edit the page, never this file.
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, EffectState, Policy, SQLiteStateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+remote_calls: list[str] = []
+
+
+@ctrlrun.protect("dns.update_record", effect="dns:{zone}:{name}", control=control)
+def update_record(zone: str, name: str, value: str) -> str:
+    remote_calls.append(f"dns {name}")
+    raise ConnectionResetError("connection reset by peer")
+
+
+@ctrlrun.protect("stripe.refund", effect="refund:{payment_id}", control=control)
+def refund(payment_id: str, amount: int) -> str:
+    remote_calls.append(f"refund {payment_id}")
+    if len(remote_calls) == 2:
+        raise TimeoutError("no response from api.stripe.com after 30s")
+    return "refunded"
+
+
+with ctrlrun.context(agent="ops-agent"):
+    for call in (
+        lambda: update_record(zone="example.com", name="api", value="203.0.113.7"),
+        lambda: refund(payment_id="txn_7", amount=50000),
+    ):
+        try:
+            call()
+        except (ConnectionResetError, TimeoutError) as lost:
+            print("the executor saw:", lost)
+
+    ambiguous = [record.effect_key for record in store.list_effects(EffectState.AMBIGUOUS)]
+    print("ambiguous effects:", ambiguous)
+
+    # A human asks the DNS provider: the record was updated. Asks Stripe: no refund exists.
+    # This is what `ctrlrun resolve <key> --committed` and `--failed` do.
+    store.resolve_effect("dns:example.com:api", EffectState.COMMITTED, "human:ops")
+    store.resolve_effect("refund:txn_7", EffectState.FAILED, "human:ops")
+
+    try:
+        update_record(zone="example.com", name="api", value="203.0.113.7")
+    except ctrlrun.DuplicateEffect:
+        print("DNS update again: refused, it committed")
+    else:
+        raise SystemExit("a committed update ran again")
+
+    print("refund again:", refund(payment_id="txn_7", amount=50000))
+
+for record in store.list_effects():
+    print(f"{record.effect_key}: {record.state.value}, resolved by {record.resolved_by}")
+print("remote calls:", remote_calls)

--- a/examples/cookbook/slack-approvals/ctrlrun.yaml
+++ b/examples/cookbook/slack-approvals/ctrlrun.yaml
@@ -1,0 +1,11 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/slack-approvals.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v2
+
+actions:
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }
+        decision: allow
+      - decision: approve

--- a/examples/cookbook/slack-approvals/main.py
+++ b/examples/cookbook/slack-approvals/main.py
@@ -1,0 +1,70 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/slack-approvals.mdx — edit the page, never this file.
+import json
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore
+from ctrlrun.webhook import handle_inbound, sign
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+SECRET = "shared-with-the-slack-service"  # from $CTRLRUN_WEBHOOK_SECRET in production
+store = SQLiteStateStore(STATE / "state.db")
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+refunds: list[int] = []
+
+
+@ctrlrun.protect("stripe.refund", effect="refund:{payment_id}", control=control)
+def refund(payment_id: str, amount: int) -> str:
+    refunds.append(amount)
+    return "refunded"
+
+
+with ctrlrun.context(agent="support-agent"):
+    try:
+        refund(payment_id="txn_5", amount=250000)
+    except ctrlrun.ApprovalRequired as pending:
+        request_id = pending.request_id
+        print("€2,500 refund: request", request_id[:4] + "…", "goes to Slack")
+    else:
+        raise SystemExit("a €2,500 refund ran without a human")
+
+    # What the Slack service POSTs to /ctrlrun/approvals/<request_id> when the lead clicks. It
+    # echoes the action hash it showed the human: an answer for a different hash is refused.
+    shown = store.get_approval(request_id).request.action_hash
+    answer = json.dumps(
+        {
+            "request_id": request_id,
+            "action_hash": shown,
+            "decision": "grant",
+            "approver": "slack:dana",
+        }
+    ).encode()
+    status, message = handle_inbound(store, request_id, answer, sign(answer, SECRET), secret=SECRET)
+    print("the lead approves in Slack:", status, message)
+
+    # A forged answer, signed with the wrong secret, changes nothing.
+    forged = json.dumps(
+        {
+            "request_id": request_id,
+            "action_hash": shown,
+            "decision": "grant",
+            "approver": "slack:nobody",
+        }
+    ).encode()
+    status, message = handle_inbound(
+        store, request_id, forged, sign(forged, "guess"), secret=SECRET
+    )
+    print("a forged answer:", status, message)
+    if status == 200:
+        raise SystemExit("a forged answer was accepted")
+
+    with ctrlrun.with_approval(request_id):
+        print("€2,500 refund, approved in Slack:", refund(payment_id="txn_5", amount=250000))
+
+print("refunds:", refunds)

--- a/examples/cookbook/sqlite-to-postgres/ctrlrun.yaml
+++ b/examples/cookbook/sqlite-to-postgres/ctrlrun.yaml
@@ -1,0 +1,8 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/sqlite-to-postgres.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v2
+
+actions:
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    decision: allow

--- a/examples/cookbook/sqlite-to-postgres/main.py
+++ b/examples/cookbook/sqlite-to-postgres/main.py
@@ -1,0 +1,47 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/sqlite-to-postgres.mdx — edit the page, never this file.
+import os
+from pathlib import Path
+
+import ctrlrun
+from ctrlrun import Control, Policy, SQLiteStateStore, StateStore
+
+HERE = Path(__file__).resolve().parent
+STATE = HERE / ".ctrlrun"
+STATE.mkdir(exist_ok=True)
+for name in ("state.db", "state.db-wal", "state.db-shm"):
+    (STATE / name).unlink(missing_ok=True)
+
+
+def open_store() -> StateStore:
+    url = os.environ.get("CTRLRUN_STORE_URL")
+    if url and url.startswith(("postgresql://", "postgres://")):
+        from ctrlrun.postgres import PostgresStateStore  # pip install "ctrlrun[postgres]"
+
+        return PostgresStateStore(url, schema="ctrlrun")  # migrates at open, forward only
+    return SQLiteStateStore(STATE / "state.db")
+
+
+store = open_store()
+control = Control(Policy.from_file(HERE / "ctrlrun.yaml"), store)
+refunds: list[str] = []
+
+
+@ctrlrun.protect("stripe.refund", effect="refund:{payment_id}", control=control)
+def refund(payment_id: str, amount: int) -> str:
+    refunds.append(payment_id)
+    return "refunded"
+
+
+with ctrlrun.context(agent="refund-agent"):
+    print("store:", type(store).__name__)
+    print("refund txn_1:", refund(payment_id="txn_1", amount=12000))
+    try:
+        refund(payment_id="txn_1", amount=12000)  # a second host, same effect
+    except ctrlrun.DuplicateEffect:
+        print("refund txn_1 from another host: refused")
+    else:
+        raise SystemExit("one effect committed twice")
+
+print("remote refund calls:", len(refunds))
+store.close()

--- a/examples/cookbook/verify-in-github-actions/ctrlrun.yaml
+++ b/examples/cookbook/verify-in-github-actions/ctrlrun.yaml
@@ -1,0 +1,14 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/verify-in-github-actions.mdx — edit the page, never this file.
+schema: ctrlrun.policy/v2
+
+actions:
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }
+        decision: allow
+      - decision: approve
+  k8s.delete_namespace:
+    effect: "namespace:{cluster}:{name}"
+    decision: approve

--- a/examples/cookbook/verify-in-github-actions/run.sh
+++ b/examples/cookbook/verify-in-github-actions/run.sh
@@ -1,0 +1,6 @@
+# Extracted by tools/docs_audit/render_cookbook.py from
+# docs/cookbook/verify-in-github-actions.mdx — edit the page, never this file.
+ctrlrun verify
+ctrlrun verify --json > verify-report.json
+python -c "import json; s = json.load(open('verify-report.json'))['summary']; print('applicable', s['applicable'], 'passed', s['passed'], 'not applicable', s['not_applicable'])"
+rm -f verify-report.json

--- a/tests/test_cookbook.py
+++ b/tests/test_cookbook.py
@@ -1,0 +1,139 @@
+"""The cookbook: every recipe runs, twice, offline, and its directory is what its page shows.
+
+A recipe page is the single source; `tools/docs_audit/render_cookbook.py` extracts the policy
+and the script into `examples/cookbook/<name>/`. Here each directory is run in a subprocess
+whose `sitecustomize` refuses every socket, twice in the same working directory so a second
+run must refuse the same things rather than trip over a stale record, and the exit status must
+be 0 — every recipe carries an `else: raise SystemExit` on the path where a refusal did not
+happen, so a recipe that quietly starts succeeding fails here.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOOLS = REPO_ROOT / "tools" / "docs_audit"
+COOKBOOK = REPO_ROOT / "examples" / "cookbook"
+PAGES = REPO_ROOT / "docs" / "cookbook"
+
+if not (TOOLS.exists() and PAGES.exists()):  # pragma: no cover - not a checkout
+    pytest.skip("no repository checkout", allow_module_level=True)
+
+sys.path.insert(0, str(TOOLS))
+
+import render_cookbook  # noqa: E402
+from snippets import NO_NETWORK  # noqa: E402
+
+RECIPES = sorted(p.name for p in COOKBOOK.iterdir() if p.is_dir() and p.name != "__pycache__")
+REQUIRED_SECTIONS = (
+    "## The policy",
+    "## The code",
+    "## What the agent sees",
+    "## The receipt",
+    "## When an AMBIGUOUS appears",
+)
+
+
+@pytest.fixture(scope="session")
+def no_network(tmp_path_factory):
+    directory = tmp_path_factory.mktemp("no-network")
+    (directory / "sitecustomize.py").write_text(NO_NETWORK, encoding="utf-8")
+    return directory
+
+
+def _run(recipe: str, no_network: Path) -> subprocess.CompletedProcess[str]:
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(no_network), environment.get("PYTHONPATH", "")) if part
+    )
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    for name in ("CTRLRUN_CONFIG", "CTRLRUN_STATE", "CTRLRUN_STORE_URL"):
+        environment.pop(name, None)
+    script = COOKBOOK / recipe / "main.py"
+    command = (
+        [sys.executable, str(script)] if script.exists() else ["bash", "-euo", "pipefail", "run.sh"]
+    )
+    if not script.exists():
+        environment["PATH"] = os.pathsep.join(
+            [str(Path(sys.executable).parent), environment.get("PATH", "")]
+        )
+    return subprocess.run(
+        command,
+        cwd=COOKBOOK / recipe,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+def test_every_recipe_directory_is_what_its_page_shows():
+    assert render_cookbook.check(render_cookbook.recipes()) == []
+
+
+def test_a_hand_edit_to_an_extracted_file_is_drift(tmp_path, monkeypatch):
+    monkeypatch.setattr(render_cookbook, "EXAMPLES", tmp_path)
+    extracted = render_cookbook.recipes()
+    render_cookbook.write(extracted)
+    first = next(iter(extracted))
+    target = tmp_path / first / "main.py"
+    target.write_text(target.read_text() + "\n# edited by hand\n")
+
+    assert any(first in item for item in render_cookbook.check(extracted))
+
+
+@pytest.mark.parametrize("recipe", RECIPES)
+def test_every_recipe_runs_offline_and_is_repeatable(recipe, no_network):
+    first = _run(recipe, no_network)
+    assert first.returncode == 0, f"{recipe} failed:\n{first.stdout}\n{first.stderr}"
+    second = _run(recipe, no_network)
+    assert second.returncode == 0, f"{recipe} is not repeatable:\n{second.stdout}\n{second.stderr}"
+
+
+@pytest.mark.parametrize("recipe", RECIPES)
+def test_every_recipe_refuses_something_and_says_so(recipe, no_network):
+    """The share unit is a failure and a refusal: every recipe's output shows one."""
+    output = _run(recipe, no_network).stdout.lower()
+    refusals = (
+        "refused",
+        "blocked",
+        "denied",
+        "a human",
+        "a checker",
+        "did not verify",
+        "approval_required",
+    )
+    assert any(word in output for word in refusals), output
+
+
+@pytest.mark.parametrize("page", sorted(p.stem for p in PAGES.glob("*.mdx") if p.stem != "index"))
+def test_every_recipe_page_has_the_five_sections(page):
+    text = (PAGES / f"{page}.mdx").read_text(encoding="utf-8")
+    for section in REQUIRED_SECTIONS:
+        assert section in text, f"{page}: missing {section!r}"
+
+
+def test_the_cookbook_directories_are_tracked_by_git():
+    listed = subprocess.run(
+        ["git", "ls-files", "examples/cookbook"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if listed.returncode != 0:  # pragma: no cover - not a checkout
+        pytest.skip("no repository checkout")
+    tracked = set(listed.stdout.split())
+    needed = {
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in COOKBOOK.rglob("*")
+        if path.is_file() and path.suffix in (".py", ".yaml") and "__pycache__" not in path.parts
+    }
+    assert not needed - tracked, f"untracked: {sorted(needed - tracked)}"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -40,7 +40,7 @@ SCENARIOS: dict[str, str] = {
 
 #: Directories under `examples/` that are not one of §1.1's failure scenarios: the sector
 #: templates, and item 8's ACS integration example (SPEC-v0.2 §9, `docs/ACS.md`).
-NOT_A_SCENARIO = ("policies", "acs", "authority", "__pycache__")
+NOT_A_SCENARIO = ("policies", "acs", "authority", "cookbook", "__pycache__")
 
 #: The nine sectors of SPEC-v0.2 §1.1.
 SECTORS = (

--- a/tools/docs_audit/render_cookbook.py
+++ b/tools/docs_audit/render_cookbook.py
@@ -1,0 +1,107 @@
+"""Extract every cookbook recipe's files from its page into `examples/cookbook/<name>/`.
+
+A recipe page under `docs/cookbook/` is the single source: its `yaml runnable` block is the
+recipe's `ctrlrun.yaml` and its `python runnable file=main.py` block is the script. This
+script writes those into `examples/cookbook/<name>/`, so the directory a reader clones runs
+exactly what the page shows, and `--check` refuses a copy that drifted either way.
+
+    python tools/docs_audit/render_cookbook.py --write
+    python tools/docs_audit/render_cookbook.py --check
+
+`tests/test_cookbook.py` runs every extracted directory offline, twice, and asserts exit 0.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from _files import REPO_ROOT, fences, relative
+
+PAGES = REPO_ROOT / "docs" / "cookbook"
+EXAMPLES = REPO_ROOT / "examples" / "cookbook"
+HEADER = (
+    "# Extracted by tools/docs_audit/render_cookbook.py from\n"
+    "# docs/cookbook/{name}.mdx — edit the page, never this file.\n"
+)
+
+
+def recipes() -> dict[str, dict[str, str]]:
+    """`{recipe name: {file name: content}}` for every page under `docs/cookbook/`."""
+    out: dict[str, dict[str, str]] = {}
+    for page in sorted(PAGES.glob("*.mdx")):
+        if page.stem == "index":
+            continue
+        files: dict[str, str] = {}
+        for fence in fences(page.read_text(encoding="utf-8"), page):
+            if "runnable" not in fence.tokens or fence.language not in {"python", "yaml", "bash"}:
+                continue
+            name = next((t[5:] for t in fence.tokens if t.startswith("file=")), None)
+            if name is None:
+                if fence.language != "yaml":
+                    continue
+                name = "ctrlrun.yaml"
+            header = HEADER.format(name=page.stem)
+            files[name] = header + fence.body
+        # A recipe is a directory only where the page carries something to run. The two adapter
+        # recipes show a framework's own code, which the adapters CI job runs against a real
+        # install; they extract nothing here rather than a directory that cannot run offline.
+        if "main.py" in files or "run.sh" in files:
+            out[page.stem] = files
+    return out
+
+
+def check(extracted: dict[str, dict[str, str]]) -> list[str]:
+    drift: list[str] = []
+    for name, files in extracted.items():
+        for filename, content in files.items():
+            target = EXAMPLES / name / filename
+            if not target.exists():
+                drift.append(f"{relative(target)} missing; run --write")
+            elif target.read_text(encoding="utf-8") != content:
+                drift.append(
+                    f"{relative(target)} differs from docs/cookbook/{name}.mdx; run --write"
+                )
+    if EXAMPLES.exists():
+        for existing in EXAMPLES.iterdir():
+            if (
+                existing.is_dir()
+                and existing.name not in extracted
+                and existing.name != "__pycache__"
+            ):
+                drift.append(f"{relative(existing)} has no page under docs/cookbook/; remove it")
+    return drift
+
+
+def write(extracted: dict[str, dict[str, str]]) -> int:
+    count = 0
+    for name, files in extracted.items():
+        directory = EXAMPLES / name
+        directory.mkdir(parents=True, exist_ok=True)
+        for filename, content in files.items():
+            (directory / filename).write_text(content, encoding="utf-8")
+            count += 1
+    return count
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--check", action="store_true")
+    arguments = parser.parse_args(argv)
+    extracted = recipes()
+    if arguments.write:
+        print(
+            f"wrote {write(extracted)} files for {len(extracted)} recipes under {relative(EXAMPLES)}"
+        )
+    if arguments.check or not arguments.write:
+        drift = check(extracted)
+        for item in drift:
+            print(f"DRIFT {item}")
+        print(f"cookbook: {len(extracted)} recipes, {len(drift)} drifted")
+        return 0 if not drift else 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Session 4 of the documentation milestone. **No kernel code.**

## Recipes

Twenty-one, under `docs/cookbook/`, each: the situation in two sentences, the policy, the code against a stand-in remote, what the agent sees when refused or asked (pasted from a run), the receipt, and what to do when an AMBIGUOUS appears.

| Domain | Recipes |
|---|---|
| money | refund agent with tiers · payout maker/checker via delegation |
| infrastructure | deploy agent · database-migration agent |
| permissions | IAM agent (read, never admin) · credential-rotation agent |
| records | CRM-update agent · data-deletion agent under a retention rule |
| communications | outbound-email agent · customer-notification agent |
| multi-agent | manager delegating bounded authority to a worker |
| integrations | protect an existing MCP server (the gateway driven in process against a stand-in upstream) · LangGraph `interrupt()` · OpenAI Agents SDK tool approval · Slack approvals (the inbound handler with the real signing) · receipts into OpenTelemetry |
| operations | observe then enforce · resolve an ambiguous effect · reconcile against Stripe/Kubernetes · verify in GitHub Actions · SQLite to Postgres |

## One source, two renders

A recipe page is the source. `tools/docs_audit/render_cookbook.py` extracts its `ctrlrun.yaml` and `main.py` (or `run.sh`) into `examples/cookbook/<name>/`; `--check` refuses drift either way and runs as a hard CI step. `tests/test_cookbook.py` runs every directory twice with the socket guard, asserts exit 0 and a refusal in the output; every recipe carries an `else: raise SystemExit` where a refusal did not happen. The two adapter recipes show their framework's own example and extract no directory, because the harness has no framework; the adapters CI job runs that shape against real installs.

## Also

- The observe-mode guide and concept quoted `ctrlrun stats` labels that had been guessed; both now quote the command's real output.
- `examples/cookbook` joins the examples test's known directories; `*.sh` joins the manifest.

## Audit

Snippets 96/0 failed across 156 documents · lint 0 · links 0 broken, 8 planned · cookbook 0 drift · CLI, schemas, API, capabilities 0 drift · `mint validate` passes · `scripts/check.sh` result recorded below.
