### PR TITLE
The theme lays the transcript box out as flex, so the lines came out in a row

### DIFF
--- a/docs/try-it.js
+++ b/docs/try-it.js
@@ -87,7 +87,20 @@
     var REFUSED = "#f28b82";
 
     function reveal(text) {
+      // The transcript goes inside one block child rather than straight into the <pre>.
+      // Mintlify's theme lays this <pre> out as `display: flex`, and in a flex container every
+      // appended child is a flex item in a *row*: the lines ran off to the right instead of
+      // down, and a coloured refusal landed beside its neighbours rather than under them.
+      // `say` never hit it because it sets a single text node, which is one item however the
+      // box is laid out. The page also asks for `display: block` — belt to this brace, since
+      // an inline style loses to an `!important` rule the theme does not have today.
       output.textContent = "";
+      var body = document.createElement("code");
+      body.style.display = "block";
+      body.style.whiteSpace = "pre";
+      body.style.fontFamily = "inherit";
+      body.style.fontSize = "inherit";
+      output.appendChild(body);
       var lines = text.split("\n");
       return new Promise(function (resolve) {
         var index = 0;
@@ -109,8 +122,8 @@
           // was dead code while the box could only grow, and the reader got a horizontal
           // scrollbar and a page that got taller instead of a terminal that scrolled.
           var following = output.scrollHeight - output.scrollTop - output.clientHeight < 40;
-          output.appendChild(node);
-          output.appendChild(document.createTextNode("\n"));
+          body.appendChild(node);
+          body.appendChild(document.createTextNode("\n"));
           if (following) output.scrollTop = output.scrollHeight;
           window.setTimeout(next, line.trim() === "" ? 0 : LINE_MS);
         }

--- a/docs/try-it.mdx
+++ b/docs/try-it.mdx
@@ -30,6 +30,7 @@ filesystem, and opens no socket.
       borderRadius: "8px",
       padding: "16px",
       marginTop: "12px",
+      display: "block",
       overflowX: "auto",
       overflowY: "auto",
       fontSize: "13px",

--- a/tests/test_docs_travelling.py
+++ b/tests/test_docs_travelling.py
@@ -161,6 +161,28 @@ def test_the_transcript_box_scrolls_down_rather_than_growing():
     assert box.get("whiteSpace") == "pre", "the demo's columns are aligned; do not wrap them"
 
 
+def test_the_transcript_does_not_depend_on_how_the_theme_lays_the_box_out():
+    """The site's theme sets `display: flex` on this `<pre>`, and we do not own that rule.
+
+    In a flex container every appended child is a flex item in a *row*, so a reveal that
+    appended a node per line laid the whole transcript out sideways: measured on the deployed
+    page, all five refusals sat at the same y and the box scrolled 6530px wide against a 529px
+    frame. `say` never hit it, because setting `textContent` makes one item however the box is
+    laid out. So the lines go inside a single block child, which is one flex item, and the
+    page also asks for `display: block`. Either alone fixes it; both together mean a theme
+    that changes its mind cannot put the transcript in a row again.
+    """
+    assert 'body.style.display = "block"' in SCRIPT
+    assert "output.appendChild(body)" in SCRIPT, "the transcript needs one container child"
+    assert "body.appendChild(node)" in SCRIPT
+    assert "output.appendChild(node)" not in SCRIPT, "a line appended straight into the <pre>"
+
+    style = re.search(r"<pre\s*\n\s*style=\{\{(.*?)\}\}", TRY_IT, re.S)
+    assert style, "docs/try-it.mdx: the transcript box is no longer a <pre> with inline style"
+    box = dict(re.findall(r"(\w+):\s*\"([^\"]*)\"", style.group(1)))
+    assert box.get("display") == "block", "the theme's flex would lay the lines out in a row"
+
+
 def test_the_reveal_follows_the_newest_line_only_for_a_reader_at_the_bottom():
     """Following the output is right until somebody scrolls up to re-read, and then it is
     yanking them away from what they are reading."""


### PR DESCRIPTION
## The bug

The reader sees the transcript running sideways: refusals beside each other rather than under each other, with a huge horizontal scroll.

Mintlify's theme sets `display: flex` on this `<pre>`. **In a flex container every appended child is a flex item laid out in a row.** The reveal appends a node per line, so the whole transcript came out as one row.

Measured on the deployed page with the real transcript:

| | deployed | container child only | both fixes |
|---|---|---|---|
| Refusal lines' y positions | all 5 at `49` | 5 distinct | 5 distinct |
| `scrollWidth` vs 529px frame | **6530** | 1007 | 991 |
| Scrolls vertically | no | yes, to 402 | yes |
| Box height | 227, no overflow | 472 | 472 |

## Why the previous fix was necessary but not sufficient

`say` sets `textContent`, and one text node is one flex item however the box is laid out, so nothing before the line-at-a-time reveal ever hit this. My earlier measurements for the max-height fix were taken against a plain block `<pre>`, which is not the element this page has. Reproducing the theme's own rule locally is what found it, and the control page proves it: the currently deployed script under `display: flex` puts all five refusals on one line.

## The fix

- The transcript is built inside **a single block child** of the `<pre>`, so the box has exactly one flex item however the theme lays it out.
- The page also asks for `display: block` on the box.

Either alone fixes it — verified separately — and both together mean a future theme change cannot put the lines in a row again.

## Verified in a browser

Three pages, all under the theme's `display: flex` rule, running the real script against a real transcript:

1. **Control**, deployed script: all 5 refusals at y=49, `scrollWidth` 6530, no vertical scroll. Bug reproduced.
2. **Container child only**, theme flex left in place: 5 distinct lines, `scrollWidth` 1007, scrolls to 402, stuck to bottom, `scrollLeft` 0.
3. **Both**: 5 distinct lines, box holds at 472px, page does not grow, body does not scroll horizontally, and scrolling up mid-reveal holds position at 0 then resumes following.

`verify-browser-wiring.mjs` still green on all five checks.

## Mutation table

| Mutation | Result |
|---|---|
| Append lines straight into the `<pre>` again | 1 failed |
| Drop `display: block` from the page | 1 failed |
| Make the container child non-block | 1 failed |
| Restored | 21 passed |

The tests pin the structural decision; they cannot measure layout, because the wiring harness runs under jsdom which computes none. The browser numbers above are the layout evidence.

## Test note

Full suite 3903 passed, 45 skipped, with the same unrelated `test_the_cli_reference_matches_clicks_help_text` failure as the last PR: it fails identically on a pristine `origin/main`, because the shared virtualenv resolves `ctrlrun` to the main working tree where another branch has uncommitted help text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
