### PR TITLE
Release 0.6.0: the changelog gets its date, and three pages get the block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project are documented here. The format follows
 Public API names are frozen in `docs/SPEC-v0.1.md` §8. Before 1.0 they may still change, and
 any change to one appears here.
 
-## [0.6.0] - unreleased — Durable runtime
+## [0.6.0] - 2026-09-07 — Durable runtime
 
 **The soak criterion was amended on 2026-09-07, and it was amended downwards.** It read *a soak
 of at least one week with no unexplained `AMBIGUOUS`*; the week was removed rather than waited
@@ -24,8 +24,6 @@ The published run is twenty minutes, 889,735 actions, 133,393 ambiguous outcomes
 the run** so a reader can discount it: the README's readiness block, the docs home, the
 production index, and `docs/production/soak.mdx`, which now recomputes the criterion from the
 published counts instead of reading `exit_criterion_met` out of the same file.
-
-This entry stays dated `unreleased` until the tag is cut.
 
 v0.5 asked *can somebody else implement this?* v0.6 asks: **does it still hold when the process
 dies, the host goes away, and the database is somewhere else?**

--- a/README.md
+++ b/README.md
@@ -552,8 +552,8 @@ one URL, the same `StateStore` protocol extended by nothing, graded by the suite
 SQLite. Choose by how many machines write, not by how serious you are.
 
 <!-- generated from the suite, pyproject and the soak (readme) — run the generator -->
-- **Version 0.6.0 is in development**; [PyPI](https://pypi.org/project/ctrlrun/) has 0.5.0. Python 3.11 and later.
-- **4,154 tests**, every version specified before it was written and every requirement mutation-tested.
+- **Version 0.6.0**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
+- **4,163 tests**, every version specified before it was written and every requirement mutation-tested.
 - **11 guarantees you can check in your own setup**, with `ctrlrun verify` against your policy, on your store's backend, in a scratch store it creates.
 - **One host: a file.** SQLite, no server, no ops. **Many hosts: Postgres**, the same guarantees, graded by the same suite.
 - **Soaked for 20m 0s on postgres**: 889,735 actions, 0 unattributed ambiguous outcomes, positive control fired. Nothing here establishes what only accumulates over days. [What it does not establish](https://ctrlrun.dev/production/soak).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -117,7 +117,7 @@ Versioned as `adapters-<framework>-MAJOR.MINOR` — `adapters-crewai-1.0`, `adap
 
 Standards: none of its own.
 
-## v0.6 — Durable runtime (Code complete 2026-09-06; **not tagged** — see Exit)
+## v0.6 — Durable runtime ✅ shipped
 
 - Postgres StateStore (cross-host reservation).
 - Schema migrations, recovery on restart, policy versioning, receipt integrity — a hash chain, which detects **alteration** and not authorship.

--- a/docs/generated/readiness.full.mdx
+++ b/docs/generated/readiness.full.mdx
@@ -1,6 +1,6 @@
 {/* generated from the suite, pyproject and the soak (full) — run the generator */}
-- **Version 0.6.0 is in development**; [PyPI](https://pypi.org/project/ctrlrun/) has 0.5.0. Python 3.11 and later.
-- **4,154 tests**, every version specified before it was written and every requirement mutation-tested. [Read more](/how-this-is-built).
+- **Version 0.6.0**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
+- **4,163 tests**, every version specified before it was written and every requirement mutation-tested. [Read more](/how-this-is-built).
 - **11 guarantees you can check in your own setup**, with `ctrlrun verify` against your policy, on your store's backend, in a scratch store it creates. [Read more](/security/verify-guarantees).
 - **One host: a file.** SQLite, no server, no ops. **Many hosts: Postgres**, the same guarantees, graded by the same suite. [Read more](/production/postgres).
 - **Soaked for 20m 0s on postgres**: 889,735 actions, 0 unattributed ambiguous outcomes, positive control fired. Nothing here establishes what only accumulates over days. [Read more](/production/soak).

--- a/docs/generated/readiness.json
+++ b/docs/generated/readiness.json
@@ -1,6 +1,6 @@
 {
   "guarantees": 11,
-  "released": "0.5.0",
+  "released": "0.6.0",
   "soak": {
     "actions": 889735,
     "backend": "postgres",
@@ -9,6 +9,6 @@
     "positive_control": true,
     "unexplained": 0
   },
-  "tests": 4154,
+  "tests": 4163,
   "version": "0.6.0"
 }

--- a/docs/generated/readiness.mdx
+++ b/docs/generated/readiness.mdx
@@ -1,6 +1,6 @@
 {/* generated from the suite, pyproject and the soak (mdx) — run the generator */}
-- **Version 0.6.0 is in development**; [PyPI](https://pypi.org/project/ctrlrun/) has 0.5.0. Python 3.11 and later.
-- **4,154 tests**, every version specified before it was written and every requirement mutation-tested.
+- **Version 0.6.0**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
+- **4,163 tests**, every version specified before it was written and every requirement mutation-tested.
 - **11 guarantees you can check in your own setup**, with `ctrlrun verify` against your policy, on your store's backend, in a scratch store it creates.
 - **One host: a file.** SQLite, no server, no ops. **Many hosts: Postgres**, the same guarantees, graded by the same suite.
 - **Soaked for 20m 0s on postgres**: 889,735 actions, 0 unattributed ambiguous outcomes, positive control fired. Nothing here establishes what only accumulates over days. [What it does not establish](https://ctrlrun.dev/production/soak).

--- a/docs/generated/readiness.readme.md
+++ b/docs/generated/readiness.readme.md
@@ -1,6 +1,6 @@
 <!-- generated from the suite, pyproject and the soak (readme) — run the generator -->
-- **Version 0.6.0 is in development**; [PyPI](https://pypi.org/project/ctrlrun/) has 0.5.0. Python 3.11 and later.
-- **4,154 tests**, every version specified before it was written and every requirement mutation-tested.
+- **Version 0.6.0**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
+- **4,163 tests**, every version specified before it was written and every requirement mutation-tested.
 - **11 guarantees you can check in your own setup**, with `ctrlrun verify` against your policy, on your store's backend, in a scratch store it creates.
 - **One host: a file.** SQLite, no server, no ops. **Many hosts: Postgres**, the same guarantees, graded by the same suite.
 - **Soaked for 20m 0s on postgres**: 889,735 actions, 0 unattributed ambiguous outcomes, positive control fired. Nothing here establishes what only accumulates over days. [What it does not establish](https://ctrlrun.dev/production/soak).

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -224,8 +224,8 @@ the framework's own interrupt, and a framework with no such primitive does not n
 ## Where it stands
 
 {/* generated from the suite, pyproject and the soak (mdx) — run the generator */}
-- **Version 0.6.0 is in development**; [PyPI](https://pypi.org/project/ctrlrun/) has 0.5.0. Python 3.11 and later.
-- **4,154 tests**, every version specified before it was written and every requirement mutation-tested.
+- **Version 0.6.0**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
+- **4,163 tests**, every version specified before it was written and every requirement mutation-tested.
 - **11 guarantees you can check in your own setup**, with `ctrlrun verify` against your policy, on your store's backend, in a scratch store it creates.
 - **One host: a file.** SQLite, no server, no ops. **Many hosts: Postgres**, the same guarantees, graded by the same suite.
 - **Soaked for 20m 0s on postgres**: 889,735 actions, 0 unattributed ambiguous outcomes, positive control fired. Nothing here establishes what only accumulates over days. [What it does not establish](https://ctrlrun.dev/production/soak).

--- a/docs/production/index.mdx
+++ b/docs/production/index.mdx
@@ -27,8 +27,8 @@ need. `test_the_first_line_of_the_section_says_which_store_and_why` asserts the 
 ## Where it stands
 
 {/* generated from the suite, pyproject and the soak (full) — run the generator */}
-- **Version 0.6.0 is in development**; [PyPI](https://pypi.org/project/ctrlrun/) has 0.5.0. Python 3.11 and later.
-- **4,154 tests**, every version specified before it was written and every requirement mutation-tested. [Read more](/how-this-is-built).
+- **Version 0.6.0**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
+- **4,163 tests**, every version specified before it was written and every requirement mutation-tested. [Read more](/how-this-is-built).
 - **11 guarantees you can check in your own setup**, with `ctrlrun verify` against your policy, on your store's backend, in a scratch store it creates. [Read more](/security/verify-guarantees).
 - **One host: a file.** SQLite, no server, no ops. **Many hosts: Postgres**, the same guarantees, graded by the same suite. [Read more](/production/postgres).
 - **Soaked for 20m 0s on postgres**: 889,735 actions, 0 unattributed ambiguous outcomes, positive control fired. Nothing here establishes what only accumulates over days. [Read more](/production/soak).


### PR DESCRIPTION
Docs and metadata only — no code changes. This is the PR that must land before `v0.6.0` is pushed, because pushing the tag *is* the release and the sentences describing it have to be true first.

## The four edits

1. **`CHANGELOG.md:10`** — `## [0.6.0] - unreleased` → `## [0.6.0] - 2026-09-07`, and the line *"This entry stays dated `unreleased` until the tag is cut"* removed, having done its job.
2. **`render_readiness.py --write`** — `released()` reads the newest *dated* changelog heading, so dating it flips `released` to `0.6.0`. The re-measured suite is 4,163 collected.
3. **The three embedded blocks, pasted by hand.** `--write` regenerates `docs/generated/` and the state file **only** — it does not touch `README.md`, `docs/index.mdx` or `docs/production/index.mdx`, and `--check` reports each as `paste it fresh` until they are. All three now read *"Version 0.6.0, on PyPI"* instead of *"Version 0.6.0 is in development; PyPI has 0.5.0"*. `render_readiness.py --check` is `0 drifted`.
4. **`docs/ROADMAP.md:120`** — the v0.6 heading still read `(Code complete 2026-09-06; **not tagged** — see Exit)`; it now matches the `✅ shipped` form v0.1–v0.5 use.

## Verification

Run against `30dcdd0`, not against the stale head this work started from:

| Check | Result |
|---|---|
| `ruff check .` | pass |
| `mypy --strict src/` | pass, 45 source files |
| Full suite | 4,120 passed, 45 skipped |
| `render_readiness.py --check` | `0 drifted` |
| `ctrlrun demo` | exit 0, 0.12s |

Every skip is `CTRLRUN_TEST_POSTGRES` unset; CI's `postgres:16` service container covers them, which matters here because the whole milestone is the Postgres backend.

A fresh-clone verification (clone, new venv, full install, full suite) also ran green, and will be repeated against the tagged commit before the tag is pushed — a green working tree is not evidence that a file is tracked.

## Not in this PR

`internal/LAUNCH-CHECKLIST.md` is stale in four places — the tag count, the badge figures, a "soak's week" step describing a gate the 2026-09-07 amendment removed, and a "Not shipping" section still calling `ctrlrun mcp-operator` a build prompt when it shipped in #96. `internal/` is excluded from commits, so those corrections are applied locally only.