### PR TITLE
Release 0.6.1: the audit's fixes get their changelog, and the pins move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,86 @@ All notable changes to this project are documented here. The format follows
 Public API names are frozen in `docs/SPEC-v0.1.md` §8. Before 1.0 they may still change, and
 any change to one appears here.
 
-## [Unreleased]
+## [0.6.1] - 2026-09-07 — The audit's fixes, and the gateway's transport
+
+Everything found after `v0.6.0` was tagged: twenty-nine defects from an audit of the shipped
+code, the gateway's transport behaviour, and the documentation's first screen. No public API
+name changes and no schema change. Two behaviours become **stricter** and could refuse input
+that 0.6.0 accepted silently — `@protect` on an `async def`, and a duplicated mapping key in a
+policy or authority document — and both are listed below with what they did before.
 
 ### Fixed
 
+- **`@protect` on an `async def` recorded a consequential action as done that never happened.**
+  The wrapper is synchronous, so "the return value" was an un-awaited coroutine: the effect was
+  committed and a `committed` receipt written before the body ran, and the legitimate retry was
+  then refused with `DuplicateEffect` for ever. Async, generator and async-generator functions
+  are refused at decoration time.
+- **One human approval could authorise two effects on Postgres.** A lost `COMMIT` on a
+  *renewal* — a reservation over a `FAILED` record, v0.1 §5.4's one automatic retry — re-issued
+  the approval without consuming it, so `find_granted_approval` would hand the same "yes" out
+  again for a different effect key. `v0.1 §4.2 A2` requires single use consumed atomically with
+  the reservation. SQLite has no lost-commit resolution, so this was also a backend-switch
+  regression.
+- **`ctrlrun verify` reported false N/A reasons, which is a false green.** N/A is excluded from
+  the denominator, so a run that could exercise one guarantee reported "1/1 declared guarantees
+  pass" beside ten reasons that were each untrue of the operator's document. A miss on the
+  authority axis is now distinguished from a miss on the policy axis and named. Verify also
+  crashed, exit 1, on an `effect:` template containing `{resource}` — a code path `--help`
+  documents as "a guarantee FAILED" — because it invented an argument for a placeholder that
+  names the action's `resource` field. Every shipped example under `examples/` is verified in
+  CI now.
+- **Webhook approvals were never routed.** `WebhookApprovalProvider` advertises
+  `POST /ctrlrun/approvals/<id>` as `respond_to` in every `APPROVAL_REQUESTED` notification, and
+  `Gateway.handle_approval` had no caller: the approver's system posted its answer to that URL,
+  read an HTML 404, and the approval sat pending until it expired.
+- **A lone surrogate in an executor's exception message stranded the effect.**
+  `mark_ambiguous` raised `UnicodeEncodeError` from inside the transaction — not a
+  `CTRLRunError` — and left the record `EXECUTING`, which is neither outcome and blocks the
+  retry until the lease expires. Executor text is escaped with `backslashreplace` where it
+  enters, so the row, the event and the receipt carry the same value and the chain hashes.
+- **The SQLite store leaked two file descriptors per thread.** Connections were pinned in a set
+  only `close()` emptied, so a host whose threads come and go eventually failed every store
+  access with "unable to open database file". Measured on the gateway: 200 connections, 410
+  descriptors; now flat.
+- **A duplicated mapping key in a policy or authority document failed open.** `yaml.safe_load`
+  resolves one to the last silently, so a grant with `actions:` written twice during a narrowing
+  edit loaded as `("**",)`. Refused now, naming the key and the line, by the one loader policy
+  and authority share.
+- **`ctrlrun delegate` and `ctrlrun revoke` ignored the store.** Both called `Control.from_file()`,
+  which always opens `.ctrlrun/state.db` beside the policy, so on Postgres a delegation went
+  into a local file no agent reads and `revoke` reported success while the delegation stayed
+  live. Both take `--store-url` now.
+- **Read commands created the store they were reporting on.** `ctrlrun receipts` in a directory
+  without a `ctrlrun.yaml` created and migrated `.ctrlrun/state.db` and answered "no receipts
+  yet" — telling an operator looking for evidence that there was none, from a store the command
+  had just made. Five commands also reached the terminal as tracebacks where the identical input
+  printed one clean line elsewhere.
+- **The gateway dropped a client's connection with no reply**, which an agent reads as a
+  transport error and retries blind: a 401 or 403 whose body is not a JSON object (an RFC 6750
+  bearer challenge, or a CDN's HTML), a malformed `Content-Length` — where `-1` bypassed
+  `--max-body-bytes` entirely — and `httpx.DecodingError` and `httpx.InvalidURL`, which inherit
+  from `RequestError` and so matched neither `except`.
+- **The gateway relayed `Content-Encoding: gzip` with the decompressed bytes.** httpx sends
+  `Accept-Encoding: gzip` by default, so an upstream doing nothing but honouring content
+  negotiation made the gateway unusable with `DecodingError: incorrect header check`.
+- **`ctrlrun scan` failed the policy `ctrlrun init` had just written**, exit 1, on the two
+  actions the starter's own comment says need no effect. The rule asked "does the policy permit
+  this?" where it meant "does this have a consequence to reserve?".
+- **`data_scope_eq: [[phi]]` raised `TypeError` on every evaluation** of that action rather than
+  a `CTRLRunError`, so an application catching the kernel's errors did not catch it. Refused at
+  load.
+- **The gateway's startup block never reached a pipe.** Python block-buffers a non-tty stdout,
+  so SPEC-v0.3 §8.4's block — which identity provider, which store, which environment — was
+  still buffered when the process was signalled. Visible only at an interactive terminal, which
+  is the one place nobody runs a server.
+- **Both adapters pinned `ctrlrun>=0.5,<0.6` beside a 0.6.0 kernel**, so `pip install
+  ctrlrun-langgraph` either refused to resolve or silently downgraded `ctrlrun`. The framework
+  range was checked against the version CI installed; the kernel range was checked against
+  nothing.
+- **Two reference pages promised a `ctrlrun[conformance]` extra that does not exist** and a
+  `MissingDependency` that could not be raised. SPEC-v0.5 §12.1 reversed that extra and
+  `pyproject.toml` never declared it, so both halves of the sentence were false.
 - Validate upstream JSON-RPC response IDs before changing effect state. Missing, mismatched,
   and malformed responses remain ambiguous and cannot make an executed action retryable.
 - Forward MCP SSE progress incrementally, record the matching final response, and keep
@@ -20,6 +96,27 @@ any change to one appears here.
 - Preserve the original request ID in synthesized gateway errors and support IPv6 listeners.
 - Restore consumed approval attribution and original attempt timing on resumed receipts,
   including across database reopenings and multiple suspension rounds.
+
+### Changed
+
+- The README's first integration example runs end to end. It stopped at `ApprovalRequired` and
+  left the approval and the resumption in prose, so no reader could reach a completed protected
+  action by copying it; it now covers the policy, the decorator, `ctrlrun approve` from the
+  shell, `with_approval`, a mutated €5,000 refused and three receipts, in one domain throughout.
+- The README states each guarantee once. It stated the same six of them six times — a table
+  after the first example, the problem table, the pipeline steps, the generated matrix, the
+  bullet list and the readiness block. Prose is down from 3,205 words to 2,662, with the demo
+  transcript, the guarantee matrix, both receipt-chain disclaimers and the whole *It can't*
+  section untouched.
+- The documentation home page leads with what CTRLRun is rather than with its own name, and
+  says the promise once instead of twice above the fold. Its `title` is the category line and
+  its `description` the tagline, which is what `docs/IA.md` assigns to each; the browser tab no
+  longer reads *CTRLRun - CTRLRun*.
+- `try-it` puts its controls above its explanation, in a wide column, with the policy below
+  them rather than between the reader and the button.
+- Four badges: CodeQL, the documentation site, Ruff and `mypy --strict`. Downloads and stars
+  are deliberately absent — `docs/STYLE.md` forbids social proof that does not exist, and a
+  count published four days after the first release measures mirrors.
 
 ## [0.6.0] - 2026-09-07 — Durable runtime
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
   - family-names: Ghoshal
     given-names: Arpan
     email: contact@arpanghoshal.com
-version: 0.6.0
+version: 0.6.1
 repository-code: https://github.com/CTRLRun/ctrlrun
 url: https://github.com/CTRLRun/ctrlrun
 license: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ with fake executors, and no network. Your `.ctrlrun/state.db` is byte-identical 
 
 ```console
 $ ctrlrun verify
-CTRLRun verify — ctrlrun 0.6.0, catalogue ctrlrun.guarantees/v2
+CTRLRun verify — ctrlrun 0.6.1, catalogue ctrlrun.guarantees/v2
 policy     examples/authority/payments.yaml (ctrlrun.policy/v3, mode: enforce)
 authority  same document, 3 grants
 store      sqlite, scratch (created and destroyed for this run)
@@ -462,13 +462,13 @@ you put the decorator, your deployment, and whether your policy is the right pol
 [GitHub Action](https://github.com/CTRLRun/ctrlrun/blob/main/docs/verify.md#in-ci):
 
 ```yaml
-      - uses: CTRLRun/ctrlrun@v0.6.0
+      - uses: CTRLRun/ctrlrun@v0.6.1
         with:
           policy: ctrlrun.yaml
 ```
 
 The ref pins the action's steps and **not** the package they install: `install` defaults to
-`ctrlrun`, which is whatever PyPI has that day. Add `install: ctrlrun==0.6.0` to pin the tool
+`ctrlrun`, which is whatever PyPI has that day. Add `install: ctrlrun==0.6.1` to pin the tool
 as well as the workflow.
 
 ## What it guarantees, and what it can't
@@ -542,8 +542,8 @@ one URL, the same `StateStore` protocol extended by nothing, graded by the suite
 SQLite. Choose by how many machines write, not by how serious you are.
 
 <!-- generated from the suite, pyproject and the soak (readme) — run the generator -->
-- **Version 0.6.0**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
-- **4,163 tests**, every version specified before it was written and every requirement mutation-tested.
+- **Version 0.6.1**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
+- **4,404 tests**, every version specified before it was written and every requirement mutation-tested.
 - **11 guarantees you can check in your own setup**, with `ctrlrun verify` against your policy, on your store's backend, in a scratch store it creates.
 - **One host: a file.** SQLite, no server, no ops. **Many hosts: Postgres**, the same guarantees, graded by the same suite.
 - **Soaked for 20m 0s on postgres**: 889,735 actions, 0 unattributed ambiguous outcomes, positive control fired. Nothing here establishes what only accumulates over days. [What it does not establish](https://ctrlrun.dev/production/soak).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,16 +26,16 @@ identity, so there is no signing key in this repository, in its secrets, or in a
 ### Verifying a release
 
 ```sh
-gh release download v0.6.0 --repo CTRLRun/ctrlrun
-gh attestation verify ctrlrun-0.6.0.tar.gz --repo CTRLRun/ctrlrun
+gh release download v0.6.1 --repo CTRLRun/ctrlrun
+gh attestation verify ctrlrun-0.6.1.tar.gz --repo CTRLRun/ctrlrun
 ```
 
 `gh attestation verify` fetches the attestation from GitHub. To check without a network round
 trip, point it at the bundle the release carries:
 
 ```sh
-gh attestation verify ctrlrun-0.6.0.tar.gz \
-  --repo CTRLRun/ctrlrun --bundle ctrlrun-0.6.0.sigstore.json
+gh attestation verify ctrlrun-0.6.1.tar.gz \
+  --repo CTRLRun/ctrlrun --bundle ctrlrun-0.6.1.sigstore.json
 ```
 
 Either way, what is verified is that these bytes were built by the `release.yml` workflow in

--- a/docs/cookbook/verify-in-github-actions.mdx
+++ b/docs/cookbook/verify-in-github-actions.mdx
@@ -47,14 +47,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: CTRLRun/ctrlrun@v0.6.0
+      - uses: CTRLRun/ctrlrun@v0.6.1
         with:
           policy: ctrlrun.yaml
 ```
 
 The ref pins the action's steps and not the package they install: `install` defaults to
 `ctrlrun`, unpinned, so the job takes whatever PyPI serves that day. Add
-`install: ctrlrun==0.6.0` to pin the tool too, and pin `CTRLRun/ctrlrun` by commit rather than
+`install: ctrlrun==0.6.1` to pin the tool too, and pin `CTRLRun/ctrlrun` by commit rather than
 by tag where you want a ref nobody can move.
 
 ## What the agent sees
@@ -62,7 +62,7 @@ by tag where you want a ref nobody can move.
 The agent sees nothing; this is the operator's check. The build sees:
 
 ```text
-CTRLRun verify — ctrlrun 0.6.0, catalogue ctrlrun.guarantees/v2
+CTRLRun verify — ctrlrun 0.6.1, catalogue ctrlrun.guarantees/v2
 policy     /home/runner/work/agent/agent/ctrlrun.yaml (ctrlrun.policy/v2, mode: enforce)
 authority  none
 store      sqlite, scratch (created and destroyed for this run)

--- a/docs/generated/readiness.full.mdx
+++ b/docs/generated/readiness.full.mdx
@@ -1,6 +1,6 @@
 {/* generated from the suite, pyproject and the soak (full) — run the generator */}
-- **Version 0.6.0**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
-- **4,163 tests**, every version specified before it was written and every requirement mutation-tested. [Read more](/how-this-is-built).
+- **Version 0.6.1**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
+- **4,404 tests**, every version specified before it was written and every requirement mutation-tested. [Read more](/how-this-is-built).
 - **11 guarantees you can check in your own setup**, with `ctrlrun verify` against your policy, on your store's backend, in a scratch store it creates. [Read more](/security/verify-guarantees).
 - **One host: a file.** SQLite, no server, no ops. **Many hosts: Postgres**, the same guarantees, graded by the same suite. [Read more](/production/postgres).
 - **Soaked for 20m 0s on postgres**: 889,735 actions, 0 unattributed ambiguous outcomes, positive control fired. Nothing here establishes what only accumulates over days. [Read more](/production/soak).

--- a/docs/generated/readiness.json
+++ b/docs/generated/readiness.json
@@ -1,6 +1,6 @@
 {
   "guarantees": 11,
-  "released": "0.6.0",
+  "released": "0.6.1",
   "soak": {
     "actions": 889735,
     "backend": "postgres",
@@ -9,6 +9,6 @@
     "positive_control": true,
     "unexplained": 0
   },
-  "tests": 4163,
-  "version": "0.6.0"
+  "tests": 4404,
+  "version": "0.6.1"
 }

--- a/docs/generated/readiness.mdx
+++ b/docs/generated/readiness.mdx
@@ -1,6 +1,6 @@
 {/* generated from the suite, pyproject and the soak (mdx) — run the generator */}
-- **Version 0.6.0**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
-- **4,163 tests**, every version specified before it was written and every requirement mutation-tested.
+- **Version 0.6.1**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
+- **4,404 tests**, every version specified before it was written and every requirement mutation-tested.
 - **11 guarantees you can check in your own setup**, with `ctrlrun verify` against your policy, on your store's backend, in a scratch store it creates.
 - **One host: a file.** SQLite, no server, no ops. **Many hosts: Postgres**, the same guarantees, graded by the same suite.
 - **Soaked for 20m 0s on postgres**: 889,735 actions, 0 unattributed ambiguous outcomes, positive control fired. Nothing here establishes what only accumulates over days. [What it does not establish](https://ctrlrun.dev/production/soak).

--- a/docs/generated/readiness.readme.md
+++ b/docs/generated/readiness.readme.md
@@ -1,6 +1,6 @@
 <!-- generated from the suite, pyproject and the soak (readme) — run the generator -->
-- **Version 0.6.0**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
-- **4,163 tests**, every version specified before it was written and every requirement mutation-tested.
+- **Version 0.6.1**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
+- **4,404 tests**, every version specified before it was written and every requirement mutation-tested.
 - **11 guarantees you can check in your own setup**, with `ctrlrun verify` against your policy, on your store's backend, in a scratch store it creates.
 - **One host: a file.** SQLite, no server, no ops. **Many hosts: Postgres**, the same guarantees, graded by the same suite.
 - **Soaked for 20m 0s on postgres**: 889,735 actions, 0 unattributed ambiguous outcomes, positive control fired. Nothing here establishes what only accumulates over days. [What it does not establish](https://ctrlrun.dev/production/soak).

--- a/docs/guides/verify-in-ci.mdx
+++ b/docs/guides/verify-in-ci.mdx
@@ -32,7 +32,7 @@ guarantees pass.
     ```
 
     ```text
-    CTRLRun verify — ctrlrun 0.6.0, catalogue ctrlrun.guarantees/v2
+    CTRLRun verify — ctrlrun 0.6.1, catalogue ctrlrun.guarantees/v2
     policy     /home/you/agent/ctrlrun.yaml (ctrlrun.policy/v2, mode: enforce)
     authority  none
     store      sqlite, scratch (created and destroyed for this run)
@@ -74,7 +74,7 @@ guarantees pass.
         runs-on: ubuntu-latest
         steps:
           - uses: actions/checkout@v4
-          - uses: CTRLRun/ctrlrun@v0.6.0
+          - uses: CTRLRun/ctrlrun@v0.6.1
             with:
               policy: ctrlrun.yaml
     ```
@@ -96,8 +96,8 @@ guarantees pass.
 
     Outputs: `passed`, `failed`, `applicable`, `not-applicable`, `badge-message`, `report-path`.
     The ref pins the action's steps and **not** the package they install: `install` is
-    unpinned by default, so `@v0.6.0` still takes whatever PyPI serves on the day. Pin both —
-    `install: ctrlrun==0.6.0` — where the run has to be reproducible, and pin the action by
+    unpinned by default, so `@v0.6.1` still takes whatever PyPI serves on the day. Pin both —
+    `install: ctrlrun==0.6.1` — where the run has to be reproducible, and pin the action by
     commit rather than by tag where the ref has to be immovable.
   </Step>
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -217,8 +217,8 @@ the framework's own interrupt, and a framework with no such primitive does not n
 ## Where it stands
 
 {/* generated from the suite, pyproject and the soak (mdx) — run the generator */}
-- **Version 0.6.0**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
-- **4,163 tests**, every version specified before it was written and every requirement mutation-tested.
+- **Version 0.6.1**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
+- **4,404 tests**, every version specified before it was written and every requirement mutation-tested.
 - **11 guarantees you can check in your own setup**, with `ctrlrun verify` against your policy, on your store's backend, in a scratch store it creates.
 - **One host: a file.** SQLite, no server, no ops. **Many hosts: Postgres**, the same guarantees, graded by the same suite.
 - **Soaked for 20m 0s on postgres**: 889,735 actions, 0 unattributed ambiguous outcomes, positive control fired. Nothing here establishes what only accumulates over days. [What it does not establish](https://ctrlrun.dev/production/soak).

--- a/docs/production/index.mdx
+++ b/docs/production/index.mdx
@@ -27,8 +27,8 @@ need. `test_the_first_line_of_the_section_says_which_store_and_why` asserts the 
 ## Where it stands
 
 {/* generated from the suite, pyproject and the soak (full) — run the generator */}
-- **Version 0.6.0**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
-- **4,163 tests**, every version specified before it was written and every requirement mutation-tested. [Read more](/how-this-is-built).
+- **Version 0.6.1**, on [PyPI](https://pypi.org/project/ctrlrun/), Python 3.11 and later.
+- **4,404 tests**, every version specified before it was written and every requirement mutation-tested. [Read more](/how-this-is-built).
 - **11 guarantees you can check in your own setup**, with `ctrlrun verify` against your policy, on your store's backend, in a scratch store it creates. [Read more](/security/verify-guarantees).
 - **One host: a file.** SQLite, no server, no ops. **Many hosts: Postgres**, the same guarantees, graded by the same suite. [Read more](/production/postgres).
 - **Soaked for 20m 0s on postgres**: 889,735 actions, 0 unattributed ambiguous outcomes, positive control fired. Nothing here establishes what only accumulates over days. [Read more](/production/soak).

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -14,7 +14,7 @@ what could not be tested at all.
 
 ```console
 $ ctrlrun verify
-CTRLRun verify — ctrlrun 0.6.0, catalogue ctrlrun.guarantees/v2
+CTRLRun verify — ctrlrun 0.6.1, catalogue ctrlrun.guarantees/v2
 policy     examples/authority/payments.yaml (ctrlrun.policy/v3, mode: enforce)
 authority  same document, 3 grants
 store      sqlite, scratch (created and destroyed for this run)
@@ -217,7 +217,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: CTRLRun/ctrlrun@v0.6.0
+      - uses: CTRLRun/ctrlrun@v0.6.1
         with:
           policy: ctrlrun.yaml
 ```
@@ -227,8 +227,8 @@ and the badge JSON **from that report** — not from a second run, so they canno
 uploads the three files as one artifact.
 
 **The ref pins the action's steps and not the package they install.** `install` defaults to
-`ctrlrun`, unpinned, so `@v0.6.0` runs whatever version PyPI serves on the day the job runs —
-pinning the action is not pinning the thing being verified with. Set `install: ctrlrun==0.6.0`
+`ctrlrun`, unpinned, so `@v0.6.1` runs whatever version PyPI serves on the day the job runs —
+pinning the action is not pinning the thing being verified with. Set `install: ctrlrun==0.6.1`
 where you want the run to be reproducible, and pin the action by commit rather than by tag
 where you want a ref that cannot be moved; this repository holds its own workflows to the
 commit form and a test enforces it.

--- a/docs/verify/get-the-badge.mdx
+++ b/docs/verify/get-the-badge.mdx
@@ -22,7 +22,7 @@ proved, and updates itself.
         runs-on: ubuntu-latest
         steps:
           - uses: actions/checkout@v4
-          - uses: CTRLRun/ctrlrun@v0.6.0
+          - uses: CTRLRun/ctrlrun@v0.6.1
             id: verify
             with:
               policy: ctrlrun.yaml
@@ -34,7 +34,7 @@ proved, and updates itself.
     if a guarantee failed.
 
     The ref pins the action's steps and not the package they install: `install` defaults to
-    `ctrlrun`, unpinned. Add `install: ctrlrun==0.6.0` where you want the run reproducible.
+    `ctrlrun`, unpinned. Add `install: ctrlrun==0.6.1` where you want the run reproducible.
   </Step>
 
   <Step title="Publish the badge JSON">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ctrlrun"
-version = "0.6.0"
+version = "0.6.1"
 description = "The execution safety layer for AI agents."
 # Mirrors the repository's GitHub topics, so PyPI search and GitHub search agree.
 keywords = [


### PR DESCRIPTION
Four PRs landed after `v0.6.0` was tagged and only one wrote a changelog entry.

| PR | Changelog entry before this |
|---|---|
| #109 — twenty-nine defects found by audit | **none** |
| #110 — gateway transport, resumed receipts | yes, under `[Unreleased]` |
| #118 — contributing | none needed |
| #119 — README and home page | none |

#109's fixes would have shipped undocumented. Among them: `@protect` on an `async def`
recording a consequential action as done that never ran, one human approval authorising two
effects after a lost `COMMIT` on Postgres, `ctrlrun verify` reporting false N/A reasons (a
false green, since N/A leaves the denominator), webhook approvals posted to a URL nothing
routed, the SQLite store leaking two descriptors per thread, and a lone surrogate in an
executor message stranding an effect in `EXECUTING`.

## What is in the release

- `pyproject.toml` and `CITATION.cff` to **0.6.1**.
- `CHANGELOG.md`'s `[Unreleased]` becomes `[0.6.1] - 2026-09-07`, gaining #109's fixes and
  #119's documentation work. The lead paragraph names the two behaviours that become
  **stricter** — `@protect` on an `async def`, and a duplicated mapping key in a policy or
  authority document — because both can refuse input 0.6.0 accepted silently.
- `render_readiness.py --write`, then the three embedded blocks pasted fresh by hand. `--write`
  regenerates `docs/generated/` and the state file only; `internal/LAUNCH-CHECKLIST.md` calls
  this out as a step of its own. All three read *"Version 0.6.1, on PyPI"*, 4,404 tests.
- **The pins.** Every reference naming the version to use moves to 0.6.1: the action ref and
  `install:` line on the README, `docs/verify.md`, `verify/get-the-badge`,
  `cookbook/verify-in-github-actions`, `guides/verify-in-ci`, and `SECURITY.md`'s attestation
  example. `SECURITY.md`'s two historical sentences — *"From v0.6.0, every GitHub Release …"*
  and *"Releases before v0.6.0 carry no …"* — are statements about the past and stay.
- The verify transcripts were **re-run, not edited**: `ctrlrun 0.6.1`, 11/11 on
  `examples/authority/payments.yaml`, 6/6 with five N/A on `examples/policies/payments.yaml`.

## Deliberately unchanged

`action.yml`'s `install` default stays `ctrlrun`, unpinned. Its own documentation explains that
choice and tells the reader to pass `ctrlrun==<version>` for a reproducible run; changing the
default would contradict the paragraph beside it.

## Note on one test

`test_T180_the_release_documents_do_not_blur_alteration_and_authorship` failed on a draft of
the changelog, on the phrase *"posted a signed grant"* — the guard scans release documents for
signing and authorship words. It meant the HMAC-signed webhook callback, not receipts, but the
sentence was rewritten rather than allow-listed: widening that allowlist to describe something
unrelated is how the guard stops working.

## Checks

`scripts/check.sh`: 4,359 passed, 47 skipped. `ruff format --check`, `ruff check`,
`mypy --strict src` clean.

After merge: fresh clone of the tagged commit, then `v0.6.1` — pushing the tag is the release.