### PR TITLE
The package keywords mirror the repository's GitHub topics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,15 +6,28 @@ build-backend = "setuptools.build_meta"
 name = "ctrlrun"
 version = "0.6.0"
 description = "The execution safety layer for AI agents."
+# Mirrors the repository's GitHub topics, so PyPI search and GitHub search agree.
 keywords = [
+    "agent-control-standard",
+    "agent-security",
+    "agentic-ai",
     "ai-agents",
-    "mcp",
+    "ai-safety",
+    "audit-log",
+    "exactly-once",
     "human-in-the-loop",
-    "idempotency",
-    "agent-safety",
     "langgraph",
+    "llm",
+    "llm-security",
+    "mcp",
+    "mcp-server",
+    "model-context-protocol",
     "openai-agents",
+    "opentelemetry",
+    "owasp",
+    "policy-engine",
     "python",
+    "tool-calling",
 ]
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
PyPI search and GitHub search read two different lists. The eight keywords in `pyproject.toml` were the topics as they stood at the docs launch; the repository now carries twenty, so the keywords carry the same twenty, sorted, with a comment saying where they come from.

No code, no tests, no docs change. `tests/test_packaging.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)