### PR TITLE
The Try-it page ran Python that does not parse, and both harnesses were green

### DIFF
--- a/docs/assets/verify-browser-demo.mjs
+++ b/docs/assets/verify-browser-demo.mjs
@@ -1,13 +1,29 @@
-// Does `ctrlrun demo` run in Pyodide? The honest test behind docs/try-it.mdx, run before that
-// page claimed anything. It performs the same sequence the page's script performs, under Node:
+// Does `ctrlrun demo` run in Pyodide? The honest test behind docs/try-it.mdx:
 //
 //     npm install pyodide
 //     node docs/assets/verify-browser-demo.mjs
 //
+// It runs the page's own Python, read out of docs/try-it.js. It did not always: until
+// 2026-09-06 this file carried its own copy of the program, so it verified code the page never
+// ran, and the copy that shipped ended a line on a trailing `+` — a SyntaxError, which every
+// reader got instead of the demo. A harness with its own copy of the artifact verifies the
+// copy. `tests/test_docs_travelling.py` compiles the same string on every commit, so that
+// class of break fails in CI without Node or the network; this file is what proves it *runs*.
+//
 // Last run 2026-09-06: Pyodide 314.0.6, Python 3.14.2, SQLite 3.39.0, ctrlrun 0.5.0 from PyPI,
 // all five scenarios. `sqlite3` is bundled into Pyodide 314 and must NOT be passed to
 // loadPackage, which is the one thing that failed the first time.
+import { readFileSync } from "node:fs";
 import { loadPyodide } from "pyodide";
+
+// The page's PROGRAM array is JSON by construction, so this is a parse and not an eval: a
+// harness that re-implemented the extraction could drift the same way the copy did.
+const here = new URL(".", import.meta.url).pathname;
+const script = readFileSync(`${here}../try-it.js`, "utf8");
+const body = /var PROGRAM = \[(.*?)\]\.join/s.exec(script);
+if (!body) throw new Error("docs/try-it.js: no PROGRAM array — the page's Python moved");
+const PROGRAM = JSON.parse(`[${body[1]}]`).join("\n");
+console.log("program read from docs/try-it.js:", PROGRAM.split("\n").length, "lines");
 
 const pyodide = await loadPyodide();
 console.log("pyodide", pyodide.version, "python", pyodide.runPython("import sys; sys.version"));
@@ -17,16 +33,5 @@ await pyodide.loadPackage(["micropip", "pyyaml"]);
 const micropip = pyodide.pyimport("micropip");
 await micropip.install("ctrlrun");
 
-const out = pyodide.runPython(`
-import importlib.metadata, io, sys
-from pathlib import Path
-from contextlib import redirect_stdout
-from ctrlrun.cli.demo import run_demo
-
-version = importlib.metadata.version("ctrlrun")
-buffer = io.StringIO()
-with redirect_stdout(buffer):
-    run_demo(Path("/tmp/demo"))
-f"ctrlrun {version}\\n" + buffer.getvalue()
-`);
+const out = pyodide.runPython(PROGRAM);
 console.log(out);

--- a/docs/try-it.js
+++ b/docs/try-it.js
@@ -11,8 +11,10 @@
  * version it prints is whatever is released on PyPI, which is the version a reader would get
  * from `pip install ctrlrun`.
  *
- * Verified against Pyodide 314.0.6 (Python 3.14.2) with ctrlrun 0.5.0 on 2026-09-06 by
- * docs/assets/verify-browser-demo.mjs, which runs this same sequence under Node.
+ * Verified against Pyodide 314.0.6 (Python 3.14.2) with ctrlrun 0.5.0 by
+ * docs/assets/verify-browser-demo.mjs, which reads PROGRAM out of this file and runs it under
+ * Node. It read its own copy until 2026-09-06, and a syntax error in the copy that shipped
+ * reached the deployed page.
  */
 (function () {
   "use strict";
@@ -24,8 +26,17 @@
   // Pyodide's own builds; `click` arrives as ctrlrun's dependency through micropip.
   var PACKAGES = ["micropip", "pyyaml"];
 
+  // The Python this page runs. `runPython` returns the value of the last expression, so the
+  // last line is an expression rather than an assignment, and it is a single line: a trailing
+  // `+` outside brackets is a SyntaxError, which is exactly what shipped here and put a
+  // traceback in front of every reader. Two harnesses claimed to have verified this page and
+  // neither ran this string — `verify-browser-wiring.mjs` loads this script with Pyodide
+  // stubbed, and `verify-browser-demo.mjs` carried its own copy of the program. The demo
+  // harness now reads this array, and `tests/test_docs_travelling.py` compiles it on every
+  // commit, which needs no network and no Node. Keep it JSON-parseable: double-quoted strings,
+  // no comment inside the array, no trailing comma.
   var PROGRAM = [
-    "import importlib.metadata, io",
+    "import importlib.metadata, io, platform",
     "from contextlib import redirect_stdout",
     "from pathlib import Path",
     "from ctrlrun.cli.demo import run_demo",
@@ -33,8 +44,8 @@
     "buffer = io.StringIO()",
     "with redirect_stdout(buffer):",
     "    run_demo(Path('/tmp/ctrlrun-demo'))",
-    "'ctrlrun ' + importlib.metadata.version('ctrlrun') + ' on Python ' +",
-    "  __import__('platform').python_version() + '\\n\\n' + buffer.getvalue()",
+    "version = importlib.metadata.version('ctrlrun')",
+    "f'ctrlrun {version} on Python {platform.python_version()}\\n\\n' + buffer.getvalue()"
   ].join("\n");
 
   function ready(fn) {

--- a/docs/try-it.mdx
+++ b/docs/try-it.mdx
@@ -108,9 +108,13 @@ else on this site describes the current release.
 
 ## Verified, and how to check
 
-The sequence this page runs was verified under Node against the same Pyodide build on
+The Python this page runs was verified under Node against the same Pyodide build on
 **2026-09-06**: Pyodide 314.0.6, Python 3.14.2, SQLite 3.39.0, `ctrlrun` 0.5.0 from PyPI, all
-five scenarios. Two harnesses are committed, and you can run both:
+five scenarios. Not a copy of it — the harness reads the program out of `try-it.js` and runs
+that. It carried its own copy until that date, which is how a syntax error in the page's copy
+reached this page: both harnesses were green, one having stubbed the Python and the other
+having verified a program the page never ran. Two harnesses are committed, and you can run
+both:
 
 ```bash
 npm install pyodide jsdom
@@ -119,7 +123,9 @@ node docs/assets/verify-browser-wiring.mjs  # this page's button, against a real
 ```
 
 [`verify-browser-demo.mjs`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/assets/verify-browser-demo.mjs)
-is the one that proved the demo runs.
+is the one that proved the demo runs. A third check needs neither Node nor the network:
+`tests/test_docs_travelling.py` lifts the program out of the JavaScript and compiles it on
+every commit, so a syntax error fails CI rather than this page.
 [`verify-browser-wiring.mjs`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/assets/verify-browser-wiring.mjs)
 is the one that proves the button on this page gets wired: this site is a single-page
 application, and the first version of the script looked for its container before the page had

--- a/tests/test_docs_travelling.py
+++ b/tests/test_docs_travelling.py
@@ -105,6 +105,51 @@ def test_the_page_says_it_runs_the_released_version_and_where_the_proof_is():
     assert "2026-09-06" in TRY_IT and "2026-09-06" in HARNESS
 
 
+def _browser_demo_program() -> str:
+    """The Python the Try-it page runs, lifted out of the JavaScript that carries it."""
+    body = re.search(r"var PROGRAM = \[(.*?)\]\.join", SCRIPT, re.S)
+    assert body, "docs/try-it.js: no PROGRAM array — the page's Python moved"
+    try:
+        lines = json.loads(f"[{body.group(1)}]")
+    except json.JSONDecodeError as exc:  # pragma: no cover - a malformed array is the failure
+        raise AssertionError(
+            f"docs/try-it.js: PROGRAM is no longer JSON-parseable ({exc}). Keep it to "
+            "double-quoted strings with no comment inside the array and no trailing comma: "
+            "verify-browser-demo.mjs parses it the same way."
+        ) from exc
+    return "\n".join(lines)
+
+
+def test_the_browser_demo_program_is_valid_python():
+    """The page's Python is a string inside a JavaScript file, which nothing else compiles.
+
+    It shipped ending a line on a trailing `+` outside brackets. That is a SyntaxError, so
+    every reader who pressed the button got a traceback where the demo should have been, and
+    both harnesses stayed green: the wiring one stubs Pyodide, and the demo one carried its own
+    copy of the program. This compiles the string the page actually runs, on every commit,
+    with no network and no Node.
+    """
+    program = _browser_demo_program()
+    compile(program, "docs/try-it.js PROGRAM", "exec")
+
+
+def test_the_program_ends_on_an_expression_pyodide_can_return():
+    """`runPython` returns the value of the last expression. An assignment there returns
+    `None`, and the page would reveal an empty transcript with nothing raised."""
+    last = _browser_demo_program().rstrip().splitlines()[-1]
+    assert not last.startswith((" ", "\t")), f"the last line is indented, not a value: {last!r}"
+    assert re.match(r"^\w+\s*=[^=]", last) is None, f"the last line assigns: {last!r}"
+    assert "buffer.getvalue()" in last, f"the last line does not return the demo: {last!r}"
+
+
+def test_the_harness_runs_the_program_the_page_runs():
+    """A harness with its own copy of the artifact verifies the copy. This one reads
+    docs/try-it.js, so the program it proves is the program the reader gets."""
+    assert "try-it.js" in HARNESS, "the harness no longer reads the page's script"
+    assert "runPython(PROGRAM)" in HARNESS
+    assert "run_demo(" not in HARNESS, "the harness has grown its own copy of the program again"
+
+
 @pytest.mark.authority
 def test_the_page_quotes_lines_the_demo_prints():
     """The transcript on the page is the demo's own output, not a sketch of it.


### PR DESCRIPTION
## The bug

Every reader who pressed the button on [docs.ctrlrun.dev/try-it](https://docs.ctrlrun.dev/try-it) got this instead of the demo:

```
  File "<exec>", line 9
    'ctrlrun ' + importlib.metadata.version('ctrlrun') + ' on Python ' +
                                                                        ^
SyntaxError: invalid syntax
```

The program's last expression ended on a trailing `+` outside brackets, with the continuation indented beneath it. Neither is legal Python.

## Why nothing caught it

Two harnesses are committed and both were green:

- `verify-browser-wiring.mjs` loads the real `try-it.js` but **stubs Pyodide**, so it never compiles the program.
- `verify-browser-demo.mjs` runs **real Pyodide** but carried its **own hand-written copy** of the program, which was valid where the page's was not.

A harness with its own copy of the artifact verifies the copy. The page's claim that "the sequence this page runs was verified" was false, and the file said so in a comment.

## The fix

- The program's last line is one expression, using an f-string.
- `verify-browser-demo.mjs` reads `PROGRAM` out of `docs/try-it.js` and runs that. The array is JSON by construction, so it parses rather than evals.
- `tests/test_docs_travelling.py` lifts the same string out and **compiles it on every commit** — no Node, no network. Plus: the last line must be a returnable expression, and the harness must not grow its own copy again.
- `try-it.mdx` now says what each harness proves and how this one got through.

## Mutation table

| Mutation | Expected | Result |
|---|---|---|
| Reinstate the shipped trailing-`+` program | red | 2 failed |
| Make the last line an assignment | red | 1 failed |
| Give the harness its own copy of the program again | red | 1 failed |
| Restored | green | 18 passed |

## Verified end to end

Ran `verify-browser-demo.mjs` against the page's own program: Pyodide 314.0.6, Python 3.14.2, SQLite 3.39.0, `ctrlrun` 0.5.0 from PyPI, output beginning `ctrlrun 0.5.0 on Python 3.14.2` and all five scenarios. `verify-browser-wiring.mjs` green on all five wiring checks. Full suite 3787 passed, 45 skipped; `ruff` clean.

Docs only, no `src/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
