### PR TITLE
Docs 6a: the domain, and the documents that were never site pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,18 +459,22 @@ refund, delete, deploy, grant, revoke, approve, submit, purchase or cancel**, yo
 
 ## Documentation
 
+**[docs.ctrlrun.dev](https://docs.ctrlrun.dev)** is the documentation: concepts, guides, a
+cookbook, the reference, and a browser demo that runs `ctrlrun demo` with no install.
+
 | Section | Where |
 |---|---|
-| Why, and how it is shaped | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) |
-| Adapters, and the three ways in | [`docs/adapters.md`](docs/adapters.md) |
-| Authority and delegation, in plain language | [`docs/authority.md`](docs/authority.md) |
-| Running the store on Postgres | [`docs/postgres.md`](docs/postgres.md) |
-| `ctrlrun verify`, the guarantees, and what the badge means | [`docs/verify.md`](docs/verify.md) |
-| Security: threat model, disclosure, how this is built | [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md), [`SECURITY.md`](SECURITY.md), [`docs/how-this-is-built.md`](docs/how-this-is-built.md) |
-| Contributing | [`CONTRIBUTING.md`](CONTRIBUTING.md), [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) |
-| Standards, read against the guarantees | [`docs/OWASP-AGENTIC-TOP10.md`](docs/OWASP-AGENTIC-TOP10.md), [`docs/ACS.md`](docs/ACS.md) |
-| Specifications, v0.1 to v0.6 | [`docs/SPEC-v0.1.md`](docs/SPEC-v0.1.md) · [v0.2](docs/SPEC-v0.2.md) · [v0.3](docs/SPEC-v0.3.md) · [v0.4](docs/SPEC-v0.4.md) · [v0.5](docs/SPEC-v0.5.md) · [v0.6](docs/SPEC-v0.6.md) |
+| Start here | [Why](https://docs.ctrlrun.dev/why) · [60-second quickstart](https://docs.ctrlrun.dev/get-started/quickstart) · [Try it in your browser](https://docs.ctrlrun.dev/try-it) |
+| The ideas | [Concepts](https://docs.ctrlrun.dev/concepts/outcomes-and-ambiguous) |
+| Doing something | [Guides](https://docs.ctrlrun.dev/guides/protect-a-function) · [Cookbook](https://docs.ctrlrun.dev/cookbook/index) |
+| MCP | [Overview](https://docs.ctrlrun.dev/mcp/overview) · [The gateway in five minutes](https://docs.ctrlrun.dev/mcp/gateway-in-5-minutes) |
+| Every key, flag and error | [Reference](https://docs.ctrlrun.dev/reference/policy-yaml) |
+| Compared with other things | [Compare](https://docs.ctrlrun.dev/compare/idempotency-keys) · [FAQ](https://docs.ctrlrun.dev/faq) |
+| Security | [Threat model](https://docs.ctrlrun.dev/THREAT_MODEL) · [What verify guarantees](https://docs.ctrlrun.dev/security/verify-guarantees) · [SECURITY.md](SECURITY.md) |
+| How this is built, and what is not done | [How this is built](https://docs.ctrlrun.dev/how-this-is-built) |
 | Every sentence above, mapped to the code and the test that proves it | [`docs/CLAIMS.md`](docs/CLAIMS.md) |
+| The contract, per version | [`docs/SPEC-v0.1.md`](docs/SPEC-v0.1.md) · [v0.2](docs/SPEC-v0.2.md) · [v0.3](docs/SPEC-v0.3.md) · [v0.4](docs/SPEC-v0.4.md) · [v0.5](docs/SPEC-v0.5.md) · [v0.6](docs/SPEC-v0.6.md) |
+| Contributing | [`CONTRIBUTING.md`](CONTRIBUTING.md), [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) |
 | Changelog and roadmap | [`CHANGELOG.md`](CHANGELOG.md), [`docs/ROADMAP.md`](docs/ROADMAP.md) |
 
 ## License

--- a/docs/.mintignore
+++ b/docs/.mintignore
@@ -7,3 +7,7 @@ SEO.md
 capabilities.yaml
 generated/
 assets/
+# The six specifications are the implementers' contract, not user documentation: 111,000
+# words written for somebody building against the kernel, and they stay public on GitHub.
+# docs/architecture/specifications.mdx links to each one.
+SPEC-v*.md

--- a/docs/ACS.md
+++ b/docs/ACS.md
@@ -1,4 +1,7 @@
-# CTRLRun and the Agent Control Standard
+---
+title: "The Agent Control Standard"
+description: "What was read, what maps onto CTRLRun's guarantees, where the standard is silent, and how the adapter is built."
+---
 
 What was read, what maps, what does not, and how the adapter is built.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,7 @@
-# CTRLRun Architecture (v0.1 kernel)
+---
+title: "Architecture"
+description: "The boundary CTRLRun owns, the six steps every protected call takes, the data model, and the key design decisions with their trade-offs."
+---
 
 Context: agent frameworks model work as `model → tool call → response`. That is fine for reads. For writes it is missing the semantics every serious system has around consequential operations: authorization bound to the exact operation, identity of the effect (not the request), atomic reservation, and an honest distinction between *failed* and *unknown*. CTRLRun adds those semantics around the dangerous part and nothing else.
 

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -1,4 +1,7 @@
-# Claims
+---
+title: "Claims"
+description: "Every sentence of the README mapped to the code that implements it and the test that proves it, re-derived at every release."
+---
 
 Every sentence of the README that asserts something about the shipped code, mapped to the code
 that implements it and the test that proves it.

--- a/docs/OWASP-AGENTIC-TOP10.md
+++ b/docs/OWASP-AGENTIC-TOP10.md
@@ -1,4 +1,7 @@
-# The OWASP Top 10 for Agentic Applications, read against CTRLRun's guarantees
+---
+title: "OWASP Top 10 for Agentic Applications"
+description: "A reading of somebody else's taxonomy against the guarantees CTRLRun tests, naming the four entries it does not address."
+---
 
 This is a **reading** of somebody else's taxonomy against the guarantees CTRLRun tests. It is
 not a compliance claim, a conformance claim, a certification, or a statement that CTRLRun

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,4 +1,7 @@
-# Roadmap
+---
+title: "Roadmap"
+description: "What each version asked and answered, from the v0.1 kernel to v1.0, and what is deliberately not on the list."
+---
 
 Dependency-first: every layer depends on the one below being correct. Milestones ship when their tests pass, not on dates. Nothing below v0.1 is in scope for code today.
 

--- a/docs/SEO.md
+++ b/docs/SEO.md
@@ -98,6 +98,18 @@ are set once in `docs.json` under `seo.metatags`.
 | `reference/exit-codes` | ctrlrun verify exit code | Every `ctrlrun` command exits 0 when it did what it was asked, 1 when CTRLRun refused, 2 on a usage error. |
 | `reference/receipt-and-event-schemas` | ctrlrun receipt json schema | A receipt is one executed action; an event is one step on the way. |
 | `reference/api/index` | ctrlrun Control · ctrlrun protect decorator | Every frozen public name of the package and its extras, one page each. |
+| `architecture/specifications` | ctrlrun specification | Every version of CTRLRun was a specification before it was code. |
+| `ARCHITECTURE` | ctrlrun architecture | The boundary CTRLRun owns, and the six steps every protected call takes. |
+| `THREAT_MODEL` | ctrlrun threat model | What CTRLRun defends against, and what it deliberately does not. |
+| `how-this-is-built` | is ctrlrun trustworthy · how ctrlrun is tested | Specification first, every requirement mutation-tested, every claim mapped to a test. |
+| `verify` | ctrlrun verify guarantees badge | Running the guarantee catalogue against your own configuration. |
+| `adapters` | ctrlrun adapter langgraph openai | The three ways in, and when you do not need an adapter. |
+| `authority` | ctrlrun authority delegation grants | Grants, containment and the omission rule, in plain language. |
+| `postgres` | ctrlrun postgres store | Connection strings, what to grant, migrations, and failover. |
+| `CLAIMS` | ctrlrun claims tests | Every README sentence mapped to the code and the test that proves it. |
+| `ROADMAP` | ctrlrun roadmap v1.0 | What each version asked and answered, and what is not on the list. |
+| `ACS` | agent control standard ctrlrun | What was read, what maps, and where the standard is silent. |
+| `OWASP-AGENTIC-TOP10` | OWASP agentic top 10 mapping | A reading of somebody else's taxonomy against the guarantees CTRLRun tests. |
 
 ## The words that appear once
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,4 +1,7 @@
-# Threat Model
+---
+title: "Threat model"
+description: "What CTRLRun defends against, what it deliberately does not, and the fail-closed rules that follow from both."
+---
 
 CTRLRun sits in the execution path of consequential actions. This document states what it defends against, what it explicitly does not, and the fail-closed rules that follow. It covers v0.1, v0.2 and v0.3, and grows with the roadmap.
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,4 +1,7 @@
-# Adapters
+---
+title: "Adapters"
+description: "The three ways in, when you do not need an adapter, what an adapter is allowed to do, and how to write one for a framework not listed."
+---
 
 ## You probably do not need one
 

--- a/docs/architecture/specifications.mdx
+++ b/docs/architecture/specifications.mdx
@@ -1,0 +1,51 @@
+---
+title: "The specifications"
+description: "Six documents, one per version, each a delta over the ones before and each still binding. They live in the repository; this page says what each asked."
+---
+
+Every version of CTRLRun was a specification before it was code: what it must do, the
+acceptance tests it is judged by, the public names it freezes, and what is deliberately out of
+scope. All six are still binding in full, and nothing in a later one relaxes an earlier one.
+
+They are written for somebody implementing against the kernel, and they are long: a hundred and
+eleven thousand words between them. So they live in the repository rather than on this site,
+where the pages are written for somebody using it. Read a concept page first; open a
+specification when you need the contract.
+
+| Version | The question it asked | Document |
+|---|---|---|
+| v0.1 | Can an action be decided, approved, executed once, and recorded? | [`SPEC-v0.1.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/SPEC-v0.1.md) |
+| v0.2 | Can it work with no code change, over MCP, with reconciliation and evidence that leaves the process? | [`SPEC-v0.2.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/SPEC-v0.2.md) |
+| v0.3 | Who is acting, and what are they entitled to? | [`SPEC-v0.3.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/SPEC-v0.3.md) |
+| v0.4 | Does it hold in *my* setup? | [`SPEC-v0.4.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/SPEC-v0.4.md) |
+| v0.5 | Can somebody else implement this? | [`SPEC-v0.5.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/SPEC-v0.5.md) |
+| v0.6 | Does it still hold when the process dies, the host goes away, and the database is somewhere else? | [`SPEC-v0.6.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/SPEC-v0.6.md) |
+
+## How to read one
+
+Each is a delta. Start at the version that introduced what you care about, and read the
+sections it names in the earlier ones: the acceptance tests are numbered continuously (`T1`
+onward), the public names are frozen in a numbered section per version, and a rule that moved
+says where it moved from.
+
+Two conventions worth knowing before you open one. **MUST, MUST NOT and SHOULD are used in the
+RFC 2119 sense.** And every specification carries a section on what building that version
+settled, including the defects an independent review found and what was done about each: those
+sections are the honest part, and they are where a reader learns what the document got wrong
+before it was right.
+
+## What is on this site instead
+
+| You want | Read |
+|---|---|
+| what a thing is, in one page | [Concepts](/concepts/action-and-hash) |
+| how to do something | [Guides](/guides/protect-a-function) |
+| every key, flag, field and error | [Reference](/reference/policy-yaml) |
+| what is guaranteed and what is not | [What verify guarantees](/security/verify-guarantees), [Threat model](/THREAT_MODEL) |
+| how the guarantees are held up | [How this is built](/how-this-is-built) |
+| every README sentence, mapped to its code and test | [Claims](/CLAIMS) |
+
+## Next
+
+- [Architecture](/ARCHITECTURE): how the kernel is shaped, and why.
+- [How this is built](/how-this-is-built) · [Get started](/get-started/quickstart) · [Why](/why).

--- a/docs/assets/verify-browser-wiring.mjs
+++ b/docs/assets/verify-browser-wiring.mjs
@@ -1,0 +1,77 @@
+// Does docs/try-it.js wire the button when the container appears *after* the script has run?
+// That is the single-page-app case the deployed site hit: Mintlify runs a custom script once,
+// when the page becomes interactive, which on this site is before React paints the page and
+// never again on a client-side navigation. The button did nothing.
+//
+//     npm install jsdom
+//     node docs/assets/verify-browser-wiring.mjs
+//
+// Last run 2026-09-06, all five checks true. The first is the one that keeps the script
+// harmless: Mintlify injects it on every page of the site, so a page without the container
+// must see nothing happen at all.
+import { readFileSync } from "node:fs";
+import { JSDOM } from "jsdom";
+
+const here = new URL(".", import.meta.url).pathname;
+const script = readFileSync(`${here}../try-it.js`, "utf8");
+
+function fresh() {
+  const dom = new JSDOM("<!doctype html><html><body><main></main></body></html>", {
+    runScripts: "outside-only",
+    pretendToBeVisual: true,
+  });
+  // The page is "interactive" before the container exists, which is the whole point.
+  dom.window.eval(script);
+  return dom;
+}
+
+function mount(dom) {
+  dom.window.document.querySelector("main").innerHTML =
+    '<div id="ctrlrun-browser-demo"><button type="button"><span>Run ctrlrun demo</span></button><pre>idle</pre></div>';
+}
+
+async function settle(dom) {
+  await new Promise((resolve) => dom.window.setTimeout(resolve, 50));
+}
+
+// 1. No container: the script must touch nothing at all.
+{
+  const dom = fresh();
+  await settle(dom);
+  const body = dom.window.document.body.innerHTML;
+  console.log("no container, body untouched:", body === "<main></main>");
+}
+
+// 2. Container mounted after the script ran: the button must end up wired, and clicking it
+//    must reach the loader rather than doing nothing.
+{
+  const dom = fresh();
+  let asked = false;
+  dom.window.loadPyodide = async () => {
+    asked = true;
+    throw new Error("stub: not loading a real runtime here");
+  };
+  mount(dom);
+  await settle(dom);
+  const container = dom.window.document.getElementById("ctrlrun-browser-demo");
+  console.log("wired after late mount:", container.dataset.wired === "yes");
+
+  container.querySelector("button").dispatchEvent(new dom.window.MouseEvent("click"));
+  await settle(dom);
+  console.log("click reached the loader:", asked);
+  console.log("failure told the reader what to do:",
+    container.querySelector("pre").textContent.includes("pip install ctrlrun && ctrlrun demo"));
+}
+
+// 3. A second mount, as a single-page navigation would produce: wired again.
+{
+  const dom = fresh();
+  mount(dom);
+  await settle(dom);
+  dom.window.document.querySelector("main").innerHTML = "";
+  await settle(dom);
+  mount(dom);
+  await settle(dom);
+  console.log("re-wired after navigation:",
+    dom.window.document.getElementById("ctrlrun-browser-demo").dataset.wired === "yes");
+}

--- a/docs/authority.md
+++ b/docs/authority.md
@@ -1,4 +1,7 @@
-# Authority: who is acting, and what are they entitled to?
+---
+title: "Authority and delegation"
+description: "Grants, containment and the omission rule in plain language: who may propose an action, and how a delegated grant can only narrow."
+---
 
 Until v0.3, a CTRLRun policy could see the action and nothing else. It answered *how much
 autonomy does this action have* — run it, ask a human, refuse it — and the principal was

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -233,12 +233,13 @@
         ]
       },
       {
-        "tab": "Architecture and specifications",
+        "tab": "Architecture",
         "groups": [
           {
             "group": "Architecture",
             "pages": [
-              "ARCHITECTURE"
+              "ARCHITECTURE",
+              "architecture/specifications"
             ]
           },
           {
@@ -249,17 +250,6 @@
               "security/disclosure",
               "THREAT_MODEL",
               "how-this-is-built"
-            ]
-          },
-          {
-            "group": "Specifications",
-            "pages": [
-              "SPEC-v0.1",
-              "SPEC-v0.2",
-              "SPEC-v0.3",
-              "SPEC-v0.4",
-              "SPEC-v0.5",
-              "SPEC-v0.6"
             ]
           },
           {
@@ -289,7 +279,9 @@
       "og:site_name": "CTRLRun",
       "og:image": "/images/social-preview.png",
       "twitter:card": "summary_large_image",
-      "twitter:image": "/images/social-preview.png"
+      "twitter:image": "/images/social-preview.png",
+      "og:url": "https://docs.ctrlrun.dev",
+      "canonical": "https://docs.ctrlrun.dev"
     },
     "indexing": "navigable"
   },

--- a/docs/how-this-is-built.md
+++ b/docs/how-this-is-built.md
@@ -1,4 +1,7 @@
-# How this is built
+---
+title: "How this is built"
+description: "Specification first, every requirement mutation-tested, independent review, every claim mapped to a test, and what has not been done yet."
+---
 
 CTRLRun is built specification-first, every requirement in it is mutation-tested, anything
 that touches authorization is reviewed by a session that did not write it, and every sentence

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -169,7 +169,7 @@ entry, and the assistant answers from these pages rather than from memory:
 ```json
 {
   "mcpServers": {
-    "ctrlrun-docs": { "type": "http", "url": "https://ctrlrun.mintlify.app/mcp" }
+    "ctrlrun-docs": { "type": "http", "url": "https://docs.ctrlrun.dev/mcp" }
   }
 }
 ```

--- a/docs/mcp/use-the-docs-from-your-editor.mdx
+++ b/docs/mcp/use-the-docs-from-your-editor.mdx
@@ -14,7 +14,7 @@ For Cursor, in `mcp.json`:
 ```json
 {
   "mcpServers": {
-    "ctrlrun-docs": { "url": "https://ctrlrun.mintlify.app/mcp" }
+    "ctrlrun-docs": { "url": "https://docs.ctrlrun.dev/mcp" }
   }
 }
 ```
@@ -24,14 +24,13 @@ For VS Code and other clients that take a `servers` block:
 ```json
 {
   "servers": {
-    "ctrlrun-docs": { "type": "http", "url": "https://ctrlrun.mintlify.app/mcp" }
+    "ctrlrun-docs": { "type": "http", "url": "https://docs.ctrlrun.dev/mcp" }
   }
 }
 ```
 
 Both shapes are the ones Mintlify's documentation gives for a hosted docs server (read
-2026-09-06). The URL is the site's; when this documentation moves to its own domain the path
-stays `/mcp` and the host changes, and this page is updated with it.
+2026-09-06). The path is always `/mcp` on whatever host serves this site.
 
 ## Three questions it can now answer
 

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -1,4 +1,7 @@
-# Postgres
+---
+title: "Running on Postgres"
+description: "Connection strings, what to grant, migrations at open, what happens on failover, and what the store does not do for you."
+---
 
 `PostgresStateStore` puts the state store on a database instead of a local file. It implements
 the same `StateStore` protocol as `SQLiteStateStore`, frozen in `SPEC-v0.1.md` §5.3, and extends

--- a/docs/try-it.js
+++ b/docs/try-it.js
@@ -54,14 +54,14 @@
     });
   }
 
-  ready(function () {
+  function wire() {
     var container = document.getElementById(CONTAINER);
     if (!container || container.dataset.wired === "yes") return;
-    container.dataset.wired = "yes";
 
     var button = container.querySelector("button");
     var output = container.querySelector("pre");
     if (!button || !output) return;
+    container.dataset.wired = "yes";
 
     var pyodide = null;
 
@@ -103,5 +103,19 @@
     }
 
     button.addEventListener("click", run);
-  });
+  }
+
+  // The site is a single-page app and this script runs once, when the page becomes
+  // interactive: on a first load that can be before React has painted the container, and on a
+  // navigation from another page the script does not run again at all. Both were true on the
+  // deployed site, where the button did nothing. So wiring is attempted now and again on every
+  // DOM change; `wire` is a `getElementById` and a flag check when there is nothing to do, and
+  // the flag lives on the element, so a container React mounts afresh is wired afresh.
+  ready(wire);
+  if (window.MutationObserver) {
+    new MutationObserver(wire).observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+    });
+  }
 })();

--- a/docs/try-it.mdx
+++ b/docs/try-it.mdx
@@ -110,14 +110,20 @@ else on this site describes the current release.
 
 The sequence this page runs was verified under Node against the same Pyodide build on
 **2026-09-06**: Pyodide 314.0.6, Python 3.14.2, SQLite 3.39.0, `ctrlrun` 0.5.0 from PyPI, all
-five scenarios. The harness is committed as
-[`docs/assets/verify-browser-demo.mjs`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/assets/verify-browser-demo.mjs)
-and you can run it yourself:
+five scenarios. Two harnesses are committed, and you can run both:
 
 ```bash
-npm install pyodide
-node docs/assets/verify-browser-demo.mjs
+npm install pyodide jsdom
+node docs/assets/verify-browser-demo.mjs    # Python, the wheel, and the five scenarios
+node docs/assets/verify-browser-wiring.mjs  # this page's button, against a real DOM
 ```
+
+[`verify-browser-demo.mjs`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/assets/verify-browser-demo.mjs)
+is the one that proved the demo runs.
+[`verify-browser-wiring.mjs`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/assets/verify-browser-wiring.mjs)
+is the one that proves the button on this page gets wired: this site is a single-page
+application, and the first version of the script looked for its container before the page had
+rendered it, so the button did nothing.
 
 ## If it does not run here
 

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -1,4 +1,7 @@
-# `ctrlrun verify`
+---
+title: "ctrlrun verify"
+description: "Running the guarantee catalogue against your own configuration: the report, the N/A rule, the badge, and what verify cannot see."
+---
 
 Everything CTRLRun guarantees is proven by this repository's tests against this repository's
 configurations. That is the right place to start and the wrong place to stop, because the thing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/CTRLRun/ctrlrun"
 Repository = "https://github.com/CTRLRun/ctrlrun"
-Documentation = "https://github.com/CTRLRun/ctrlrun/tree/main/docs"
+Documentation = "https://docs.ctrlrun.dev"
 Changelog = "https://github.com/CTRLRun/ctrlrun/blob/main/CHANGELOG.md"
 Issues = "https://github.com/CTRLRun/ctrlrun/issues"
 

--- a/tests/test_docs_seo.py
+++ b/tests/test_docs_seo.py
@@ -18,7 +18,9 @@ DOCS = REPO_ROOT / "docs"
 if not (DOCS / "docs.json").exists():  # pragma: no cover - not a checkout
     pytest.skip("no repository checkout", allow_module_level=True)
 
-PAGES = sorted(path for path in DOCS.rglob("*.mdx") if "generated" not in path.parts)
+import test_docs_site  # noqa: E402 - one definition of "a site page", not two
+
+PAGES = test_docs_site.PAGES
 TITLE_LIMIT = 60
 DESCRIPTION_LIMIT = 155
 _FRONTMATTER = re.compile(r"\A---\n(.*?)\n---\n", re.S)

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -19,7 +19,56 @@ DOCS = REPO_ROOT / "docs"
 if not (DOCS / "docs.json").exists():  # pragma: no cover - not a checkout
     pytest.skip("no repository checkout", allow_module_level=True)
 
-PAGES = sorted(path for path in DOCS.rglob("*.mdx") if "generated" not in path.parts)
+
+def _published() -> set[str]:
+    """Every page path `docs.json` lists, so a Markdown document that is a site page is tested
+    like one and a Markdown document that is not is left alone."""
+    import json
+
+    found: set[str] = set()
+
+    def walk(node: object) -> None:
+        # Only the strings inside a `pages` array are page paths. A group's own label is a
+        # string too, and on a case-insensitive filesystem the label "Architecture" resolved
+        # to ARCHITECTURE.md and was tested as a page that does not exist.
+        if isinstance(node, list):
+            for item in node:
+                walk(item)
+        elif isinstance(node, dict):
+            for key, value in node.items():
+                if key == "pages":
+                    found.update(item for item in value if isinstance(item, str))
+                walk(value)
+
+    walk(json.loads((DOCS / "docs.json").read_text(encoding="utf-8"))["navigation"])
+    return found
+
+
+#: Site pages: the MDX ones, and the Markdown documents `docs.json` publishes. The second half
+#: was missing until the deployed site showed a filename title above each document's own H1 --
+#: eighteen pages no test looked at, because the glob said `*.mdx`.
+PAGES = sorted(
+    [path for path in DOCS.rglob("*.mdx") if "generated" not in path.parts]
+    + [DOCS / f"{slug}.md" for slug in sorted(_published()) if (DOCS / f"{slug}.md").exists()]
+)
+
+#: Long-form documents that predate the site and are read the way a specification is. The word
+#: budget is for pages written to be read in one sitting.
+LONG_FORM = frozenset(
+    {
+        "ARCHITECTURE",
+        "THREAT_MODEL",
+        "CLAIMS",
+        "ROADMAP",
+        "verify",
+        "postgres",
+        "adapters",
+        "authority",
+        "ACS",
+        "OWASP-AGENTIC-TOP10",
+        "how-this-is-built",
+    }
+)
 CONCEPTS = sorted((DOCS / "concepts").glob("*.mdx"))
 WORD_BUDGET = 900
 _FRONTMATTER = re.compile(r"\A---\n(.*?)\n---\n", re.S)
@@ -82,6 +131,8 @@ def test_every_page_has_a_title_and_a_description(page: Path):
 
 @pytest.mark.parametrize("page", PAGES, ids=[p.relative_to(DOCS).as_posix() for p in PAGES])
 def test_every_page_ends_with_next_links(page: Path):
+    if page.suffix == ".md":
+        return  # a document read on GitHub too ends where its own text ends
     body = _body(page).rstrip()
     assert "## Next" in body, page.name
     tail = body.split("## Next", 1)[1]
@@ -90,6 +141,8 @@ def test_every_page_ends_with_next_links(page: Path):
 
 @pytest.mark.parametrize("page", PAGES, ids=[p.relative_to(DOCS).as_posix() for p in PAGES])
 def test_every_page_links_to_why_and_to_get_started_or_is_one_of_them(page: Path):
+    if page.suffix == ".md":
+        return  # same reason: read on GitHub too, where a site path resolves to nothing
     slug = page.relative_to(DOCS).with_suffix("").as_posix()
     text = _body(page)
     if slug != "why":
@@ -107,7 +160,7 @@ def test_every_page_is_in_the_navigation(page: Path):
 @pytest.mark.parametrize("page", PAGES, ids=[p.relative_to(DOCS).as_posix() for p in PAGES])
 def test_every_page_but_a_reference_page_fits_the_word_budget(page: Path):
     slug = page.relative_to(DOCS).with_suffix("").as_posix()
-    if slug.startswith("reference/") or slug == "index":
+    if slug.startswith("reference/") or slug == "index" or slug in LONG_FORM:
         return
     words = len(_prose(page).split())
     assert words <= WORD_BUDGET, f"{page.name}: {words} words of prose, budget {WORD_BUDGET}"

--- a/tests/test_docs_travelling.py
+++ b/tests/test_docs_travelling.py
@@ -77,6 +77,16 @@ def test_the_script_does_not_load_sqlite3_as_a_package():
     assert "sqlite3" in HARNESS, "the harness no longer proves sqlite3 is there"
 
 
+def test_the_script_wires_itself_after_the_page_renders():
+    """The site is a single-page app: the script runs once, before React paints the container,
+    and not again on a client-side navigation. Wiring only on DOMContentLoaded left the button
+    dead on the deployed site, so the script watches the DOM as well.
+    `docs/assets/verify-browser-wiring.mjs` proves both halves against a real DOM."""
+    assert "MutationObserver" in SCRIPT
+    assert "subtree: true" in SCRIPT
+    assert (DOCS / "assets" / "verify-browser-wiring.mjs").exists()
+
+
 def test_the_page_tells_a_reader_what_to_do_when_it_does_not_run():
     """A page that can fail in somebody's browser owes them the command that always works.
 


### PR DESCRIPTION
Three things you found, and the answer to your question. **No kernel code**, except one test.

## 1. docs.ctrlrun.dev, everywhere

The MCP server's URL on Home and on the page that gives its configuration; `Documentation` in `pyproject.toml`; `canonical` and `og:url` in `docs.json`; the repository's website field (set with `gh repo edit`); and the README's documentation table, which now points at the site's sections instead of at files. The sentence promising the URL would change when a domain arrived is gone, because it has.

## 2. Why `/ARCHITECTURE` looked broken

It rendered `# ARCHITECTURE` (the filename, as the page title) above `# CTRLRun Architecture (v0.1 kernel)` (the document's own H1). **Eighteen pages had that**, because none of them had frontmatter: they were written as repository documents and later listed in `docs.json`.

Both halves are fixed:

- Eleven documents gain a `title` and a `description` inside the site's limits and lose their leading H1: ARCHITECTURE, THREAT_MODEL, how-this-is-built, verify, adapters, authority, postgres, CLAIMS, ROADMAP, ACS, OWASP-AGENTIC-TOP10.
- **The tests that should have caught it now do.** `test_docs_site.py` and `test_docs_seo.py` globbed `*.mdx`, so those eighteen pages were never checked. They now take their page list from `docs.json`, so a Markdown document the site publishes is tested like the site page it is: frontmatter, one H1, a title ≤ 60 and a description ≤ 155, and a row in the search plan. Long-form documents are exempt from the 900-word budget, listed by name with the reason.

While fixing that I found a second bug in my own test helper: the navigation walk collected group *labels* as well as page paths, and on a case-insensitive filesystem the label "Architecture" resolved to `ARCHITECTURE.md`. It now reads only the strings inside a `pages` array.

## 3. Your question: do the specifications belong in public documentation?

**No, and they are off the site.** They are the implementers' contract — 111,000 words across six documents, written for somebody building against the kernel — and on a site whose pages are written for somebody *using* it they dominate search and read as a wall. `SPEC-v0.3.md` alone is 31,000 words against a 900-word page budget.

They stay fully public in the repository, which is where a reader who wants the contract goes. `docs/architecture/specifications.mdx` replaces them on the site: what each version asked, a link to each document, how to read one, and a table pointing at the concept, guide, reference and security pages instead. `.mintignore` stops Mintlify building them at all.

## 4. The browser demo's button did nothing

Mintlify runs a custom script **once**, when the page becomes interactive. On this single-page application that is before React has painted the container, and it does not run again on a client-side navigation — so `getElementById` returned null and nothing was ever wired.

The script now also wires on a `MutationObserver`, and keeps its flag on the element so a re-mounted container is wired afresh. It still does nothing at all on a page without the container, which matters because Mintlify injects it on every page of the site.

`docs/assets/verify-browser-wiring.mjs` proves it against a real DOM (jsdom), and all five checks pass:

```
no container, body untouched: true
wired after late mount: true
click reached the loader: true
failure told the reader what to do: true
re-wired after navigation: true
```

A test asserts the observer is still there, so this cannot silently regress.

## Your work in progress

Your branding — the brand colours and light/dark wordmarks in `docs.json`, the README picture element, the new logos, favicon and the re-recorded demo — is **uncommitted in the working tree and untouched by this PR**. One thing to know: the longer recording makes `test_the_recording_ends_on_the_line_that_matters` red, because it pins the recording's last line to `remote refund calls: 1`. Verified from a clean worktree that the committed state here is green.

## Audit

Snippets 96/0 · lint 0 · links 0 broken, 0 planned · six generators 0 drift · `mint validate` passes · from a clean checkout of this commit, 1264 docs tests pass.
