### PR TITLE
A Demos section, and a medical affairs demo that runs the real wheel

### DIFF
--- a/docs/IA.md
+++ b/docs/IA.md
@@ -100,7 +100,10 @@ Architecture and specifications
   ├─ Architecture                      architecture/overview
   └─ Specifications                    architecture/specifications
 Changelog                              changelog
-Try it in your browser                 try-it
+Demos
+  ├─ Overview                          demos/index
+  ├─ Try it in your browser            try-it
+  └─ Medical affairs                   demos/medical-affairs
 Research: does your framework
   double-execute?                      study/does-your-framework-double-execute
 Get the badge                          verify/get-the-badge
@@ -294,6 +297,8 @@ signature · what is not covered. Query: *ctrlrun faq* and each question verbati
 
 | Path | Purpose | Query |
 |---|---|---|
+| `demos/index` | The two pages that run the released wheel in the reader's own browser, and the one line that runs the same thing faster offline. | *ctrlrun demo online* |
+| `demos/medical-affairs` | An approval bound to revision A of a letter to a physician, and the send of revision B refused after new evidence redrafts it — the browser demo under a policy whose consequential action is a document rather than a payment. | *AI medical information letter review · agent citation drift* |
 | `try-it` | `ctrlrun demo` in the browser via Pyodide, the same five refusals the README shows, a run-again button, and one line to install it for real. Any scenario the browser cannot run says so by name. | *try ctrlrun* |
 | `study/does-your-framework-double-execute` | The framework-probe results, rendered from `research/framework-probe/results/*.json` by script; *No published results yet* until a file exists. Behaviour, not quality. | *does langgraph retry tool calls* · *agent framework double execution study* |
 | `verify/get-the-badge` | The two-minute version of adding the verified badge: the workflow, what *declared guarantees pass* means, what N/A means. No gallery until a repo carries it. | *ctrlrun verified badge* |

--- a/docs/SEO.md
+++ b/docs/SEO.md
@@ -101,6 +101,8 @@ that page's frontmatter, never here.
 | `compare/governance-toolkits` | AI agent oversight vs enforcement | A toolkit describes; CTRLRun refuses. |
 | `compare/durable-workflows` | temporal vs ctrlrun · durable execution agents | One drives work forward; the other decides whether the work may happen. |
 | `compare/idempotency-keys` | idempotency keys AI agents · stripe idempotency vs | An idempotency key deduplicates at one API; an effect key deduplicates at the agent, across every API it touches. |
+| `demos/index` | ctrlrun demo online · try agent safety library | Every demo here runs real Python in your tab. |
+| `demos/medical-affairs` | AI medical information letter review · agent citation drift · medical affairs LLM harness | A harness that retrieves biomedical evidence, reasons over it, cites it and drafts a reply is four problems, and CTRLRun solves none of them. |
 | `try-it` | try ctrlrun in browser · ctrlrun demo online | Press the button and `ctrlrun demo` runs in this tab: real Python, the released wheel. |
 | `verify/get-the-badge` | ctrlrun verified badge | Two minutes, three steps: verify on every push, publish the badge JSON, point Shields at it. |
 | `study/does-your-framework-double-execute` | does langgraph retry tool calls · agent framework double execution | When a remote commits a refund and the reply is lost, what does an agent framework do? |

--- a/docs/demos/index.mdx
+++ b/docs/demos/index.mdx
@@ -1,0 +1,34 @@
+---
+title: "Demos"
+description: "Two pages that run the released ctrlrun wheel in your browser, so you can break a protected action before you install anything."
+---
+
+Every demo here runs real Python in your tab. Pyodide loads, micropip installs the released
+`ctrlrun` wheel from PyPI, and the remote is a fake in the same process — nothing you press is
+sent anywhere, and every refusal you read is the library's own.
+
+<Columns cols={2}>
+  <Card title="Break a refund" href="/try-it" icon="rotate-left">
+    One protected refund under one policy. Change the amount, lose the reply, approve one amount
+    and execute another, and read what refused you.
+  </Card>
+  <Card title="Medical affairs" href="/demos/medical-affairs" icon="microscope">
+    A letter to a physician is drafted, reviewed and signed. New evidence lands, the
+    recommendation flips, and the send is refused.
+  </Card>
+</Columns>
+
+The refund demo is the shortest way to see all five refusals. The medical affairs demo is the
+same kernel under a different policy, and it exists to answer a question people ask about their
+own domain: what does this look like when the consequential action is a document rather than a
+payment. Nothing in CTRLRun knows what a refund is, or what a letter is.
+
+Neither page is a substitute for running it yourself. Both take about ten megabytes of download
+on the first press and cache after that; a laptop offline can run the same thing faster with
+`pip install ctrlrun && ctrlrun demo`.
+
+## Next
+
+- [Why](/why) — what these demos are demonstrating, in 700 words
+- [Get started](/get-started/quickstart) — the same guarantees around your own function
+- [Cookbook](/cookbook/index) — nineteen wirings you can copy

--- a/docs/demos/medical-affairs.mdx
+++ b/docs/demos/medical-affairs.mdx
@@ -1,0 +1,111 @@
+---
+title: "The letter that changed after it was signed"
+sidebarTitle: "Medical affairs"
+description: "A medical information letter is drafted, reviewed and signed. New evidence lands, the recommendation flips, and the send is refused — in your browser."
+mode: "wide"
+---
+
+A harness that retrieves biomedical evidence, reasons over it, cites it and drafts a reply is
+four problems, and CTRLRun solves none of them. It solves the fifth: the letter that leaves the
+building is the letter a named human read, it goes out once, and there is a receipt. Press the
+buttons below and watch a signature stop matching.
+
+<div style={{ display: "flex", flexWrap: "wrap", gap: "8px", alignItems: "stretch", margin: "24px 0" }}>
+  {[
+    ["Retrieve", "your pipeline"],
+    ["Reason", "your pipeline"],
+    ["Cite", "your pipeline"],
+    ["Validate", "your pipeline"],
+  ].map(([step, who]) => (
+    <div key={step} style={{ flex: "1 1 0", minWidth: "102px", border: "1px solid currentColor", borderRadius: "8px", padding: "10px 12px", opacity: 0.55 }}>
+      <div style={{ fontSize: "15px", fontWeight: 600 }}>{step}</div>
+      <div style={{ fontSize: "12px" }}>{who}</div>
+    </div>
+  ))}
+  <div style={{ flex: "1 1 0", minWidth: "112px", border: "2px solid #B8730A", borderRadius: "8px", padding: "10px 12px" }}>
+    <div style={{ fontSize: "15px", fontWeight: 700, color: "#B8730A" }}>The gate</div>
+    <div style={{ fontSize: "12px" }}>this library</div>
+  </div>
+  <div style={{ flex: "1 1 0", minWidth: "102px", border: "1px solid currentColor", borderRadius: "8px", padding: "10px 12px", opacity: 0.55 }}>
+    <div style={{ fontSize: "15px", fontWeight: 600 }}>Send</div>
+    <div style={{ fontSize: "12px" }}>a physician reads it</div>
+  </div>
+</div>
+
+<div id="ctrlrun-medical-demo">
+  <div style={{ display: "flex", flexWrap: "wrap", gap: "8px", marginBottom: "16px" }}>
+    <button type="button" name="draft" style={{ background: "#F5A623", color: "#14161b", border: "1px solid #B8730A", borderRadius: "8px", padding: "9px 16px", fontSize: "14px", cursor: "pointer" }}>Retrieve and draft</button>
+    <button type="button" name="send" style={{ background: "#F5A623", color: "#14161b", border: "1px solid #B8730A", borderRadius: "8px", padding: "9px 16px", fontSize: "14px", cursor: "pointer" }}>Send to the physician</button>
+    <button type="button" name="approve" style={{ background: "#14161b", color: "#8bd5a0", border: "1px solid #8bd5a0", borderRadius: "8px", padding: "9px 16px", fontSize: "14px", cursor: "pointer" }}>Approve, as the medical reviewer</button>
+    <button type="button" name="refresh" style={{ background: "transparent", color: "inherit", border: "1px solid currentColor", borderRadius: "8px", padding: "9px 16px", fontSize: "14px", cursor: "pointer" }}>A newer study lands</button>
+    <button type="button" name="reset" style={{ background: "transparent", color: "inherit", border: "1px dashed currentColor", borderRadius: "8px", padding: "9px 16px", fontSize: "14px", cursor: "pointer" }}>Start over</button>
+  </div>
+
+  <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))", gap: "16px" }}>
+    <div name="letter" style={{ border: "1px solid currentColor", borderRadius: "8px", padding: "16px", minHeight: "200px" }} />
+    <pre name="transcript" style={{ background: "#14161b", color: "#c9ccd3", borderRadius: "8px", padding: "16px", margin: 0, minHeight: "200px", maxHeight: "340px", overflowY: "auto", fontSize: "13px", lineHeight: 1.5, whiteSpace: "pre-wrap" }} />
+  </div>
+
+  <div style={{ display: "flex", flexWrap: "wrap", gap: "8px", alignItems: "center", marginTop: "16px", fontSize: "13px" }}>
+    <button type="button" name="event" style={{ background: "transparent", color: "inherit", border: "1px solid currentColor", borderRadius: "8px", padding: "7px 14px", fontSize: "13px", cursor: "pointer" }}>File the safety case</button>
+    <label style={{ display: "flex", gap: "6px", alignItems: "center" }}>
+      <input type="checkbox" name="lose_reply" />
+      lose the reply from the safety database
+    </label>
+    <button type="button" name="unapproved" style={{ background: "transparent", color: "inherit", border: "1px solid currentColor", borderRadius: "8px", padding: "7px 14px", fontSize: "13px", cursor: "pointer" }}>Cite an unapproved use</button>
+  </div>
+</div>
+
+The product, the physician's question and the three references are invented. Nothing on this
+page is medical information about a real medicine.
+
+## What refused you
+
+Revision A says no dose adjustment is needed. The reviewer reads that letter and signs for it,
+and the approval is bound to [the hash of that exact action](/concepts/approval-binding) — its
+name, its arguments, its recommendation sentence, its reference list. Then a newer study
+supersedes reference 2 and the pipeline redrafts. Revision B recommends the opposite. The
+signature is still there, still valid, still unexpired, and it authorizes nothing, because the
+letter it covers no longer exists.
+
+The two side buttons are the other two failures. Filing a safety case with the reply lost leaves
+the effect [AMBIGUOUS rather than failed](/concepts/outcomes-and-ambiguous), so the retry is
+refused and the case is filed once. An unapproved use is refused by the policy at any size, and
+an action nobody wrote down is refused for [not being in it](/concepts/fail-closed).
+
+```yaml
+schema: ctrlrun.policy/v2
+actions:
+  literature.search:
+    effect: "search:{inquiry_id}:{revision}"
+    decision: allow
+  safety.report_icsr:
+    effect: "icsr:{inquiry_id}"
+    decision: allow
+  response.send_to_hcp:
+    effect: "mi_response:{inquiry_id}"
+    decision: approve
+  response.cite_unapproved_use:
+    effect: "unapproved_use:{inquiry_id}"
+    decision: deny
+```
+
+## What CTRLRun is not doing here
+
+It did not read the papers. It has no opinion on whether reference 2 supports the sentence that
+cites it, whether the newer study is the better one, or whether either letter is correct. Claim
+checking is the hard scientific half of the harness, and it is yours to build — the transferable
+idea is to make it a precondition of `response.send_to_hcp` rather than a line in a prompt, so a
+claim with no source behind it is a refusal with a receipt instead of a suggestion the model can
+talk itself out of.
+
+This page runs real Python: Pyodide 314.0.6 loads in your tab and micropip installs the
+released `ctrlrun` wheel from PyPI. The medical portal and the safety database are fakes in the
+same process, the store is in memory, and no socket is opened. Every refusal you read above came
+from the same wheel `pip install ctrlrun` gives you.
+
+## Next
+
+- [Why](/why) — the 700-word version of the problem underneath this one
+- [Get started](/get-started/quickstart) — the same guarantees around your own function
+- [Approval binding](/concepts/approval-binding) — what an approval is bound to, and why

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -36,8 +36,7 @@
             "pages": [
               "index",
               "why",
-              "not-only-agents",
-              "try-it"
+              "not-only-agents"
             ]
           },
           {
@@ -47,6 +46,14 @@
               "get-started/quickstart",
               "get-started/three-ways-in",
               "get-started/choosing"
+            ]
+          },
+          {
+            "group": "Demos",
+            "pages": [
+              "demos/index",
+              "try-it",
+              "demos/medical-affairs"
             ]
           },
           {

--- a/docs/medical-demo.js
+++ b/docs/medical-demo.js
@@ -1,0 +1,413 @@
+/*
+ * The medical affairs portal, for docs/demos/medical-affairs.mdx.
+ *
+ * Mintlify includes every .js file in the content directory on every page and cannot scope one
+ * to a single page, so this does nothing at all unless the page it belongs to has mounted its
+ * container. Everything it touches lives inside that container.
+ *
+ * What it does: load Pyodide from the jsDelivr CDN, install `ctrlrun` from PyPI with micropip,
+ * and run real CTRLRun in the reader's own browser -- the same arrangement docs/try-it.js uses,
+ * over a different policy. Nothing is sent anywhere: the medical portal and the safety database
+ * are fakes in the same process, the state store is in memory, and no socket is opened.
+ *
+ * MODULE is a JSON array of lines so the test suite can read it out rather than carrying a
+ * copy. `tests/test_docs_medical_demo.py` runs it natively through the whole sequence the page
+ * tells the reader to press, on every commit, with no Node and no network.
+ *
+ * The product, the physician's question and the three references are invented. Nothing here is
+ * medical information about a real medicine, and the page says so above the fold.
+ */
+(function () {
+  "use strict";
+
+  var PYODIDE = "https://cdn.jsdelivr.net/pyodide/v314.0.6/full/";
+  var CONTAINER = "ctrlrun-medical-demo";
+
+  // `sqlite3` is bundled into Pyodide 314 and is not a loadable package; `pyyaml` is one of
+  // Pyodide's own builds; `click` arrives as ctrlrun's dependency through micropip.
+  var PACKAGES = ["micropip", "pyyaml"];
+
+  // Public API only -- `Control`, `InMemoryStateStore`, `LocalApprovalProvider`,
+  // `Policy.from_yaml`, `@protect`, `context`, `with_approval`, and the exceptions -- so what a
+  // reader sees here is what the same calls do in their own process. An approval is a
+  // `grant_approval` on the store, the same write `ctrlrun approve` makes; there is no
+  // auto-approve and no dry run. Keep it JSON-parseable: double-quoted strings, no comment
+  // inside the array, no trailing comma.
+  var MODULE = [
+    "import json",
+    "from ctrlrun import Control, InMemoryStateStore, LocalApprovalProvider, Policy",
+    "from ctrlrun import ActionDenied, AmbiguousEffect, ApprovalMismatch, ApprovalRequired, DuplicateEffect",
+    "from ctrlrun import context, protect, with_approval",
+    "",
+    "POLICY = \"\"\"",
+    "schema: ctrlrun.policy/v2",
+    "actions:",
+    "  literature.search:",
+    "    effect: \"search:{inquiry_id}:{revision}\"",
+    "    decision: allow",
+    "  safety.report_icsr:",
+    "    effect: \"icsr:{inquiry_id}\"",
+    "    decision: allow",
+    "  response.send_to_hcp:",
+    "    effect: \"mi_response:{inquiry_id}\"",
+    "    decision: approve",
+    "  response.cite_unapproved_use:",
+    "    effect: \"unapproved_use:{inquiry_id}\"",
+    "    decision: deny",
+    "\"\"\"",
+    "",
+    "INQUIRY = \"MI-2026-004471\"",
+    "",
+    "DRAFTS = [",
+    "    {",
+    "        \"revision\": \"A\",",
+    "        \"retrieved\": \"2026-09-01\",",
+    "        \"recommendation\": \"No dose adjustment is required in moderate hepatic impairment.\",",
+    "        \"references\": [\"PMID 37884120\", \"PMID 38119042\", \"PMID 38446701\"],",
+    "    },",
+    "    {",
+    "        \"revision\": \"B\",",
+    "        \"retrieved\": \"2026-09-07\",",
+    "        \"recommendation\": \"A 50% dose reduction is recommended in moderate hepatic impairment.\",",
+    "        \"references\": [\"PMID 37884120\", \"PMID 40219847\", \"PMID 38446701\"],",
+    "    },",
+    "]",
+    "",
+    "",
+    "class Portal:",
+    "    def __init__(self):",
+    "        self.letters = []",
+    "        self.cases = []",
+    "        self.lose_reply = False",
+    "",
+    "    def send_letter(self, inquiry_id):",
+    "        self.letters.append(inquiry_id)",
+    "        return {\"document\": \"SRL-0442\", \"status\": \"sent\"}",
+    "",
+    "    def report_case(self, inquiry_id):",
+    "        self.cases.append(inquiry_id)",
+    "        if self.lose_reply:",
+    "            raise TimeoutError(\"no response from the safety database after 30s\")",
+    "        return {\"case\": \"AER-2026-0881\", \"status\": \"received\"}",
+    "",
+    "",
+    "store = InMemoryStateStore()",
+    "control = Control(Policy.from_yaml(POLICY, source=\"<medical-demo>\"), store, LocalApprovalProvider(store))",
+    "portal = Portal()",
+    "draft_index = [0]",
+    "",
+    "",
+    "@protect(\"literature.search\", effect=\"search:{inquiry_id}:{revision}\", control=control)",
+    "def search(inquiry_id, revision, query):",
+    "    return {\"hits\": 3}",
+    "",
+    "",
+    "@protect(\"response.send_to_hcp\", effect=\"mi_response:{inquiry_id}\", control=control)",
+    "def send_to_hcp(inquiry_id, recommendation, references):",
+    "    return portal.send_letter(inquiry_id)",
+    "",
+    "",
+    "@protect(\"safety.report_icsr\", effect=\"icsr:{inquiry_id}\", control=control)",
+    "def report_icsr(inquiry_id, term):",
+    "    return portal.report_case(inquiry_id)",
+    "",
+    "",
+    "@protect(\"response.cite_unapproved_use\", effect=\"unapproved_use:{inquiry_id}\", control=control)",
+    "def cite_unapproved_use(inquiry_id, claim):",
+    "    return portal.send_letter(inquiry_id)",
+    "",
+    "",
+    "@protect(\"response.publish_unreviewed\", effect=\"unreviewed:{inquiry_id}\", control=control)",
+    "def publish_unreviewed(inquiry_id):",
+    "    return portal.send_letter(inquiry_id)",
+    "",
+    "",
+    "def _draft():",
+    "    return DRAFTS[draft_index[0]]",
+    "",
+    "",
+    "def _send(approval_id):",
+    "    draft = _draft()",
+    "    if approval_id:",
+    "        with with_approval(approval_id):",
+    "            return send_to_hcp(inquiry_id=INQUIRY, recommendation=draft[\"recommendation\"], references=draft[\"references\"])",
+    "    return send_to_hcp(inquiry_id=INQUIRY, recommendation=draft[\"recommendation\"], references=draft[\"references\"])",
+    "",
+    "",
+    "def step(request_json):",
+    "    request = json.loads(request_json)",
+    "    op = request[\"op\"]",
+    "    result = {\"op\": op, \"inquiry_id\": INQUIRY}",
+    "    try:",
+    "        with context(agent=\"mi-agent\", user=\"msl-de-0042\"):",
+    "            if op == \"draft\":",
+    "                draft = _draft()",
+    "                search(inquiry_id=INQUIRY, revision=draft[\"revision\"], query=\"hepatic impairment\")",
+    "                result[\"outcome\"] = \"executed\"",
+    "            elif op == \"approve\":",
+    "                approval = store.grant_approval(request[\"request_id\"], \"human:medical-reviewer\")",
+    "                result[\"outcome\"] = \"approved\"",
+    "                result[\"approval_id\"] = approval.approval_id",
+    "                result[\"action_hash\"] = approval.action_hash",
+    "            elif op == \"refresh\":",
+    "                draft_index[0] = 1",
+    "                result[\"outcome\"] = \"refreshed\"",
+    "                result[\"superseded\"] = \"PMID 38119042 superseded by PMID 40219847\"",
+    "            elif op == \"send\":",
+    "                _send(request.get(\"approval_id\"))",
+    "                result[\"outcome\"] = \"executed\"",
+    "            elif op == \"event\":",
+    "                portal.lose_reply = bool(request.get(\"lose_reply\"))",
+    "                report_icsr(inquiry_id=INQUIRY, term=\"hepatic enzyme increased\")",
+    "                result[\"outcome\"] = \"executed\"",
+    "            elif op == \"unapproved\":",
+    "                cite_unapproved_use(inquiry_id=INQUIRY, claim=\"use in an unapproved indication\")",
+    "                result[\"outcome\"] = \"executed\"",
+    "            elif op == \"unreviewed\":",
+    "                publish_unreviewed(inquiry_id=INQUIRY)",
+    "                result[\"outcome\"] = \"executed\"",
+    "            else:",
+    "                result[\"outcome\"] = \"unknown_op\"",
+    "    except ApprovalRequired as pending:",
+    "        record = store.get_approval(pending.request_id)",
+    "        result[\"outcome\"] = \"approval_required\"",
+    "        result[\"request_id\"] = pending.request_id",
+    "        result[\"action_hash\"] = record.action_hash if record else \"\"",
+    "    except ApprovalMismatch as refused:",
+    "        result[\"outcome\"] = \"approval_mismatch\"",
+    "        result[\"reason\"] = refused.reason",
+    "    except ActionDenied as refused:",
+    "        result[\"outcome\"] = \"denied\"",
+    "        result[\"reason\"] = refused.reason",
+    "    except DuplicateEffect as refused:",
+    "        result[\"outcome\"] = \"duplicate\"",
+    "        result[\"reason\"] = refused.state",
+    "    except AmbiguousEffect as refused:",
+    "        result[\"outcome\"] = \"ambiguous_retry\"",
+    "        result[\"reason\"] = refused.effect_key",
+    "    except TimeoutError as lost:",
+    "        result[\"outcome\"] = \"reply_lost\"",
+    "        result[\"reason\"] = str(lost)",
+    "    draft = _draft()",
+    "    result[\"revision\"] = draft[\"revision\"]",
+    "    result[\"retrieved\"] = draft[\"retrieved\"]",
+    "    result[\"recommendation\"] = draft[\"recommendation\"]",
+    "    result[\"references\"] = draft[\"references\"]",
+    "    result[\"letters\"] = len(portal.letters)",
+    "    result[\"cases\"] = len(portal.cases)",
+    "    return json.dumps(result)"
+  ].join("\n");
+
+  function ready(fn) {
+    if (document.readyState !== "loading") fn();
+    else document.addEventListener("DOMContentLoaded", fn);
+  }
+
+  function load(src) {
+    return new Promise(function (resolve, reject) {
+      var tag = document.createElement("script");
+      tag.src = src;
+      tag.onload = resolve;
+      tag.onerror = function () {
+        reject(new Error("could not load " + src));
+      };
+      document.head.appendChild(tag);
+    });
+  }
+
+  var runtimePromise = null;
+
+  function runtime(say) {
+    if (runtimePromise) return runtimePromise;
+    runtimePromise = (async function () {
+      say("Loading Python in this tab. The first run downloads about 10 MB from the Pyodide\nCDN and the ctrlrun wheel from PyPI; after that the browser caches them.");
+      if (!window.loadPyodide) await load(PYODIDE + "pyodide.js");
+      var pyodide = await window.loadPyodide({ indexURL: PYODIDE });
+      say("Installing ctrlrun from PyPI…");
+      await pyodide.loadPackage(PACKAGES);
+      var micropip = pyodide.pyimport("micropip");
+      await micropip.install("ctrlrun");
+      return pyodide;
+    })();
+    runtimePromise.catch(function () {
+      runtimePromise = null; // a failed download is retried on the next click
+    });
+    return runtimePromise;
+  }
+
+  // What each outcome the module can return says to a reader, and which colour it is shown in.
+  // Every branch of `step`'s try/except is named here; a new one with no entry would print
+  // its raw outcome, which the test suite refuses.
+  var OUTCOMES = {
+    executed: ["ran", "ok"],
+    approved: ["the reviewer signed for this exact letter", "ok"],
+    refreshed: ["the draft changed under the signature", "warn"],
+    approval_required: ["a human decides", "warn"],
+    approval_mismatch: ["BLOCKED — the approved letter is not the letter being sent", "stop"],
+    denied: ["BLOCKED — the policy refuses this", "stop"],
+    duplicate: ["BLOCKED — this letter already went out", "stop"],
+    ambiguous_retry: ["BLOCKED — the case may already be filed; blind retry refused", "stop"],
+    reply_lost: ["the reply never came back — outcome AMBIGUOUS, not failed", "warn"],
+    unknown_op: ["nothing to do", "ok"],
+  };
+
+  // The site is a single-page app and this script runs once, when the page becomes
+  // interactive: on a first load that can be before React has painted the container, and on a
+  // navigation from another page the script does not run again at all. Both were true of the
+  // first version of this file, where every button did nothing. So wiring is attempted now and
+  // again on every DOM change; `wire` is a `getElementById` and a flag check when there is
+  // nothing to do, and the flag lives on the element, so a container React mounts afresh is
+  // wired afresh.
+  function wire() {
+    var root = document.getElementById(CONTAINER);
+    if (!root) return; // every other page on the site
+    if (root.getAttribute("data-wired") === "yes") return;
+    root.setAttribute("data-wired", "yes");
+
+    var find = function (name) {
+      return root.querySelector("[name='" + name + "']");
+    };
+    var buttons = {};
+    ["draft", "send", "approve", "refresh", "event", "unapproved", "reset"].forEach(function (name) {
+      buttons[name] = find(name);
+    });
+    var loseReply = find("lose_reply");
+    var letter = find("letter");
+    var transcript = find("transcript");
+    if (!letter || !transcript || !buttons.draft) return;
+
+    var pyodide = null;
+    var pending = null;
+    var approval = null;
+    var busy = false;
+
+    function say(text) {
+      transcript.textContent += (transcript.textContent ? "\n" : "") + text;
+      transcript.scrollTop = transcript.scrollHeight;
+    }
+
+    function stage(next) {
+      Object.keys(buttons).forEach(function (name) {
+        var button = buttons[name];
+        if (!button) return;
+        var live = name === "reset" || name === "event" || name === "unapproved" || name === next;
+        button.disabled = !live;
+        button.style.opacity = live ? "1" : "0.35";
+        button.style.cursor = live ? "pointer" : "not-allowed";
+        button.style.boxShadow = name === next ? "0 0 0 3px rgba(184,115,10,0.35)" : "none";
+      });
+    }
+
+    function render(result) {
+      var references = (result.references || [])
+        .map(function (reference, index) {
+          var fresh = reference === "PMID 40219847";
+          return (
+            "<li style=\"font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px;" +
+            (fresh ? "font-weight:600;" : "") +
+            "\">[" + (index + 1) + "] " + reference + (fresh ? "  ← new" : "") + "</li>"
+          );
+        })
+        .join("");
+      letter.innerHTML =
+        "<div style=\"font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;opacity:0.7;letter-spacing:0.04em;text-transform:uppercase\">" +
+        "Standard response letter · " + result.inquiry_id + " · revision " + result.revision +
+        " · evidence retrieved " + result.retrieved + "</div>" +
+        "<p style=\"font-size:16px;margin:12px 0 4px;font-weight:600\">" + result.recommendation + "</p>" +
+        "<div style=\"font-size:12px;opacity:0.7;margin-bottom:4px\">References</div>" +
+        "<ul style=\"margin:0;padding-left:20px\">" + references + "</ul>";
+    }
+
+    async function run(op, extra) {
+      if (busy) return;
+      busy = true;
+      try {
+        if (!pyodide) {
+          pyodide = await runtime(say);
+          pyodide.runPython(MODULE);
+          say("ctrlrun is running in this tab. Nothing leaves it.\n");
+        }
+        var request = { op: op };
+        if (extra) Object.keys(extra).forEach(function (key) { request[key] = extra[key]; });
+        pyodide.globals.set("MEDICAL_REQUEST", JSON.stringify(request));
+        var result = JSON.parse(pyodide.runPython("step(MEDICAL_REQUEST)"));
+        report(op, result);
+        render(result);
+      } catch (error) {
+        say(
+          "\nThis did not run in this browser:\n\n    " +
+            (error && error.message ? error.message : String(error)) +
+            "\n\nThat is this page failing, not CTRLRun. Run it locally instead:\n\n    pip install ctrlrun && ctrlrun demo"
+        );
+      } finally {
+        busy = false;
+      }
+    }
+
+    function report(op, result) {
+      var known = OUTCOMES[result.outcome] || [result.outcome, "warn"];
+      var mark = known[1] === "stop" ? "✗" : known[1] === "warn" ? "○" : "✓";
+      say("\n$ " + op);
+      say("  " + mark + " " + known[0] + (result.reason ? "  (" + result.reason + ")" : ""));
+
+      if (result.outcome === "approval_required") {
+        pending = result.request_id;
+        say("    request " + result.request_id);
+        say("    bound to " + (result.action_hash || "").slice(0, 27) + "…");
+        stage("approve");
+      } else if (result.outcome === "approved") {
+        approval = result.approval_id;
+        say("    approval " + result.approval_id);
+        say("    action hash " + (result.action_hash || "").slice(0, 27) + "…");
+        say("    the reviewer read revision " + result.revision + " and signed for that one");
+        stage("refresh");
+      } else if (result.outcome === "refreshed") {
+        say("    " + result.superseded);
+        say("    the letter now recommends the opposite, under yesterday's signature");
+        stage("send");
+      } else if (result.outcome === "approval_mismatch") {
+        say("    the approval covers a letter with a different recommendation");
+        say("    nothing but a new approval, on the new letter, moves this on");
+        stage("reset");
+      } else if (op === "draft") {
+        stage("send");
+      }
+      say("  letters sent to the physician: " + result.letters + "   safety cases filed: " + result.cases);
+    }
+
+    buttons.draft.addEventListener("click", function () { run("draft"); });
+    buttons.send.addEventListener("click", function () { run("send", approval ? { approval_id: approval } : null); });
+    buttons.approve.addEventListener("click", function () { run("approve", { request_id: pending }); });
+    buttons.refresh.addEventListener("click", function () { run("refresh"); });
+    if (buttons.event) {
+      buttons.event.addEventListener("click", function () {
+        run("event", { lose_reply: !!(loseReply && loseReply.checked) });
+      });
+    }
+    if (buttons.unapproved) {
+      buttons.unapproved.addEventListener("click", function () { run("unapproved"); });
+    }
+    if (buttons.reset) {
+      buttons.reset.addEventListener("click", function () {
+        pending = null;
+        approval = null;
+        transcript.textContent = "";
+        if (pyodide) pyodide.runPython(MODULE);
+        stage("draft");
+        letter.innerHTML = "";
+        say("A fresh store, a fresh policy, revision A. Press Retrieve and draft.");
+      });
+    }
+
+    stage("draft");
+    say("Press Retrieve and draft. The first press downloads Python and the ctrlrun wheel.");
+  }
+
+  ready(wire);
+  if (window.MutationObserver) {
+    new MutationObserver(wire).observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+    });
+  }
+})();

--- a/docs/medical-demo.js
+++ b/docs/medical-demo.js
@@ -198,6 +198,22 @@
     "    return json.dumps(result)"
   ].join("\n");
 
+  var MONO = "font-family:ui-monospace,SFMono-Regular,Menlo,monospace;";
+
+  //: The reference the newer study brings in. The panel marks it so a reader can see which
+  //: line moved without diffing two revisions by eye.
+  var NEW_REFERENCE = "PMID 40219847";
+
+  // Built as nodes rather than markup. Nothing here is attacker-controlled -- every string
+  // comes from the module in this file -- but a page whose whole subject is a boundary does
+  // not hand strings to an HTML parser to make a bulleted list.
+  function el(tag, style, text) {
+    var node = document.createElement(tag);
+    node.setAttribute("style", style);
+    if (text) node.textContent = text;
+    return node;
+  }
+
   function ready(fn) {
     if (document.readyState !== "loading") fn();
     else document.addEventListener("DOMContentLoaded", fn);
@@ -299,23 +315,25 @@
     }
 
     function render(result) {
-      var references = (result.references || [])
-        .map(function (reference, index) {
-          var fresh = reference === "PMID 40219847";
-          return (
-            "<li style=\"font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px;" +
-            (fresh ? "font-weight:600;" : "") +
-            "\">[" + (index + 1) + "] " + reference + (fresh ? "  ← new" : "") + "</li>"
-          );
-        })
-        .join("");
-      letter.innerHTML =
-        "<div style=\"font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;opacity:0.7;letter-spacing:0.04em;text-transform:uppercase\">" +
-        "Standard response letter · " + result.inquiry_id + " · revision " + result.revision +
-        " · evidence retrieved " + result.retrieved + "</div>" +
-        "<p style=\"font-size:16px;margin:12px 0 4px;font-weight:600\">" + result.recommendation + "</p>" +
-        "<div style=\"font-size:12px;opacity:0.7;margin-bottom:4px\">References</div>" +
-        "<ul style=\"margin:0;padding-left:20px\">" + references + "</ul>";
+      var made = document.createDocumentFragment();
+      made.appendChild(
+        el("div", MONO + "font-size:12px;opacity:0.7;letter-spacing:0.04em;text-transform:uppercase",
+          "Standard response letter · " + result.inquiry_id + " · revision " + result.revision +
+          " · evidence retrieved " + result.retrieved)
+      );
+      made.appendChild(el("p", "font-size:16px;margin:12px 0 4px;font-weight:600", result.recommendation));
+      made.appendChild(el("div", "font-size:12px;opacity:0.7;margin-bottom:4px", "References"));
+      var list = el("ul", "margin:0;padding-left:20px", "");
+      (result.references || []).forEach(function (reference, index) {
+        var fresh = reference === NEW_REFERENCE;
+        list.appendChild(
+          el("li", MONO + "font-size:13px;" + (fresh ? "font-weight:600;" : ""),
+            "[" + (index + 1) + "] " + reference + (fresh ? "  ← new" : ""))
+        );
+      });
+      made.appendChild(list);
+      letter.textContent = "";
+      letter.appendChild(made);
     }
 
     async function run(op, extra) {
@@ -394,7 +412,7 @@
         transcript.textContent = "";
         if (pyodide) pyodide.runPython(MODULE);
         stage("draft");
-        letter.innerHTML = "";
+        letter.textContent = "";
         say("A fresh store, a fresh policy, revision A. Press Retrieve and draft.");
       });
     }

--- a/tests/test_docs_medical_demo.py
+++ b/tests/test_docs_medical_demo.py
@@ -163,7 +163,27 @@ def test_the_script_does_not_load_sqlite3_as_a_package():
 def test_the_page_and_the_script_name_one_pyodide_build():
     versions = set(re.findall(r"v?(\d+\.\d+\.\d+)", SCRIPT.split("PYODIDE =")[1].split("\n")[0]))
     assert len(versions) == 1, versions
-    assert versions.pop() in PAGE, "the page does not name the build the script loads"
+    version = versions.pop()
+    assert version in PAGE, "the page does not name the build the script loads"
+
+
+def test_the_reference_the_panel_marks_is_the_one_the_newer_study_brings_in():
+    """The panel marks the line that moved. A module that renamed the reference without the
+    script following would draw revision B with nothing marked, which is the page's whole
+    point going quietly missing."""
+    marked = SCRIPT.split('var NEW_REFERENCE = "', 1)[1].split('"', 1)[0]
+    revisions = re.findall(r'"references": \[([^\]]+)\]', MODULE)
+    assert len(revisions) == 2, "the module no longer holds two revisions of the letter"
+    assert marked not in revisions[0], f"{marked} is already in revision A"
+    assert marked in revisions[1], f"{marked} is not in revision B"
+
+
+def test_the_script_builds_the_letter_from_nodes_and_not_from_markup():
+    """`try-it.js` hands nothing to an HTML parser and neither does this. Not because a string
+    here is attacker-controlled -- every one comes from the module in the same file -- but
+    because a page about a boundary should not be the page that makes an exception."""
+    assert "innerHTML" not in SCRIPT
+    assert "insertAdjacentHTML" not in SCRIPT
 
 
 def test_the_script_names_every_outcome_the_module_can_return():

--- a/tests/test_docs_medical_demo.py
+++ b/tests/test_docs_medical_demo.py
@@ -1,0 +1,192 @@
+"""The medical affairs demo page, held to the module it claims to run.
+
+The page tells a reader to press four buttons and promises what each one does. The promise is
+cheap to write and expensive to get wrong, so the module the browser runs is run here too --
+natively, with no Node and no network -- through that exact sequence. A page describing a
+refusal nobody reproduced is the false green this repository keeps finding.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS = REPO_ROOT / "docs"
+
+if not (DOCS / "demos" / "medical-affairs.mdx").exists():  # pragma: no cover - not a checkout
+    pytest.skip("no repository checkout", allow_module_level=True)
+
+PAGE = (DOCS / "demos" / "medical-affairs.mdx").read_text(encoding="utf-8")
+SCRIPT = (DOCS / "medical-demo.js").read_text(encoding="utf-8")
+
+
+def _array(name: str) -> str:
+    """The JSON array of Python lines the script embeds, joined the way the script joins it."""
+    body = SCRIPT.split(f"var {name} = [", 1)[1].split("].join", 1)[0]
+    return "\n".join(json.loads("[" + body + "]"))
+
+
+MODULE = _array("MODULE")
+
+
+@pytest.fixture
+def harness():
+    """The module, executed the way Pyodide executes it, with `step` exposed."""
+    namespace: dict[str, object] = {}
+    exec(compile(MODULE, "<medical-demo>", "exec"), namespace)
+    step = namespace["step"]
+
+    def call(op: str, **request: object) -> dict:
+        return json.loads(step(json.dumps({"op": op, **request})))
+
+    return call
+
+
+# --- the module ----------------------------------------------------------------------------
+
+
+def test_the_module_is_valid_python_and_defines_step():
+    namespace: dict[str, object] = {}
+    exec(compile(MODULE, "<medical-demo>", "exec"), namespace)
+    assert callable(namespace["step"])
+
+
+def test_the_module_runs_the_sequence_the_page_tells_the_reader_to_press(harness):
+    """Draft, send, approve, let a newer study land, send again. The last one is the page."""
+    drafted = harness("draft")
+    assert drafted["outcome"] == "executed"
+    assert drafted["revision"] == "A"
+
+    pending = harness("send")
+    assert pending["outcome"] == "approval_required"
+    assert pending["action_hash"].startswith("sha256:")
+
+    approved = harness("approve", request_id=pending["request_id"])
+    assert approved["outcome"] == "approved"
+    assert approved["action_hash"] == pending["action_hash"], "the reviewer signed another action"
+
+    refreshed = harness("refresh")
+    assert refreshed["outcome"] == "refreshed"
+    assert refreshed["revision"] == "B"
+    assert refreshed["recommendation"] != drafted["recommendation"], "the letter did not change"
+
+    refused = harness("send", approval_id=approved["approval_id"])
+    assert refused["outcome"] == "approval_mismatch"
+    assert refused["reason"] == "mismatch"
+    assert refused["letters"] == 0, "the letter reached the physician"
+
+
+def test_the_approval_that_matches_is_spent_once(harness):
+    """The positive control for the test above: the same approval, on the letter it covers,
+    sends -- and a second send under a fresh approval is refused as a duplicate. Without this,
+    a module that refused everything would pass."""
+    pending = harness("send")
+    approved = harness("approve", request_id=pending["request_id"])
+    sent = harness("send", approval_id=approved["approval_id"])
+    assert sent["outcome"] == "executed"
+    assert sent["letters"] == 1
+
+    again = harness("send")
+    assert again["outcome"] == "approval_required"
+    granted = harness("approve", request_id=again["request_id"])
+    duplicate = harness("send", approval_id=granted["approval_id"])
+    assert duplicate["outcome"] == "duplicate"
+    assert duplicate["reason"] == "committed"
+    assert duplicate["letters"] == 1, "the same letter went out twice"
+
+
+def test_a_lost_reply_from_the_safety_database_is_ambiguous_and_not_failed(harness):
+    lost = harness("event", lose_reply=True)
+    assert lost["outcome"] == "reply_lost"
+    assert lost["cases"] == 1
+
+    retried = harness("event")
+    assert retried["outcome"] == "ambiguous_retry"
+    assert retried["cases"] == 1, "the case was filed twice"
+
+
+def test_the_policy_refuses_an_unapproved_use_and_an_action_nobody_wrote_down(harness):
+    denied = harness("unapproved")
+    assert denied["outcome"] == "denied"
+    assert denied["letters"] == 0
+
+    unknown = harness("unreviewed")
+    assert unknown["outcome"] == "denied"
+    assert unknown["reason"] == "unknown_action"
+    assert unknown["letters"] == 0
+
+
+def test_the_module_has_no_way_to_grant_but_the_reviewer_button(harness):
+    """`grant_approval` appears once, under the `approve` op. An auto-approve or a dry run in
+    here would make every refusal on the page a decoration."""
+    assert MODULE.count("grant_approval") == 1
+    for forbidden in ("auto_approve", "dry_run", "deny_approval", "reserve_effect"):
+        assert forbidden not in MODULE, forbidden
+
+
+def test_the_policy_on_the_page_is_the_policy_in_the_module():
+    """A reader reads the YAML on the page and believes it produced what they just saw."""
+    shown = PAGE.split("```yaml", 1)[1].split("```", 1)[0].strip()
+    embedded = MODULE.split('POLICY = """', 1)[1].split('"""', 1)[0].strip()
+    assert shown == embedded
+
+
+# --- the script ----------------------------------------------------------------------------
+
+
+def test_the_script_does_nothing_unless_the_page_mounts_it():
+    """Mintlify includes every .js file on every page and cannot scope one, so the script must
+    find its container before it touches anything."""
+    assert 'var CONTAINER = "ctrlrun-medical-demo";' in SCRIPT
+    assert "if (!root) return;" in SCRIPT
+    assert 'id="ctrlrun-medical-demo"' in PAGE
+
+
+def test_the_script_wires_itself_after_the_page_renders():
+    """Mintlify is a single-page application: wiring only on DOMContentLoaded misses every
+    client-side navigation, which is how a reader reaches this page from the sidebar."""
+    assert "document.readyState" in SCRIPT
+    assert "MutationObserver" in SCRIPT, "a sidebar navigation would leave the buttons dead"
+    assert "data-wired" in SCRIPT, "wiring twice would double every click"
+
+
+def test_the_script_does_not_load_sqlite3_as_a_package():
+    """sqlite3 is built into Pyodide and asking micropip for it fails the whole boot."""
+    packages = SCRIPT.split("var PACKAGES = ", 1)[1].split(";", 1)[0]
+    assert "sqlite3" not in packages
+
+
+def test_the_page_and_the_script_name_one_pyodide_build():
+    versions = set(re.findall(r"v?(\d+\.\d+\.\d+)", SCRIPT.split("PYODIDE =")[1].split("\n")[0]))
+    assert len(versions) == 1, versions
+    assert versions.pop() in PAGE, "the page does not name the build the script loads"
+
+
+def test_the_script_names_every_outcome_the_module_can_return():
+    """A new branch in `step` with no entry in OUTCOMES would print a raw enum at a reader."""
+    outcomes = set(re.findall(r'result\["outcome"\] = "(\w+)"', MODULE))
+    mapped = set(re.findall(r"^    (\w+): \[", SCRIPT, re.M))
+    assert outcomes - mapped == set(), f"the script does not name: {sorted(outcomes - mapped)}"
+
+
+def test_the_script_wires_every_control_the_page_mounts():
+    """A button the page shows and the script never binds is a control that does nothing."""
+    mounted = set(re.findall(r'<button[^>]*name="(\w+)"', PAGE))
+    assert mounted, "the page mounts no buttons"
+    for name in mounted:
+        assert f"buttons.{name}.addEventListener" in SCRIPT or f'find("{name}")' in SCRIPT, name
+
+
+def test_the_page_tells_a_reader_what_to_do_when_it_does_not_run():
+    assert "pip install ctrlrun" in SCRIPT
+
+
+def test_the_page_says_the_product_and_the_references_are_invented():
+    """The one sentence that keeps an illustration from reading as medical information."""
+    flowed = " ".join(PAGE.lower().split())
+    assert "are invented" in flowed
+    assert "nothing on this page is medical information about a real medicine" in flowed


### PR DESCRIPTION
## What this adds

A **Demos** group in the Documentation tab — `demos/index`, `try-it` (moved out of Start, where it sat alone), and a new `demos/medical-affairs`.

The new page is the same arrangement `try-it.js` uses, over a different policy: Pyodide loads in the reader's tab, micropip installs the **released `ctrlrun` wheel from PyPI**, and every refusal on the page is the library's own. It exists to answer a question people ask about their own domain — what this looks like when the consequential action is a document rather than a payment.

## The story it tells

A medical information letter is drafted, sent, refused for wanting a human, and signed for by a reviewer. Then a newer study supersedes one of its references, the pipeline redrafts, and the recommendation flips from *no dose adjustment* to *a 50% reduction*. The signature is still there, still valid, still unexpired — and it authorizes nothing, because the letter it covers no longer exists. `letters sent to the physician: 0`.

Two side buttons carry the other two failures: a safety case whose reply is lost is `AMBIGUOUS` rather than failed, so the retry is refused and the case is filed once; an unapproved use is denied by the policy, and an action nobody wrote down is denied for not being in it.

## What it does not claim

The page says in its own body that CTRLRun did not read the papers, has no opinion on whether a reference supports the sentence citing it, and that claim checking is the reader's half to build. The product, the physician's question and the three references are invented, and the page says that above the fold.

## Tests

`tests/test_docs_medical_demo.py` lifts the module out of the JavaScript and runs it natively on every commit — no Node, no network — through the exact sequence the page tells the reader to press.

- **A positive control**: the approval that *does* match sends, and the second send under a fresh approval is refused as a duplicate. Without it, a module that refused everything would pass every other test here.
- The page's YAML is held equal to the module's.
- An outcome the script cannot name, or a button the script never wires, fails.
- `grant_approval` appears exactly once, and `auto_approve` / `dry_run` appear nowhere.

1521 docs tests pass; the forbidden-words lint and the link checker are both clean.

## Verified in a browser

The whole sequence was driven against `mint dev` before this commit, which is what found the wiring bug: the site is a single-page application, and the first version looked for its container before React had painted it, so every button did nothing. It now wires on `readyState` and again on every DOM change, with a flag on the element so a click is never bound twice.