### PR TITLE
The first screen does the selling, and the first example finishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,14 @@
 <p align="center">
   <a href="https://pypi.org/project/ctrlrun/"><img src="https://img.shields.io/pypi/v/ctrlrun?color=B8730A&label=pypi" alt="PyPI"></a>
   <a href="https://pypi.org/project/ctrlrun/"><img src="https://img.shields.io/pypi/pyversions/ctrlrun?color=B8730A" alt="Python versions"></a>
+  <a href="https://ctrlrun.dev"><img src="https://img.shields.io/badge/docs-ctrlrun.dev-B8730A" alt="Docs"></a>
   <a href="https://github.com/CTRLRun/ctrlrun/actions/workflows/ci.yml"><img src="https://github.com/CTRLRun/ctrlrun/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="https://github.com/CTRLRun/ctrlrun/actions/workflows/codeql.yml"><img src="https://github.com/CTRLRun/ctrlrun/actions/workflows/codeql.yml/badge.svg?branch=main" alt="CodeQL"></a>
   <a href="https://ctrlrun.dev/how-this-is-built"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/CTRLRun/ctrlrun/badges/tests-badge.json" alt="Tests"></a>
   <a href="https://ctrlrun.dev/security/verify-guarantees"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/CTRLRun/ctrlrun/badges/verify-badge.json" alt="CTRLRun verified"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/CTRLRun/ctrlrun"><img src="https://api.scorecard.dev/projects/github.com/CTRLRun/ctrlrun/badge" alt="OpenSSF Scorecard"></a>
+  <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff"></a>
+  <a href="https://github.com/CTRLRun/ctrlrun/blob/main/scripts/check.sh"><img src="https://img.shields.io/badge/mypy-strict-B8730A" alt="Checked with mypy --strict"></a>
   <a href="https://github.com/CTRLRun/ctrlrun/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/ctrlrun?color=B8730A" alt="License"></a>
 </p>
 <!-- end generated -->
@@ -50,6 +54,11 @@ pip install ctrlrun && ctrlrun demo
 No Python to hand? [Break a protected action in your browser](https://ctrlrun.dev/try-it):
 one refund under one policy on the released wheel, in the tab, with nothing sent anywhere.
 Approve €2,000, execute €5,000, lose a reply, retry — and read what refused you.
+
+The same boundary has five other faces: two workers running one `kubectl delete namespace`, an
+approval for `grant reader` spent on `grant admin`, a `delete_customer` nobody put in the
+policy, quarterly numbers mailed to a personal address, and a web page that talks the agent
+into a refund. [Why](https://ctrlrun.dev/why) is the 700-word version.
 
 ## What `ctrlrun demo` shows
 
@@ -119,71 +128,130 @@ prints, and a test fails if the two drift apart.
 
 ## Protect your first action
 
-Wrap the call that has the consequence, and let one YAML file say how much autonomy it gets. In
-a directory with a `ctrlrun.yaml` (`ctrlrun init` writes a starter, and the starter already says
-a namespace delete needs a human):
+Wrap the call that has the consequence, and let one YAML file say how much autonomy it gets.
+Save this as `ctrlrun.yaml`. Amounts are integer minor units — cents, not euros — and both ends
+of every band are bound, because an upper bound alone lets a negative amount through, and a
+refund of a negative amount is a charge.
 
-```bash runnable
-ctrlrun init
+```yaml runnable
+schema: ctrlrun.policy/v2
+
+actions:
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 50000 }      # up to €500: autonomous
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 500000 }     # up to €5,000: a human decides
+        decision: approve
+      - decision: deny                                  # above that: never
 ```
 
-```python runnable
+Anything not listed here is denied; there is no default-allow. Now `agent.py`, where `stripe`
+is a stand-in that records calls instead of making them:
+
+```python runnable file=agent.py
+import sys
+
 import ctrlrun
 
 
-def kubectl(*args: str) -> str:  # stand-in for your real client
-    return " ".join(args)
+class FakeStripe:
+    calls: list[tuple[str, int]] = []
+
+    def refund(self, payment_id: str, amount: int) -> dict:
+        self.calls.append((payment_id, amount))
+        return {"id": f"re_{payment_id}", "status": "succeeded"}
 
 
-@ctrlrun.protect("k8s.delete_namespace", effect="namespace:{cluster}:{name}")
-def delete_namespace(cluster: str, name: str) -> str:
-    return kubectl("delete", "namespace", name, "--context", cluster)
+stripe = FakeStripe()
 
 
-with ctrlrun.context(agent="deploy-agent"):
-    try:
-        delete_namespace(cluster="prod-eu", name="checkout")
-    except ctrlrun.ApprovalRequired as pending:
-        print(f"a human decides:  ctrlrun approve {pending.request_id}")
-    else:
-        raise SystemExit("the delete ran without a human; the policy is not in force")
+@ctrlrun.protect("stripe.refund", effect="refund:{payment_id}")
+def refund(payment_id: str, amount: int) -> dict:
+    return stripe.refund(payment_id, amount)
+
+
+if __name__ == "__main__":
+    with ctrlrun.context(agent="refund-agent"):
+        print("€100:", refund(payment_id="txn_1", amount=10000)["status"])
+        try:
+            refund(payment_id="txn_2", amount=200000)
+        except ctrlrun.ApprovalRequired as pending:
+            print("€2,000: a human decides:", pending.request_id)
+            with open("request_id.txt", "w") as handle:
+                handle.write(pending.request_id)
+        else:
+            sys.exit("the €2,000 refund ran without a human; the policy is not in force")
 ```
 
-The human runs `ctrlrun approve <request id>` and the agent calls again inside
-`ctrlrun.with_approval(request_id)`. The approval matches this cluster and this namespace and
-nothing else; `effect` names the consequence, so the same delete from a second worker is refused.
-The same starter file holds a refund by amount, and what it does with one is the rest of the
-product in six lines:
+The €100 refund runs on its own. The €2,000 one stops and names the request a human answers:
 
-| The agent | CTRLRun |
-|---|---|
-| refunds €100 | runs it; one receipt |
-| refunds €2,000 | `ApprovalRequired`; a human answers `ctrlrun approve <id>` |
-| has €2,000 approved, executes €5,000 | `ApprovalMismatch`: the approval is bound to what the human saw |
-| refunds €20,000 | `ActionDenied`; no request is created |
-| retries a refund whose reply was lost | `AmbiguousEffect`: the remote may have committed; a human or a hook decides |
-| runs the same refund from two workers | one reserves `refund:txn_1`, the other gets `DuplicateEffect` |
+```text
+€100: succeeded
+€2,000: a human decides: apr_8b9942fd15fbecaa88ccac05c3a71e15
+```
 
-[Protect your first action](https://ctrlrun.dev/get-started/quickstart), end to end with the
-outputs · [Try it in your browser](https://ctrlrun.dev/try-it) · [Policy YAML reference](https://ctrlrun.dev/reference/policy-yaml) · [Cookbook](https://ctrlrun.dev/cookbook/index): refunds, deploys, IAM, deletions, email, MCP, each a recipe that runs.
+The human answers from the shell. The grant names the action hash it authorizes, and when it
+lapses:
 
-## The problem
+```bash runnable
+ctrlrun approve "$(cat request_id.txt)"
+```
 
-Agents are getting write access to the real world. The hard part is not deciding whether a
-tool call is allowed. It is what happens at the boundary between *intending* an effect and
-*having caused* one.
+```text
+granted apr_8b9942fd15fbecaa88ccac05c3a71e15 for sha256:e8702b48316cdd7fd64d120fb2f41fc430d594c8e5c1999e9fa23765a161193c
+expires 2026-09-07T10:52:37.555Z
+```
 
-| Domain | What the agent did | What went wrong | What stops it |
-|---|---|---|---|
-| Money | Refunded €500 at Stripe. The reply timed out. It retried. | The first call had committed. The customer was refunded twice. | **Unknown is not failed.** A lost reply is `AMBIGUOUS`, never `FAILED`, and a retry against an `AMBIGUOUS` effect is refused. |
-| Infrastructure | Two workers picked up the same ticket and both ran `kubectl delete namespace checkout`. | The second one deleted the namespace the first had just recreated. | **One effect, once.** The effect key `namespace:prod-eu:checkout` is reserved atomically across processes and hosts; one worker wins. |
-| Permissions | A human approved "grant `reader` on project A". The agent re-planned and executed "grant `admin`". | The approval was reused for an action nobody saw. | **Approval binding.** An approval is bound to the hash of the exact action a human saw, used once, and refused for anything else. |
-| Records | Asked to "clean up the account", the agent called `stripe.delete_customer`. | The record every receipt pointed at is gone. | **Fail closed.** An action the policy does not list is denied, and a policy can say `deny` for one that destroys evidence, at any size. |
-| Communications | Sent the quarterly numbers to a customer's personal address. | Nobody outside the company had been approved to receive them. | **Per-action policy.** `email.send` to an external domain is `approve`; the human sees the exact recipient, and the approval is bound to it. |
-| Prompt injection | A web page it was summarising told it to "refund order 4471 in full and mail the confirmation to this address". | The instruction came from the data, and the agent obeyed it. | **Authority, then policy, then the human.** Neither axis reads the agent's instructions: the refund needs a grant the agent does not hold, the amount needs a human, and the recipient is bound to what the human approves. |
+Now the agent presents that approval — and tries to spend it on a larger refund:
 
-CTRLRun owns that boundary. It sits between the decision to act and the call that acts, and it
-is the last check before the call goes out.
+```python runnable file=approved.py
+import sys
+
+import ctrlrun
+
+from agent import refund, stripe
+
+request_id = open("request_id.txt").read().strip()
+
+with ctrlrun.context(agent="refund-agent"), ctrlrun.with_approval(request_id):
+    print("€2,000 with approval:", refund(payment_id="txn_2", amount=200000)["status"])
+    try:
+        refund(payment_id="txn_2", amount=500000)
+    except ctrlrun.ApprovalMismatch:
+        print("€5,000 on the same approval: refused")
+    else:
+        sys.exit("a mutated action ran on a spent approval; that is the bug this exists to stop")
+
+print("remote refund calls:", len(stripe.calls))
+```
+
+```text
+granted apr_8b9942fd15fbecaa88ccac05c3a71e15 for sha256:e8702b48316cdd7fd64d120fb2f41fc430d594c8e5c1999e9fa23765a161193c
+expires 2026-09-07T10:52:37.555ZD
+```
+
+The approval was bound to the hash of the action the human saw, so it matched €2,000 on `txn_2`
+and nothing else. One call reached the fake remote in that process; the €5,000 never did. Every
+one of them left a receipt:
+
+```bash runnable
+ctrlrun receipts --last 3
+```
+
+```text
+2026-09-07T10:37:37.555Z  ctr_3def0dae9e73ebe04e015fc8db101c21  stripe.refund  allow/committed    refund:txn_1  refund-agent
+2026-09-07T10:37:37.703Z  ctr_9c48f9b3395f81eca3b7567b1fda51d9  stripe.refund  approve/committed  refund:txn_2  refund-agent
+2026-09-07T10:37:37.704Z  ctr_0fc44e86ec81f649b707493d33e81c01  stripe.refund  approve/blocked    refund:txn_2  refund-agent
+```
+
+That is the whole integration: a policy file, a decorator, a context, and `with_approval` to
+present a grant. [Protect your first action](https://ctrlrun.dev/get-started/quickstart) is the
+same walkthrough with every output explained · [Try it in your browser](https://ctrlrun.dev/try-it) ·
+[Policy YAML reference](https://ctrlrun.dev/reference/policy-yaml) ·
+[Cookbook](https://ctrlrun.dev/cookbook/index): refunds, deploys, IAM, deletions, email, MCP,
+each a recipe that runs.
 
 ## How it works
 
@@ -193,52 +261,44 @@ Every protected call, whichever way it arrives, goes through the same six steps:
   normalize  →  decide  →  approve  →  reserve  →  execute  →  record
 ```
 
-1. **Normalize.** The call becomes an `Action`: a name, canonical arguments (sorted keys, no
-   floats), a resource, the principal and the environment. Its SHA-256 is the action hash.
-2. **Decide.** Authority first (may *this principal* propose this action at all?), then policy
-   (how much autonomy does *this action* have?). Unknown action, missing policy or missing
-   principal is `deny`.
-3. **Approve.** If the decision is `approve`, a human answers against the action hash. The
-   approval is single-use, expires, and matches nothing but that exact action.
-4. **Reserve.** The effect key — `refund:txn_1`, `namespace:prod-eu:checkout` — is reserved in
-   one atomic write. A second caller, in another process or on another host, is refused.
-5. **Execute.** Your function runs. Only `NotExecuted`, raised by you, means `FAILED`. Any
-   other exception, and every timeout, means `AMBIGUOUS`, and an `AMBIGUOUS` effect blocks a
-   blind retry until a human or a reconcile hook says what happened.
+1. **Normalize.** The call becomes an `Action` — a name, canonical arguments (sorted keys, no
+   floats), a resource, the principal — and its SHA-256 is the action hash.
+2. **Decide.** Authority first (may *this principal* propose this at all?), then policy (how
+   much autonomy does *this action* get?). Unknown action, missing policy or missing principal
+   is `deny`.
+3. **Approve.** A human answers against the action hash. The approval is single-use, expires,
+   and matches nothing but that exact action.
+4. **Reserve.** The effect key — `refund:txn_1`, `namespace:prod-eu:checkout` — is taken in one
+   atomic write. A second caller, in another process or on another host, is refused.
+5. **Execute.** Your function runs. Only `NotExecuted`, raised by you, means `FAILED`; every
+   other exception and every timeout means `AMBIGUOUS`, and an `AMBIGUOUS` effect blocks a
+   blind retry until a human or a `reconcile` hook says what happened.
 6. **Record.** A portable JSON receipt: who, what, decision, approval, effect key, outcome, and
    the hash of the policy that decided it, chained to the receipt before it.
 
 ## Three ways to use it
 
-**You probably do not need an adapter.** `@protect` covers anything running in this process:
-a raw model call, a LangChain tool, a hand-rolled loop, a cron job. The gateway covers anything
-that reaches its tools over MCP, in any language. Most readers need the decorator and should not
-look for an adapter; an adapter buys exactly one thing, and it is described last.
+**You probably do not need an adapter.** `@protect` covers anything running in this process: a
+raw model call, a LangChain tool, a hand-rolled loop, a cron job. The gateway covers anything
+that reaches its tools over MCP, in any language.
 
-### The decorator
+| You have | Use | Needs |
+|---|---|---|
+| Python in this process | the `@protect` decorator, shown above | nothing beyond `pip install ctrlrun` |
+| Tools behind an MCP server, in any language | the gateway | `pip install "ctrlrun[gateway]"` |
+| A framework with its own approval interrupt | an adapter | the framework to have a human-in-the-loop primitive |
 
-Shown above in *Protect your first action*: `@ctrlrun.protect(name, effect=...)` around the call
-that acts, `ctrlrun.context(agent=...)` around the caller, `ctrlrun.with_approval(request_id)`
-to present a grant. It needs nothing beyond `pip install ctrlrun`.
-
-### The gateway
-
-No agent changes and no server changes, in any language. Point the MCP client at the gateway
-instead of at the tool server:
-
-```text
-before    agent  ──▶  MCP server
-after     agent  ──▶  CTRLRun gateway  ──▶  MCP server
-```
-
+**The gateway** changes no agent code and no server code. Point the MCP client at it instead of
+at the tool server, and tools become actions named `mcp.<alias>.<tool>`, decided by the same
+policy:
 
 ```bash
 pip install "ctrlrun[gateway]"
 ctrlrun gateway --upstream http://localhost:8000/mcp --alias acme --principal refund-agent
 ```
 
-Tools become actions named `mcp.<alias>.<tool>`, decided by the same policy. A tool call has no
-decorator to carry its effect and resource templates, so they are declared in the policy:
+A tool call has no decorator to carry its effect and resource templates, so the policy declares
+them:
 
 ```yaml runnable file=gateway.yaml
 schema: ctrlrun.policy/v2
@@ -252,35 +312,28 @@ actions:
     decision: allow
 ```
 
-Everything but `tools/call` is relayed untouched. [`ctrlrun.dev/mcp/overview`](https://ctrlrun.dev/mcp/overview)
-is the MCP section of the documentation: the gateway, this documentation as an MCP server, and
-what is planned. A lost response over the wire blocks the
-retry exactly as it does in process, and the gateway prints, on the line that starts it, every
-action in your policy that has no `effect:` template, because a write with no effect key is
-exactly the configuration this exists to prevent.
+Everything but `tools/call` is relayed untouched, a lost response over the wire blocks the retry
+exactly as it does in process, and the gateway prints on the line that starts it every action in
+your policy with no `effect:` template — because a write with no effect key is the configuration
+this exists to prevent. [`ctrlrun.dev/mcp/overview`](https://ctrlrun.dev/mcp/overview) is the
+whole section.
 
-### Adapters
-
-An adapter exists for one reason: to route an `approve` decision through **the framework's own
-interrupt** instead of raising `ApprovalRequired` past your graph. A human answers where they
-already answer, and one core provider writes the grant through the same calls `ctrlrun approve`
-makes. There is never a second place to say yes.
+**An adapter** exists for one reason: to route an `approve` decision through **the framework's
+own interrupt** instead of raising `ApprovalRequired` past your graph. A human answers where
+they already answer, and one core provider writes the grant through the same calls `ctrlrun
+approve` makes. There is never a second place to say yes.
 
 | | reuses | binding |
 |---|---|---|
 | [`ctrlrun-langgraph`](https://github.com/CTRLRun/ctrlrun/blob/main/adapters/langgraph/README.md) | `interrupt()` and the checkpointer | **prevention** — the resumption carries the arguments and core re-checks them against the hash |
 | [`ctrlrun-openai-agents`](https://github.com/CTRLRun/ctrlrun/blob/main/adapters/openai-agents/README.md) | the SDK's tool-approval interruption | **attribution** — the SDK records *that* a call was approved, not what its arguments were |
 
-```console
-$ pip install ctrlrun-langgraph
-```
-
-You build the `Control` with your policy, store, identity provider and authority document, and
+You build the `Control` with your policy, store, identity provider and authority document and
 hand it over: an adapter never constructs one and never supplies a principal. Adapters ship on
 their own version line, `adapters-langgraph-1.0` and never `0.6.1`, because an adapter breaks
 when its framework makes a breaking release, which is not a kernel event.
-[`docs/adapters.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/adapters.md) has the three ways in and how to write one for a
-framework not listed here.
+[`docs/adapters.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/adapters.md) has the three
+ways in and how to write one for a framework not listed here.
 
 ## Write down what the agent may do
 
@@ -343,19 +396,18 @@ actions:
 
 Amounts are integer minor units; floats are rejected outright, because `0.1` and `0.10` are the
 same money and different hashes. The policy cannot see who is asking — deliberately, since v0.1:
-`agent_eq` and every other principal-addressing condition is refused at load. Who may ask is
-the second axis, `authority:`. It is **opt-in, and then fail-closed**: a policy with no
-`authority:` section behaves exactly as before, and the moment one exists every principal needs
-a grant and no grant means denied. A grant carries no `decision:`; the two axes are evaluated
-separately, authority first, and combine as the **stricter of the two**. A principal holding a
-`delegable` grant can narrow it at runtime with `ctrlrun delegate`, a delegation is valid only
-if it is provably a subset of its parent on every dimension, at creation and again at every
-evaluation, omitting a dimension the parent constrains is rejected rather than inherited, and
-`ctrlrun revoke` cuts a chain of any depth with one write.
-[`docs/authority.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/authority.md) has it in plain language.
-
-The nine files under [`examples/policies/`](https://github.com/CTRLRun/ctrlrun/tree/main/examples/policies) are starting points for
-payments, devops, HR, legal, security and others. Adapt them; none is a drop-in.
+`agent_eq` and every other principal-addressing condition is refused at load. Who may ask is the
+second axis, `authority:`, and it is **opt-in, then fail-closed**: a policy without one behaves
+exactly as before, and the moment one exists every principal needs a grant and no grant means
+denied. The two axes are evaluated separately, authority first, and combine as the **stricter of
+the two**. A `delegable` grant can be narrowed at runtime with `ctrlrun delegate` and never
+widened — a delegation must be provably a subset of its parent on every dimension, at creation
+and again at every evaluation, and omitting a dimension the parent constrains is rejected rather
+than inherited — and `ctrlrun revoke` cuts a chain of any depth with one write.
+[`docs/authority.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/authority.md) has it in
+plain language, and the nine files under
+[`examples/policies/`](https://github.com/CTRLRun/ctrlrun/tree/main/examples/policies) are
+starting points for payments, devops, HR, legal and security. Adapt them; none is a drop-in.
 
 **Roll it out with `mode: observe` first.** One top-level line runs every real decision against
 real traffic and records what *would* have been blocked, without blocking anything, and
@@ -397,38 +449,10 @@ G11  an altered receipt is detected   PASS  stripe.refund
 
 **Not applicable is not a pass.** A policy with no `approve` rule cannot exercise the
 approval-binding guarantees, and one with no `effect:` templates cannot exercise the effect
-guarantees, so each is reported `N/A` with the reason, excluded from the denominator and listed
-separately: `6/6 (5 not applicable)`, never `11/11`. There is no flag that folds one into the
-count. The same command against a `ctrlrun.policy/v1` document with no templates and no grants:
-
-<details>
-<summary>The same command against a v1 policy with no templates and no grants: 6/6, five N/A</summary>
-
-```console
-$ CTRLRUN_CONFIG=examples/policies/payments.yaml ctrlrun verify
-CTRLRun verify — ctrlrun 0.6.0, catalogue ctrlrun.guarantees/v2
-policy     examples/policies/payments.yaml (ctrlrun.policy/v1, mode: enforce)
-authority  none
-store      sqlite, scratch (created and destroyed for this run)
-
-G1   mutated approval refused         PASS  stripe.create_payout
-G2   replayed approval refused        PASS  stripe.create_payout
-G3   duplicate effect refused         N/A   no action declares an `effect:` template
-                                            (in a `ctrlrun.policy/v1` document the template lives in
-                                            the @protect decorator, which verify does not read)
-G4   one winner under concurrency     N/A   no action declares an `effect:` template
-G5   ambiguous blocks a blind retry   N/A   no action declares an `effect:` template
-G6   unknown action refused           PASS
-G7   no principal refused             PASS  invoice.read
-G8   expired authority refused        N/A   no authority section
-G9   delegation cannot escalate       N/A   no authority section
-G10  unknown exception is ambiguous   PASS  invoice.read
-G11  an altered receipt is detected   PASS  invoice.read
-
-6/6 declared guarantees pass. 5 not applicable: G3, G4, G5, G8, G9.
-```
-
-</details>
+guarantees. Each is reported `N/A` with the reason, excluded from the denominator and listed
+separately — the same command against a `ctrlrun.policy/v1` document with no templates and no
+grants ends `6/6 declared guarantees pass. 5 not applicable: G3, G4, G5, G8, G9.`, never
+`11/11`. There is no flag that folds one into the count.
 
 The badge at the top of this page means the **declared guarantees pass**: every guarantee this
 configuration can exercise was exercised, and none failed. It does not mean secure, safe,
@@ -462,65 +486,32 @@ The six guarantees, and which of the three ways in carries each:
 | **Receipts** — Every executed action leaves a portable JSON receipt of who, what and outcome. | yes | yes | yes |
 <!-- end generated -->
 
-**It guarantees**, with a test behind every line in [`docs/CLAIMS.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/CLAIMS.md), and
-[`docs/how-this-is-built.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/how-this-is-built.md) says how those tests came to exist:
+**It guarantees** what the matrix says, plus the mechanics behind it. Every line has a test in
+[`docs/CLAIMS.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/CLAIMS.md), and
+[`docs/how-this-is-built.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/how-this-is-built.md)
+says how those tests came to exist:
 
-- An approval is bound to the exact action a human saw, is used once, expires, and is refused
-  for a mutated or replayed action.
-- One logical effect executes at most once per intent, across threads, processes and hosts. On
-  SQLite that is `BEGIN IMMEDIATE`; on Postgres (`pip install "ctrlrun[postgres]"`) it is a
-  unique index on the effect key and compare-and-set updates whose row counts are checked, the
-  same `StateStore` protocol, extended by nothing, and graded by the suite written for SQLite.
-- It will not *knowingly* execute the same logical effect twice, and will never treat an unknown
-  outcome as a failure. Only `NotExecuted` means `FAILED`; a timeout, a lost reply, a lost
-  connection during `COMMIT` and every unexpected exception are `AMBIGUOUS`, and the store
-  re-reads the row to find out which. A crashed worker's effect stays `AMBIGUOUS` until a human
-  runs `ctrlrun resolve` or a `reconcile` hook asks the remote what happened, the only thing
-  besides a human permitted to move a record out of `AMBIGUOUS`, and only in the direction its
-  answer points.
-- Unknown action, missing policy, malformed policy, missing principal, missing or mismatched
-  approval and inconsistent state are all `deny`. No flag makes a consequential action
-  permissive by default, and verify has no flag that relaxes a check.
-- With `authority:` on, every principal needs a grant, delegation cannot widen one, and
-  `ctrlrun revoke` cuts a chain with one write. Identity is consumed, never invented:
-  `pip install "ctrlrun[identity]"` verifies a bearer token against a JWKS or a pinned key and
-  maps the verified claims onto a principal. CTRLRun issues no credential and defines no
-  identity format.
-- Every executed action leaves a portable JSON receipt, and every receipt records which policy
-  decided it: the policy's declared `version:` and a hash of its canonical content, so a receipt
-  from six months ago says what the rules were rather than what they are now. Where a policy
-  changes between a human approving and an agent executing, the approval is re-checked against
-  the policy in force at execution.
-- Each receipt carries the hash of the one before it. An edit, a deletion from the middle, a
-  reordering: each is detected and named, and `ctrlrun receipts --verify-chain` reports it by
-  `seq`.
-- The schema is versioned and migrations are automatic at open, forward-only, with no flag that
-  opens a database un-migrated. An older binary against a newer schema refuses immediately.
-- Releases carry PyPI provenance attestations from GitHub Actions: trusted publishing, no API
-  token anywhere, and an attestation on every distribution naming the workflow that built it.
-- `ctrlrun approve`, `deny`, `resolve`, `inspect`, `receipts`, `effects` and `stats` work from
-  the shell against any store, and `ctrlrun mcp-operator` exposes those same read and write
-  commands over MCP, so the person who has to answer an approval can answer it from the
-  assistant they are already talking to. It authenticates who answered and records it; it does
-  not check that they were entitled to.
-- `ctrlrun scan` reads a Python tree and a policy document and reports the consequential call
-  sites and policy entries CTRLRun is **not** covering — the gap between *installed* and *in the
-  path*. It reports what it found where it looked, says on every run what it misses by
-  construction, and has no score, no percentage and no badge: a number that improves when the
-  vocabulary is shortened is a number that will be.
-- `WebhookApprovalProvider` sends an approval request to a webhook, such as Slack, and takes the
-  answer back through the same grant calls. `pip install "ctrlrun[otel]"` exports one
-  OpenTelemetry span per action, one span event per step, and argument values stay out of it
-  unless you ask for them. Receipts in a `ctrlrun.policy/v4` document can cite the `controls:` an
-  action satisfies, and a rule can condition on the `data:` labels present in an action's
-  arguments.
+- **One effect, once, across hosts.** `BEGIN IMMEDIATE` on SQLite; on Postgres a unique index on
+  the effect key and compare-and-set updates whose row counts are checked.
+- **Only `NotExecuted` means `FAILED`.** Every timeout, lost reply and unexpected exception is
+  `AMBIGUOUS`, and a crashed worker's effect stays that way until a human runs `ctrlrun resolve`
+  or a `reconcile` hook asks the remote — and then only in the direction that answer points.
+- **Identity is consumed, never invented.** `ctrlrun[identity]` verifies a bearer token against a
+  JWKS or a pinned key and maps the claims onto a principal. CTRLRun issues no credential.
+- **Every receipt names the policy that decided it** and carries the hash of the receipt before
+  it. Where a policy changes between the approval and the execution, the approval is re-checked
+  against the policy in force at execution.
+- **Releases carry PyPI provenance attestations from GitHub Actions**: trusted publishing, no API
+  token anywhere, an attestation on every distribution naming the workflow that built it.
+- **The operator works from the shell** — `approve`, `deny`, `resolve`, `inspect`, `receipts`,
+  `effects`, `stats` against any store — or over MCP with `ctrlrun mcp-operator`. It records who
+  answered; it does not check that they were entitled to.
 
 **It can't**, and does not claim to:
 
 - CTRLRun cannot guarantee exactly-once execution against external systems it doesn't control.
   It refuses to *knowingly* act twice; whether a remote acted is a fact only the remote holds.
-- CTRLRun is not a transaction manager: it rolls nothing back and never pretends a remote
-  system's write is undone.
+  It is not a transaction manager: it rolls nothing back.
 - The receipt chain detects alteration, and alteration is not authorship. Receipts are not
   signed, the chain is no evidence of who wrote one, and it is not tamper-proof: it does not
   survive an administrator who can rewrite every row including the chain head, and erasing the
@@ -530,14 +521,13 @@ The six guarantees, and which of the three ways in carries each:
   remote acted turns the one retryable exception into a licence to act twice, and nothing here
   can check that for you.
 - **CTRLRun does not detect prompt injection**, and nothing here reads the agent's instructions
-  to decide whether they were poisoned. What the table above claims is narrower and is the part
-  that holds: an injected instruction still has to get past a grant the agent does not hold, an
-  amount that needs a human, and an approval bound to the recipient the human saw. That is
-  containment of the consequence, not detection of the cause.
-- It does not host models, plan, prompt, retrieve, route, remember or orchestrate. It is not a
-  guardrail library, an IAM system, a workflow engine or a compliance product, and it makes no
-  claim about any standard: [`docs/OWASP-AGENTIC-TOP10.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/OWASP-AGENTIC-TOP10.md) is a
-  reading of somebody else's taxonomy against the guarantees, and names the four entries it
+  to decide whether they were poisoned. The narrower claim is the one that holds: an injected
+  instruction still has to get past a grant the agent does not hold, an amount that needs a
+  human, and an approval bound to the recipient the human saw. Containment of the consequence,
+  not detection of the cause.
+- It does not host models, plan, prompt, retrieve, route, remember or orchestrate, and it makes
+  no claim about any standard: [`docs/OWASP-AGENTIC-TOP10.md`](https://github.com/CTRLRun/ctrlrun/blob/main/docs/OWASP-AGENTIC-TOP10.md)
+  is a reading of somebody else's taxonomy against the guarantees, and names the four entries it
   does not address.
 
 If an agent only reads and answers, you don't need CTRLRun. The moment it can **send, pay,
@@ -567,31 +557,26 @@ SQLite. Choose by how many machines write, not by how serious you are.
 - No sector packs. (the policy templates are starting points, not a product)
 <!-- end generated -->
 
-[ctrlrun.dev/production/index](https://ctrlrun.dev/production/index) is the whole section:
-choosing a store, what reservation does under a lost `COMMIT`, migrations, recovery after a
-crash, the receipt chain, the soak, and what to watch once it is running.
-
 ### Beyond one process
 
-Every guarantee before 0.6 was a guarantee about one process holding one SQLite file.
-`BEGIN IMMEDIATE` is a whole-database write lock on a local file; take the file away, put the
-store on another host, and *one effect, once* has to be re-earned by a different mechanism.
+`BEGIN IMMEDIATE` is a whole-database write lock on a local file; take the file away and *one
+effect, once* has to be re-earned. What 0.6 added to re-earn it:
 
-- **Postgres** — `pip install "ctrlrun[postgres]"`, one URL. The same `StateStore` protocol,
-  extended by nothing, graded by the suite written for SQLite rather than one written for it.
-- **Schema migrations**, automatic at open and forward-only, with no flag that opens a database
-  un-migrated. An older binary against a newer schema refuses immediately.
-- **Recovery after a crash** — what a restarted worker may conclude, and what nothing sweeps.
+- **Postgres**, **migrations** at open and forward-only with no flag that opens a database
+  un-migrated, **recovery after a crash**, and **a store conformance suite**, so a second backend
+  is graded rather than described.
+- **Policy versioning** — a receipt from six months ago says what the rules were, not what they
+  are now.
 - **Receipt integrity** — each receipt carries the hash of the one before it, so an edit, a
   deletion from the middle or a reordering is detected and named by `seq`. It detects
   **alteration**, which is not authorship: receipts are not signed.
-- **Policy versioning** — every receipt records the policy that decided it, so a receipt from six
-  months ago says what the rules were rather than what they are now.
-- **A store conformance suite**, so a second backend is graded rather than described.
 
-[`CHANGELOG.md`](https://github.com/CTRLRun/ctrlrun/blob/main/CHANGELOG.md) has the entry, including the two subcommands that
-ride along in this release without being part of the milestone: `ctrlrun scan` and
-`ctrlrun mcp-operator`.
+[ctrlrun.dev/production/index](https://ctrlrun.dev/production/index) is the whole section:
+choosing a store, what reservation does under a lost `COMMIT`, migrations, recovery after a
+crash, the receipt chain, the soak, and what to watch once it is running.
+[`CHANGELOG.md`](https://github.com/CTRLRun/ctrlrun/blob/main/CHANGELOG.md) has the entry,
+including the two subcommands that ride along in this release without being part of the
+milestone: `ctrlrun scan` and `ctrlrun mcp-operator`.
 
 ## Documentation
 

--- a/docs/generated/badges.readme.md
+++ b/docs/generated/badges.readme.md
@@ -2,10 +2,14 @@
 <p align="center">
   <a href="https://pypi.org/project/ctrlrun/"><img src="https://img.shields.io/pypi/v/ctrlrun?color=B8730A&label=pypi" alt="PyPI"></a>
   <a href="https://pypi.org/project/ctrlrun/"><img src="https://img.shields.io/pypi/pyversions/ctrlrun?color=B8730A" alt="Python versions"></a>
+  <a href="https://ctrlrun.dev"><img src="https://img.shields.io/badge/docs-ctrlrun.dev-B8730A" alt="Docs"></a>
   <a href="https://github.com/CTRLRun/ctrlrun/actions/workflows/ci.yml"><img src="https://github.com/CTRLRun/ctrlrun/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="https://github.com/CTRLRun/ctrlrun/actions/workflows/codeql.yml"><img src="https://github.com/CTRLRun/ctrlrun/actions/workflows/codeql.yml/badge.svg?branch=main" alt="CodeQL"></a>
   <a href="https://ctrlrun.dev/how-this-is-built"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/CTRLRun/ctrlrun/badges/tests-badge.json" alt="Tests"></a>
   <a href="https://ctrlrun.dev/security/verify-guarantees"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/CTRLRun/ctrlrun/badges/verify-badge.json" alt="CTRLRun verified"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/CTRLRun/ctrlrun"><img src="https://api.scorecard.dev/projects/github.com/CTRLRun/ctrlrun/badge" alt="OpenSSF Scorecard"></a>
+  <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff"></a>
+  <a href="https://github.com/CTRLRun/ctrlrun/blob/main/scripts/check.sh"><img src="https://img.shields.io/badge/mypy-strict-B8730A" alt="Checked with mypy --strict"></a>
   <a href="https://github.com/CTRLRun/ctrlrun/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/ctrlrun?color=B8730A" alt="License"></a>
 </p>
 <!-- end generated -->

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,25 +1,15 @@
 ---
-title: "CTRLRun"
+title: "The execution safety layer for AI agents"
 sidebarTitle: "Home"
-description: "The execution safety layer for AI agents. A consequential action happens at most once, exactly as approved, and leaves a receipt."
+description: "The last check before an AI agent does something it can't undo. Autonomy belongs to the action, not the agent."
 mode: "wide"
 "og:title": "CTRLRun — the execution safety layer for AI agents"
 "twitter:title": "CTRLRun — the execution safety layer for AI agents"
 ---
 
-**The last check before an AI agent does something it can't undo.**
-
-Autonomy belongs to the action, not the agent. A consequential action happens at most once,
-exactly as approved, and leaves a receipt — and when the outcome is unknown, CTRLRun says so
-instead of guessing.
-
-**Runs in production on a single file, or on Postgres across hosts.** SQLite is the default and
-is production-grade on one host; Postgres is for many. Apache-2.0.
-
 CTRLRun is a Python library that sits between an agent's decision to act and the call that acts.
-It binds a human's approval to the exact action they saw, executes one logical effect at most
-once across processes and hosts, treats an unknown outcome as unknown rather than failed, denies
-anything it cannot decide, and records what happened.
+A consequential action happens at most once, exactly as approved, and leaves a receipt — and when
+the outcome is unknown, CTRLRun says so instead of guessing.
 
 ```bash
 pip install ctrlrun && ctrlrun demo
@@ -33,6 +23,9 @@ pip install ctrlrun && ctrlrun demo
     One policy file, one decorator, one approval from the shell, three receipts.
   </Card>
 </Columns>
+
+**Runs in production on a single file, or on Postgres across hosts.** SQLite is the default and
+is production-grade on one host; Postgres is for many. Apache-2.0.
 
 ## Protect one function
 

--- a/docs/try-it.mdx
+++ b/docs/try-it.mdx
@@ -1,29 +1,12 @@
 ---
 title: "Try it in your browser"
 description: "Break a protected agent action with no install: real Python and the released ctrlrun wheel run in this tab, and every refusal you see is CTRLRun's own."
+mode: "wide"
 ---
 
-Real Python and the released `ctrlrun` wheel from PyPI load into this tab. Below is one
-protected refund under one policy, with a fake Stripe that commits before its reply can go
+One protected refund, under one policy, with a fake Stripe that commits before its reply can go
 missing. Change the amount, lose the reply, approve one amount and execute another, and read
-what CTRLRun did. Every line in the box was produced by `ctrlrun` here: the page owns the
-controls and nothing else. Nothing is sent anywhere; the store is in memory and no socket is
-opened.
-
-The policy the refund runs under, in cents:
-
-```yaml
-schema: ctrlrun.policy/v2
-actions:
-  stripe.refund:
-    effect: "refund:{payment_id}"
-    rules:
-      - when: { amount_gte: 0, amount_lte: 100000 }
-        decision: allow
-      - when: { amount_gte: 0, amount_lte: 1000000 }
-        decision: approve
-      - decision: deny
-```
+what refused you.
 
 <div id="ctrlrun-playground">
   <div style={{ display: "flex", flexWrap: "wrap", gap: "12px", alignItems: "flex-end" }}>
@@ -90,6 +73,24 @@ actions:
 Press Refund. The first press downloads about 10 MB of Python; after that the browser caches it.
   </pre>
 </div>
+
+Real Python and the released `ctrlrun` wheel from PyPI load into this tab. Every line in the box
+was produced by `ctrlrun` here: the page owns the controls and nothing else. Nothing is sent
+anywhere; the store is in memory and no socket is opened. The policy the refund runs under, in
+cents:
+
+```yaml
+schema: ctrlrun.policy/v2
+actions:
+  stripe.refund:
+    effect: "refund:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 100000 }
+        decision: allow
+      - when: { amount_gte: 0, amount_lte: 1000000 }
+        decision: approve
+      - decision: deny
+```
 
 ## Try this, in order
 

--- a/tools/docs_audit/render_badges.py
+++ b/tools/docs_audit/render_badges.py
@@ -9,13 +9,21 @@ artifact nobody reads, and an independent review is what noticed the first versi
     python tools/docs_audit/render_badges.py --write    # refresh docs/generated/
     python tools/docs_audit/render_badges.py --check    # CI
 
-Six of the seven badges are rendered by somebody else — PyPI, GitHub Actions, OpenSSF. Two are
+Most of the row is rendered by somebody else — PyPI, GitHub Actions, OpenSSF, Astral. Two are
 this repository's own, published to the orphan `badges` branch by a job that runs only on a
 push to `main`:
 
 - `verify-badge.json`, written by the composite action from a real `ctrlrun verify` run;
 - `tests-badge.json`, written by `--write-count` **after** `scripts/check.sh` has passed, so no
   number is published for a run whose suite was red.
+
+Two are static, and a static badge is a self-assertion unless something enforces it. These two
+are enforced: `scripts/check.sh` runs `ruff format --check`, `ruff check` and `mypy --strict
+src`, CI calls that file rather than naming the tools itself, and `test_ci_runs_the_check_script`
+fails if it stops. The `docs` badge is a link and claims nothing.
+
+Downloads and stars are deliberately absent. `docs/STYLE.md` forbids social proof that does not
+exist, and a count published four days after the first release measures mirrors.
 
 `--write-count` is what CI calls, and what it counts is what `pytest` **collects**. That is not
 the same as what passed: the suite skips a handful of tests on a machine without a framework
@@ -53,8 +61,9 @@ class Badge:
     href: str
 
 
-#: The row, in reading order: what it is, that it builds, that its own suite is this big, that
-#: its guarantees were checked, how its supply chain scores, and the licence.
+#: The row, in reading order: what it is, where it is documented, that it builds and is
+#: analysed, that its own suite is this big, that its guarantees were checked, how its supply
+#: chain scores, how it is written, and the licence.
 BADGES: tuple[Badge, ...] = (
     Badge(
         "PyPI",
@@ -67,9 +76,19 @@ BADGES: tuple[Badge, ...] = (
         "https://pypi.org/project/ctrlrun/",
     ),
     Badge(
+        "Docs",
+        "https://img.shields.io/badge/docs-ctrlrun.dev-B8730A",
+        "https://ctrlrun.dev",
+    ),
+    Badge(
         "CI",
         "https://github.com/CTRLRun/ctrlrun/actions/workflows/ci.yml/badge.svg?branch=main",
         "https://github.com/CTRLRun/ctrlrun/actions/workflows/ci.yml",
+    ),
+    Badge(
+        "CodeQL",
+        "https://github.com/CTRLRun/ctrlrun/actions/workflows/codeql.yml/badge.svg?branch=main",
+        "https://github.com/CTRLRun/ctrlrun/actions/workflows/codeql.yml",
     ),
     Badge(
         "Tests",
@@ -85,6 +104,16 @@ BADGES: tuple[Badge, ...] = (
         "OpenSSF Scorecard",
         "https://api.scorecard.dev/projects/github.com/CTRLRun/ctrlrun/badge",
         "https://scorecard.dev/viewer/?uri=github.com/CTRLRun/ctrlrun",
+    ),
+    Badge(
+        "Ruff",
+        "https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json",
+        "https://github.com/astral-sh/ruff",
+    ),
+    Badge(
+        "Checked with mypy --strict",
+        "https://img.shields.io/badge/mypy-strict-B8730A",
+        "https://github.com/CTRLRun/ctrlrun/blob/main/scripts/check.sh",
     ),
     Badge(
         "License",


### PR DESCRIPTION
Editorial review of the README and the home page found four things worth fixing and two
claims that were already false of the shipped pages.

## The first example finishes

`## Protect your first action` stopped at `ApprovalRequired` and left approval and resumption
in prose, so nobody could reach a completed protected action by copying. It now runs end to
end — policy, decorator, `ctrlrun approve` from the shell, `with_approval`, a mutated €5,000
refused, three receipts — in the refund domain throughout rather than switching to Kubernetes
mid-section. The outputs are from a real run; all seven runnable blocks execute offline.

## The repetition goes, the substance stays

The README stated the same six guarantees six times: a table after the first example, the
problem table, the six pipeline steps, the generated matrix, the "It guarantees" bullets and
the readiness block. Prose is down from 3,205 words to 2,662. Untouched: the demo transcript
(every line the demo prints is still quoted), the capability matrix, both receipt-chain
disclaimers, the verify N/A rule, the whole "It can't" section, and every string the suite
pins.

## The home page's first screen

`title: "CTRLRun"` rendered as the H1, so the largest text on the page was a word rather than
the promise, and the promise sentence then appeared twice above the fold — once as the
frontmatter description, once in paragraph two. At 1280x720 that put the install command at
the bottom edge and both demo cards below it.

`title` is now the category line and `description` the tagline, which is what `docs/IA.md`
assigns to each slot. This also fixes the browser tab reading **"CTRLRun - CTRLRun"** — the
condition `test_the_home_pages_share_title_is_not_the_site_name_twice` documents, which was
guarded for `og:title` and `twitter:title` but not for the title itself.

## The playground leads with its controls

`try-it.mdx` opened with two paragraphs and a policy file before the thing you press, in a
narrow column. Controls first, `mode: "wide"`, policy below.

## Four badges

CodeQL, docs, Ruff, mypy `--strict`. Downloads and stars are deliberately absent and the
generator's docstring says why: `docs/STYLE.md` forbids social proof that does not exist, and
a count published four days after the first release measures mirrors. The two static badges
are enforced rather than asserted — `scripts/check.sh` runs both and CI calls that file.

## Checks

`scripts/check.sh`: 4,359 passed, 47 skipped. `ruff format --check`, `ruff check`,
`mypy --strict src` clean. `snippets.py README.md`: 7 runnable blocks, 0 failed.
`links.py` and `lint.py` clean on all three changed documents.

No `src/` change.