### PR TITLE
Contributing: say where to start before saying what the rules are

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,29 @@ CTRLRun sits in the execution path of actions that move money, delete infrastruc
 grant permissions. The rules below exist so that a change to it is evidence rather than
 intention. They are short to state and long to live with.
 
+## Where to start
+
+Not every contribution carries every rule below. In rough order of what they ask of you:
+
+- **[`good first issue`](https://github.com/CTRLRun/ctrlrun/labels/good%20first%20issue)** is
+  the current list, and each issue says what *done* means for it rather than leaving you to
+  infer it from this file.
+- **Two of them want a comment, not a patch.** Running `ctrlrun scan` against a real
+  application tree and reporting what it got wrong is a measurement this project does not have
+  and cannot take for itself; so is telling us where the policy template for your sector is
+  wrong. Neither needs the suite installed.
+- **Documentation** — a cookbook recipe, a `ctrlrun verify` snippet for a CI that is not GitHub
+  Actions — is held to `docs/STYLE.md` and the audit below, and not to the mutation table.
+- **Anything under `src/`** is where the rest of this file applies in full, and a maintainer
+  reads it whatever CI says.
+
+Claim an issue in a comment before you start, so two people do not write the same page. An
+issue not on the list is welcome; say what you intend to change before you change it, because
+the specification comes first and a pull request that arrives without one has the harder half
+still ahead of it.
+
+A security problem is not an issue. Report it privately, per [SECURITY.md](SECURITY.md).
+
 ## Run the suite
 
 ```bash


### PR DESCRIPTION
`CONTRIBUTING.md` opened with the suite, then specification-first, then the mutation table. Those are the right rules and the wrong first screen for somebody deciding whether to spend an evening here: they describe the bar for a change to the kernel, and most first contributions are not that.

This adds a **Where to start** section between the intro and *Run the suite*, mapping the rules already in the file onto four tiers:

- the [`good first issue`](https://github.com/CTRLRun/ctrlrun/labels/good%20first%20issue) label, where each issue states its own definition of done;
- the two issues whose deliverable is a **comment rather than a patch** — scan's false-positive rate against a real tree (#114) and the sector templates (#117) — neither of which needs the suite installed;
- documentation, held to `docs/STYLE.md` and `tools/docs_audit/`, not to the mutation table;
- anything under `src/`, where the rest of the file applies in full.

Plus the two things the issue list cannot say for itself: claim an issue before starting, and a security problem goes to `SECURITY.md` and not to the tracker.

No rule is relaxed and none is restated more loosely — this is a map of the ones already there.

## Checks

`CONTRIBUTING.md` is outside `tools/docs_audit/_files.py`'s scope, so its links are not machine-checked; the label URL is absolute because the target is not a docs page, which is what `docs/STYLE.md` §Links allows. Run anyway:

```
lint: 186 document(s), 0 finding(s)
links: 180 document(s), 0 broken, 0 planned
capabilities: 26 entries, 0 drifted copy(ies)
```

`tests/test_repository_signals.py` (21 passed) asserts the phrases this file must keep; all five are still present.