### PR TITLE
The transcript box could only grow, so the only scrollbar was the horizontal one

### DIFF
--- a/docs/try-it.js
+++ b/docs/try-it.js
@@ -103,9 +103,15 @@
           } else {
             node = document.createTextNode(line);
           }
+          // Follow the newest line, but only for a reader who is already at the bottom:
+          // yanking somebody back who has scrolled up to re-read scenario 1 is worse than
+          // not following at all. The box has a max height, so this is a real scroll — it
+          // was dead code while the box could only grow, and the reader got a horizontal
+          // scrollbar and a page that got taller instead of a terminal that scrolled.
+          var following = output.scrollHeight - output.scrollTop - output.clientHeight < 40;
           output.appendChild(node);
           output.appendChild(document.createTextNode("\n"));
-          output.scrollTop = output.scrollHeight;
+          if (following) output.scrollTop = output.scrollHeight;
           window.setTimeout(next, line.trim() === "" ? 0 : LINE_MS);
         }
         next();

--- a/docs/try-it.mdx
+++ b/docs/try-it.mdx
@@ -31,9 +31,11 @@ filesystem, and opens no socket.
       padding: "16px",
       marginTop: "12px",
       overflowX: "auto",
+      overflowY: "auto",
       fontSize: "13px",
       lineHeight: "1.5",
       minHeight: "180px",
+      maxHeight: "min(60vh, 440px)",
       whiteSpace: "pre",
     }}
   >

--- a/tests/test_docs_travelling.py
+++ b/tests/test_docs_travelling.py
@@ -142,6 +142,32 @@ def test_the_program_ends_on_an_expression_pyodide_can_return():
     assert "buffer.getvalue()" in last, f"the last line does not return the demo: {last!r}"
 
 
+def test_the_transcript_box_scrolls_down_rather_than_growing():
+    """A `min-height` with no `max-height` is a box that can only get taller.
+
+    That is what shipped. The transcript grew the page instead of scrolling, `scrollTop`
+    stayed 0 so the script's follow-the-newest-line was dead code, and the only scrollbar the
+    reader got was the horizontal one the long lines need. Measured in a browser at 820px: the
+    box grew to 910px with `scrollHeight == clientHeight`. With both bounds it holds at 452px
+    and scrolls to 458.
+    """
+    style = re.search(r"<pre\s*\n\s*style=\{\{(.*?)\}\}", TRY_IT, re.S)
+    assert style, "docs/try-it.mdx: the transcript box is no longer a <pre> with inline style"
+    box = dict(re.findall(r"(\w+):\s*\"([^\"]*)\"", style.group(1)))
+
+    assert "maxHeight" in box, "minHeight without maxHeight is a box that can only grow"
+    assert box.get("overflowY") == "auto", "the box cannot scroll vertically"
+    assert box.get("overflowX") == "auto", "the long lines must scroll inside the box"
+    assert box.get("whiteSpace") == "pre", "the demo's columns are aligned; do not wrap them"
+
+
+def test_the_reveal_follows_the_newest_line_only_for_a_reader_at_the_bottom():
+    """Following the output is right until somebody scrolls up to re-read, and then it is
+    yanking them away from what they are reading."""
+    assert "output.scrollHeight - output.scrollTop - output.clientHeight" in SCRIPT
+    assert "if (following) output.scrollTop = output.scrollHeight;" in SCRIPT
+
+
 def test_the_harness_runs_the_program_the_page_runs():
     """A harness with its own copy of the artifact verifies the copy. This one reads
     docs/try-it.js, so the program it proves is the program the reader gets."""


### PR DESCRIPTION
## The bug

The Try-it page's output box had `minHeight: "180px"` and **no `maxHeight`, no `overflowY`**. So as the reveal appended lines the box got taller and pushed the page down. It never scrolled vertically, because there was no vertical overflow to scroll — which also made `output.scrollTop = output.scrollHeight` in `try-it.js` dead code. The only scrollbar the reader got was the horizontal one the demo's long lines need.

Measured in a headless browser at 820px wide, running the real script against a real transcript:

| | before | after |
|---|---|---|
| Box height at the end | 910px, still growing | 452px, fixed |
| `scrollHeight` vs `clientHeight` | 910 = 910, no overflow | 910 > 452 |
| `scrollTop` at the end | 0 | 458 |
| Page height (700px viewport) | 956, page grew | 700, page did not grow |
| `scrollLeft` during the reveal | 0 | 0, no horizontal jump |

## The fix

- `overflowY: "auto"` and `maxHeight: "min(60vh, 440px)"` on the box, so it is a terminal that scrolls rather than a block that grows. `overflowX: "auto"` and `whiteSpace: "pre"` stay: the demo's columns are aligned and must not wrap, so the few long lines scroll inside the box. The page body never scrolls horizontally.
- The reveal follows the newest line **only for a reader already within 40px of the bottom**, and resumes when they scroll back down. Yanking somebody away from a scenario they are re-reading is worse than not following.

Verified in a browser: scrolling up mid-reveal held position at 0 for six seconds, and scrolling back to the bottom resumed following.

## Mutation table

| Mutation | Result |
|---|---|
| Remove `maxHeight` (the shipped state) | 1 failed |
| Remove `overflowY` | 1 failed |
| Restore the unconditional follow | 1 failed |
| Restored | 20 passed |

## Test note

The full suite is 3902 passed, 45 skipped, with one unrelated failure: `test_the_cli_reference_matches_clicks_help_text`. It fails identically on a pristine `origin/main` checkout, because the shared virtualenv resolves `ctrlrun` to the main working tree, where another branch has uncommitted `verify --url` help text. Not from this change, and CI installs from the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
