### PR TITLE
Test and declare Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     # SPEC-v0.6 §4. The Postgres tests skip when CTRLRUN_TEST_POSTGRES is unset, and a
     # skipping test proves nothing -- so CI supplies a real server rather than letting the

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,7 @@ name: CodeQL
 # the extra queries cost a few minutes that a project this size can afford.
 #
 # Findings land in the repository's code-scanning tab. Nothing here gates a merge -- the
-# required checks stay `check (3.11)`, `check (3.12)` and `package` -- because a static
+# required checks stay `check (3.11)` through `check (3.14)` and `package` -- because a static
 # analyser's first run on an unfamiliar codebase is a reading list, not a verdict.
 
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ All notable changes to this project are documented here. The format follows
 Public API names are frozen in `docs/SPEC-v0.1.md` §8. Before 1.0 they may still change, and
 any change to one appears here.
 
+## [Unreleased]
+
+### Added
+
+- **Python 3.13 and 3.14 are tested and declared.** CI's `check` job runs the full suite on
+  3.11, 3.12, 3.13 and 3.14, and the package classifiers name all four. The floor is unchanged:
+  `requires-python` stays `>=3.11`, and mypy and ruff still check against 3.11. No library code
+  changed; the one test fix is below.
+
+### Fixed
+
+- **The migration tests' release fixtures could not build a venv on some interpreters.**
+  `venv.create` copies the interpreter by default, and a copied binary from a shared-libpython
+  build (uv's CPython 3.14 on macOS) aborted inside `ensurepip`, so all five release fixtures
+  errored before a release was installed. The fixture now symlinks, as `python -m venv` does on
+  POSIX.
+
 ## [0.6.1] - 2026-09-07 — The audit's fixes, and the gateway's transport
 
 Everything found after `v0.6.0` was tagged: twenty-nine defects from an audit of the shipped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
 dependencies = [

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -68,7 +68,11 @@ def _release_venv(tmp_path_factory, version: str) -> Path | None:
     """
     root = tmp_path_factory.mktemp(f"rel-{version}")
     env = root / "venv"
-    venv.create(env, with_pip=True)
+    # Symlinks, as `python -m venv` uses on POSIX. `venv.create` copies the interpreter by
+    # default, and a copied binary from a shared-libpython build looks for `libpython` beside
+    # itself: on uv's CPython 3.14 for macOS it aborted inside `ensurepip`, and every release
+    # fixture errored before a release was installed.
+    venv.create(env, with_pip=True, symlinks=os.name != "nt")
     python = env / "bin" / "python"
     done = subprocess.run(
         [str(python), "-m", "pip", "install", "-q", f"ctrlrun=={version}"],


### PR DESCRIPTION
## What

- **CI:** the `check` matrix runs `3.11`, `3.12`, `3.13`, `3.14`.
- **Packaging:** classifiers add `Python :: 3.13` and `Python :: 3.14`. The PyPI "Python versions" badge in the README reads these, so it updates at the next release.
- **Floor unchanged:** `requires-python` stays `>=3.11`, mypy `python_version` and ruff `target-version` stay 3.11, and the single-version jobs (adapters, docs, package, release, publish, fuzz) and `action.yml`'s default stay on the floor.
- **No library code changes.** Nothing under `src/`.

## The one test fix

`tests/test_migrations.py`'s release fixtures built their venv with `venv.create(env, with_pip=True)`, which **copies** the interpreter by default (`python -m venv` symlinks on POSIX). A copied binary from a shared-libpython build looks for `libpython` next to itself; on uv's CPython 3.14.2 for macOS it aborted with SIGABRT inside `ensurepip`, and all five release fixtures errored (4 failed + 2 errors). The fixture now passes `symlinks=os.name != "nt"`. I have not confirmed whether GitHub's Linux 3.14 build hits the same abort; the change is harmless either way.

## Evidence (local, macOS arm64, `scripts/check.sh` with `CTRLRUN_REQUIRE_RELEASE_FIXTURES=1`)

| Python | ruff format / check | mypy --strict src | pytest |
|---|---|---|---|
| 3.12.3 (this branch) | pass | pass | 2900 passed, 45 skipped |
| 3.13.5 | pass | pass | 2824 passed, 47 skipped |
| 3.14.2 (this branch) | pass | pass | 2824 passed, 47 skipped |
| 3.14.2 adapter suites (langgraph 1.2.11, openai-agents 0.22.2) | | | 76 passed |

Before the fixture fix, 3.14 was 2818 passed, 4 failed, 2 errors, all in `test_migrations.py`. 3.14's `multiprocessing` default start method change does not reach `tests/test_concurrency.py`, which pins `spawn`. The only 3.14 deprecation warning seen comes from `openai-agents` itself (`asyncio.get_event_loop_policy`).

## After merge

Branch protection: add `check (3.13)` and `check (3.14)` to the required status checks on `main`, beside `check (3.11)` and `check (3.12)`. Until then a red 3.13/3.14 leg would not block a merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support and package metadata for Python 3.13 and 3.14.
  * Expanded automated testing across Python 3.11–3.14.

* **Bug Fixes**
  * Improved migration test virtual environment setup on POSIX platforms by linking the interpreter instead of copying it.

* **Documentation**
  * Updated the unreleased changelog with Python support and migration test details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->