### PR TITLE
A provider token that changes when the attempt does, so one retry cannot replay the last answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,27 @@ any change to one appears here.
   Postgres `--store-url` and `N/A` on SQLite, and the catalogue moves to
   `ctrlrun.guarantees/v3`; the store conformance suite gains a `clock` case, `not_applicable`
   on SQLite and the in-memory store because neither has a clock of its own.
+- **The provider idempotency token** (SPEC-v0.7 §4, item 3). `ctrlrun.idempotency_token()`, a new
+  zero-argument accessor re-exported at package import, answers inside an executor with the token
+  of the attempt it is running: `ctrlrun.effect.idempotency_token_for(effect_key, attempt)`, a
+  SHA-256 over the canonical form of `(effect_key, attempt)` under the domain tag
+  `ctrlrun.idempotency/v1`, rendered as a 36-character UUID of version 8. Send it to a provider as
+  its idempotency key. **Derived from the attempt and not from the effect key alone**: the effect
+  key is stable across `SPEC-v0.1.md` §5.4's renewal, so a provider given it would answer the one
+  retry the kernel permits, permitted *because the executor proved nothing happened*, with the
+  cached failure of the attempt that failed. It is stable within one attempt, including across a
+  `Control.resume` of a suspended one, and different after a renewal. **What it is for is
+  reconciliation**: a deterministic handle to ask a provider what became of an attempt whose
+  outcome is unknown, by a key the provider already indexes. It does not make a retry safe, and
+  after an `AMBIGUOUS` outcome the kernel still refuses one. Nothing is stored: the token is a pure
+  function of two fields every receipt of an attempt that ran already carries, so a receipt
+  re-derives it and a `reconcile` hook reads the attempt off the record. The executor signature is
+  unchanged, and an executor that never calls the accessor runs exactly as it did at 0.6.1. Outside
+  an executor, for an action with no effect key, for an observe-mode attempt whose reservation was
+  refused, and on a thread started without a copy of the executor's context, it raises
+  `InvalidArgument`. Verify gains G14, with a note beneath the table: a token is unique only as far
+  as the operator's effect keys are, and a kernel that sees one store cannot check that two stores
+  sharing a provider account never produce one effect-key string for two different effects.
 
 ### Fixed
 

--- a/docs/SPEC-v0.7.md
+++ b/docs/SPEC-v0.7.md
@@ -2559,6 +2559,73 @@ action that can store it and a sink is handed only an event that was stored.
 
 ### 12.3 Item 3: the idempotency token
 
+**The derivation is §4.2's, byte for byte, and the three worked values are the code's.**
+`idempotency_token_for("refund:txn_1", 1)` is `382ee448-97da-8107-b674-8c253650d93f`, attempt 2 is
+`28bb40af-814c-8fb6-ba63-e8663b1c036d` and `refund:txn_2` at attempt 1 is
+`89977bc9-d128-8ae8-871f-f5265155e60f`. T235 pins the first as a literal and the other two beside
+it, so a change to the domain tag, the truncation, the version nibble or the canonical form is a
+red test rather than a silent change of every token a deployment has ever sent.
+
+**The domain tag is a module constant, `effect.IDEMPOTENCY_SCHEMA`, not a literal and not a private
+name.** Every schema string in this codebase is a public `Final` beside the code that stamps it, as
+`ACTION_SCHEMA`, `RECEIPT_SCHEMA` and `INSPECTION_SCHEMA` are, and none of them is in §9's frozen
+list either; item 1's `_CLOCK_SKEW_TRIGGERS` is private because it is a closed vocabulary a caller
+would otherwise be tempted to extend, which a schema tag is not.
+
+**The binding is a context manager around `executor()` and nothing else.** `_attempt_token` sets the
+variable where `held_key is not None` and resets it in a `finally`, so the value is gone whether the
+executor returned, raised, or suspended. `_outcome` is the single place `execute`, `_observed` and
+`resume` all reach, which is why a resumed leg reads the token of the attempt it resumes without a
+second binding site: `resume` passes `held.record.attempt`, unchanged (`control.py:992`), and T233
+asserts the number and the token together, so a change to either is visible.
+
+**`held_key`, not `effect_key`.** The two differ for an observe-mode attempt whose reservation was
+refused, where `effect_key` names the key and `held_key` is `None` because another attempt owns the
+record. Binding on `effect_key` would hand that executor attempt 1's token, which names the real
+holder's attempt, and it would do so on the one path where nothing can be written to say so. T236
+drives it, and the test beside it, an observe-mode attempt that *does* hold its key and is answered,
+is the control that keeps it from passing against a kernel that simply never answers in observe mode.
+
+**The context variable takes a default of `None` rather than being left unset.** `_CONTEXT` and
+`_PRESENTED_APPROVAL` are read with `.get(None)`; this one is read with `.get()` against a declared
+default, which is the same refusal and lets a test undo a deliberately leaking mutant without a
+reset token. The accessor refuses `None` and never guesses.
+
+**G14 runs its control first.** The two reads and the refusal outside any executor are asserted
+before the renewal, so a kernel whose answer moves within an attempt, and a kernel that sets the
+variable and never resets it, both report `control failed` rather than a violation of the
+observable, which is the distinction §1.3 draws. The leaking kernel is the sharper of the two: it
+passes the observable, because each executor still reads its own attempt's value.
+
+**The note beneath the table is not an N/A reason and not a finding.** §4.6's sentence is printed
+under the table whenever G14 is graded, once, from `EFFECT_KEY_SCOPE_NOTE`, rather than in G14's
+`detail.note`: `detail.note` is rendered under the guarantee's own row and only for the first
+result carrying one, so a run where an earlier N/A already printed a note would have swallowed it.
+A guarantee silent about the one thing a single-store run cannot check would read as having checked
+it.
+
+**No `reconcile` hook signature changed, and none needed to.** The hook is handed the effect key
+(`v0.2 §11`), and the attempt is on the record, so `idempotency_token_for(key,
+store.get_effect(key).attempt)` is the whole of what §4.5 asks for. Making the accessor answer inside
+a hook was rejected in §4.3 and nothing in the code argued for it: the blocking call really does run
+under a different attempt from the eager one.
+
+**Its catalogue title is *token changes across a renewal*,** thirty characters, because the report's
+title column is thirty-two and a longer one pushes every status on that row out of line. G13's entry
+made the same choice for the same reason.
+
+**The counts verify pins moved by one, as item 1's did.** G14 joins G3, G4 and G5 wherever the
+effect template lives in a `@protect` decorator verify does not read, so `V1_PAYMENTS` reports six
+over six with seven not applicable; the authority example reports twelve over twelve. The
+catalogue-size guard in T101 was the literal `"8/8"`, which is the real summary now that eight
+guarantees are applicable there, and it is computed from `len(GUARANTEES)` instead.
+
+**Item 3a is what makes this sound on Postgres, and it is not merged.** The token is unique per
+dispatch only where the attempt number is unique per key and the number `Control` is handed is the
+number the store wrote, and on Postgres neither holds until item 3a lands (§1.4 item 3, §4.4, §5.6).
+This item is built on `main` and cherry-picks nothing; T232 cannot see that defect and does not
+claim to.
+
 ### 12.4 Item 4: the attempt ceiling
 
 ### 12.5 Item 5: precondition fingerprints

--- a/src/ctrlrun/__init__.py
+++ b/src/ctrlrun/__init__.py
@@ -20,7 +20,7 @@ from .approval import (
     ScriptedApprovalProvider,
 )
 from .authority import Authority, AuthorityResult, Delegation, Grant, Subject
-from .control import Control, context, protect, with_approval
+from .control import Control, context, idempotency_token, protect, with_approval
 from .effect import EffectRecord, EffectState, ReconcileOutcome
 from .errors import (
     ActionDenied,
@@ -111,6 +111,7 @@ __all__ = [
     "canonical_bytes",
     "canonicalize",
     "context",
+    "idempotency_token",
     "needs_approval",
     "parse_conditions",
     "protect",

--- a/src/ctrlrun/control.py
+++ b/src/ctrlrun/control.py
@@ -41,6 +41,7 @@ from .effect import (
     UNRESOLVED_EFFECT,
     ReconcileOutcome,
     Reservation,
+    idempotency_token_for,
     resolve_effect_key,
     resolve_resource,
     template_placeholders,
@@ -149,6 +150,60 @@ class _Invocation:
 
 _CONTEXT: ContextVar[_Invocation] = ContextVar("ctrlrun_context")
 _PRESENTED_APPROVAL: ContextVar[str] = ContextVar("ctrlrun_approval")
+
+#: SPEC-v0.7 §4.3. The token of the attempt whose executor is running, and nothing else. Set
+#: around `executor()` in `_outcome`, and only where the attempt holds its reservation.
+_IDEMPOTENCY_TOKEN: ContextVar[str | None] = ContextVar("ctrlrun_idempotency_token", default=None)
+
+
+@contextmanager
+def _attempt_token(held_key: str | None, attempt: int) -> Iterator[None]:
+    """Bind this attempt's token for exactly the executor's run (SPEC-v0.7 §4.3).
+
+    Nothing is bound where the attempt holds no reservation: `held_key` is `None` for an action
+    with no effect key and for an observe-mode attempt whose reservation was refused, and handing
+    the second one attempt 1's token would name the real holder's attempt (§4.3).
+    """
+    if held_key is None:
+        yield
+        return
+    token = _IDEMPOTENCY_TOKEN.set(idempotency_token_for(held_key, attempt))
+    try:
+        yield
+    finally:
+        _IDEMPOTENCY_TOKEN.reset(token)
+
+
+def idempotency_token() -> str:
+    """The provider idempotency token for the attempt this executor is running (SPEC-v0.7 §4).
+
+    Send it to the provider as its idempotency key. It is
+    `ctrlrun.effect.idempotency_token_for(effect_key, attempt)` for the attempt that holds the
+    reservation, so it is stable across a `Control.resume` of the same attempt and **different
+    after a renewal**: a token stable across v0.1 §5.4's renewal would have the provider answer
+    the one retry the kernel permits with the cached failure of the attempt that failed (§4.1).
+
+    What it is for is reconciliation: a deterministic handle to ask the provider what became of
+    an attempt whose outcome is unknown, by a key the provider already indexes (§4.7). It does
+    not make a retry safe, and after an `AMBIGUOUS` outcome the kernel still refuses one.
+
+    Nothing is stored: the token is a pure function of two fields every receipt of an attempt
+    that ran already carries, so a receipt re-derives it with `idempotency_token_for` and a
+    `reconcile` hook reads the attempt off the record (§4.5).
+
+    **Outside an executor this raises `InvalidArgument`**, because a token invented outside an
+    attempt identifies nothing. So does an executor whose action has no effect key, an
+    observe-mode attempt whose reservation was refused, and a thread the executor started
+    without copying its context: a missing value is refused rather than guessed (§4.3).
+    """
+    token = _IDEMPOTENCY_TOKEN.get()
+    if token is None:
+        raise InvalidArgument(
+            "idempotency_token() is defined only inside an executor running an attempt that "
+            "holds its effect key. There is no attempt here to name, so there is no token "
+            "(SPEC-v0.7 §4.3)"
+        )
+    return token
 
 
 @contextmanager
@@ -1074,9 +1129,15 @@ class Control:
 
         `observation` turns every terminal receipt below into an `observed` one carrying what
         the executor did and what enforce mode would have done (§6.3).
+
+        SPEC-v0.7 §4.3. The idempotency token is bound around `executor()` and nowhere else,
+        for the attempt named by the key this attempt holds and the number the store assigned
+        it. `execute` and `resume` both arrive here, which is why a resumed leg reads the token
+        of the attempt it is resuming: `resume` passes `held.record.attempt` unchanged (§4.4).
         """
         try:
-            result = executor()
+            with _attempt_token(held_key, attempt):
+                result = executor()
         except Suspended as suspension:
             # SPEC-v0.2 §6.9 — no outcome, no receipt: the remote has not said what happened
             # and this attempt is not finished. Handled above the generic branch precisely so

--- a/src/ctrlrun/effect.py
+++ b/src/ctrlrun/effect.py
@@ -15,14 +15,16 @@ only way out of `AMBIGUOUS`, because it is the only one a human drives — arriv
 
 from __future__ import annotations
 
+import hashlib
 import re
+import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta
 from enum import StrEnum
 from typing import Any, Final, Literal
 
-from .action import Action
+from .action import Action, canonical_bytes
 from .errors import (
     AmbiguousEffect,
     CTRLRunError,
@@ -36,6 +38,11 @@ UNRESOLVED_EFFECT: Final = "effect_key_error"
 
 #: SPEC-v0.1 §5.3 E3 — a reservation is held for five minutes unless told otherwise.
 DEFAULT_LEASE: Final = timedelta(minutes=5)
+
+#: SPEC-v0.7 §4.2. The domain tag inside the idempotency token's canonical input. Versioned so
+#: a later derivation cannot collide with this one, and so a token can never equal a hash
+#: computed over the same pair for another purpose. Never a document on its own (§9.3).
+IDEMPOTENCY_SCHEMA: Final = "ctrlrun.idempotency/v1"
 
 #: `DuplicateEffect.state` values (SPEC-v0.1 §5.4).
 COMMITTED_EFFECT: Final = "committed"
@@ -417,3 +424,62 @@ def plan_lease_extension(
             f"which expires at {record.lease_expires_at!r}"
         )
     return replace(record, lease_expires_at=until, updated_at=now)
+
+
+def idempotency_token_for(effect_key: str, attempt: int) -> str:
+    """The provider idempotency token for one attempt on one effect key (SPEC-v0.7 §4.2).
+
+    A deterministic handle for reconciliation to observe **with**: an `AMBIGUOUS` effect can ask
+    the provider "did this attempt happen?" by a key the provider already indexes, without a
+    bespoke lookup per provider (§4.7). It gives nothing permission to act twice: after an
+    ambiguous outcome the kernel still refuses a blind retry, and that is unchanged.
+
+    Derived from `(effect_key, attempt)` and **never from the effect key alone** (§4.1). The
+    effect key is stable across v0.1 §5.4's renewal, so a provider sent the key would answer the
+    one retry the kernel permits *because the executor proved nothing happened* with the cached
+    failure of the attempt that failed. A renewal is a new attempt and gets a new token; a repeat
+    within one attempt, which is what provider-side deduplication is for, keeps the old one.
+
+    The canonical input carries a versioned domain tag and goes through `canonical_bytes`, so two
+    hosts agree byte for byte and the float rejection and the lone-surrogate refusal are inherited
+    rather than re-argued (`v0.6 §6.2`). SHA-256, truncated to 16 octets and rendered as a UUID of
+    **version 8**, because RFC 9562 puts a name-based UUID derived from SHA-256 in that space and
+    not in version 5's. 36 characters fits every limit §1.3 checked, and the effect key itself
+    does not appear in the token, which is what Stripe asks of callers whose keys are built from
+    arguments that may identify a person.
+
+    `attempt` must be an `int` that is not a `bool`, and at least 1. `canonical_bytes` accepts a
+    `bool`, since `bool` subclasses `int` and JSON has `true`, so left to the canonicalizer
+    `attempt=True` would derive a token nobody's attempt has: the check is here rather than
+    inherited, and T235 is what keeps it load-bearing.
+
+    An operator's effect key must name its effect uniquely across every store that shares one
+    provider account (§4.6): two stores deriving one key string for two different effects would
+    have the provider deduplicate the second against the first, and the kernel, which sees one
+    store, cannot check that.
+    """
+    if not isinstance(effect_key, str) or not effect_key:
+        raise InvalidArgument(
+            f"idempotency_token_for(effect_key={effect_key!r}) must be a non-empty string; a "
+            "token names an attempt on an effect key (SPEC-v0.7 §4.2)"
+        )
+    if isinstance(attempt, bool) or not isinstance(attempt, int):
+        raise InvalidArgument(
+            f"idempotency_token_for(attempt={attempt!r}) must be an int and not a bool; a bool "
+            "would canonicalize as true and derive a token no attempt has (SPEC-v0.7 §4.2)"
+        )
+    if attempt < 1:
+        raise InvalidArgument(
+            f"idempotency_token_for(attempt={attempt!r}) must be at least 1; attempts are "
+            "numbered from one (SPEC-v0.1 §5.4)"
+        )
+    digest = bytearray(
+        hashlib.sha256(
+            canonical_bytes(
+                {"schema": IDEMPOTENCY_SCHEMA, "effect_key": effect_key, "attempt": attempt}
+            )
+        ).digest()[:16]
+    )
+    digest[6] = (digest[6] & 0x0F) | 0x80  # version 8   (RFC 9562 §4.2, §5.8)
+    digest[8] = (digest[8] & 0x3F) | 0x80  # variant 10  (RFC 9562 §4.1)
+    return str(uuid.UUID(bytes=bytes(digest)))

--- a/src/ctrlrun/verify/guarantees.py
+++ b/src/ctrlrun/verify/guarantees.py
@@ -62,6 +62,16 @@ GUARANTEES: Final = (
             "v0.7 §8 T213",
         ),
     ),
+    Guarantee(
+        "G14",
+        "token changes across a renewal",
+        (
+            "v0.1 §5.4",
+            "v0.7 §8 T232",
+            "v0.7 §8 T233",
+            "v0.7 §8 T238",
+        ),
+    ),
 )
 
 #: By id, for `--only` and for the report. Insertion order is catalogue order.
@@ -141,6 +151,17 @@ STORE_READS_APPLICATION_CLOCK: Final = (
     "to diverge from; pass --store-url postgresql://… to grade this"
 )
 
+#: G14's note, printed once beneath the table (SPEC-v0.7 §8.9, §4.6). Not an N/A reason and not
+#: a finding: the token is a function of `(effect_key, attempt)` and nothing else, so two stores
+#: that share a provider account derive one token wherever their effect-key strings coincide.
+#: Verify sees one store and cannot check it, and a guarantee that stayed silent about the one
+#: thing it cannot see would be read as having checked it.
+EFFECT_KEY_SCOPE_NOTE: Final = (
+    "a token is unique only as far as your effect keys are: two stores sharing a provider "
+    "account must not produce the same effect-key string for different effects, and nothing "
+    "here can check that"
+)
+
 #: `--only` (§4.6).
 NOT_SELECTED: Final = "not selected"
 
@@ -152,6 +173,7 @@ __all__ = [
     "CANDIDATE_BOUND",
     "CATALOGUE",
     "CONTROL_FAILED",
+    "EFFECT_KEY_SCOPE_NOTE",
     "EFFECT_TEMPLATE_NOTE",
     "EVERY_ACTION_DENIED",
     "GRANT_ALREADY_EXPIRED",

--- a/src/ctrlrun/verify/report.py
+++ b/src/ctrlrun/verify/report.py
@@ -19,7 +19,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any, Final
 
-from .guarantees import CATALOGUE, EFFECT_TEMPLATE_NOTE, GUARANTEES
+from .guarantees import CATALOGUE, EFFECT_KEY_SCOPE_NOTE, EFFECT_TEMPLATE_NOTE, GUARANTEES
 
 #: SPEC-v0.4 §4.2 — the schema of one `ctrlrun verify --json` document.
 REPORT_SCHEMA: Final = "ctrlrun.verify/v1"
@@ -257,6 +257,14 @@ class Report:
                 lines += _wrapped_note(str(note))
             if result.counterexample is not None:
                 lines += [f"     {line}" for line in result.counterexample.to_text().split("\n")]
+        if any(
+            result.id == "G14" and result.status in (Status.PASS, Status.FAIL)
+            for result in self.guarantees
+        ):
+            # SPEC-v0.7 §8.9. Beneath the table rather than under G14's own row, because it is
+            # not a reason for G14's status: it is the one thing a single-store run cannot check
+            # (§4.6), and a guarantee silent about that would read as having checked it.
+            lines += _wrapped_note(EFFECT_KEY_SCOPE_NOTE)
         lines.append("")
         lines.append(self.summary_line())
         return "\n".join(lines)
@@ -482,6 +490,7 @@ __all__ = [
     "BADGE_LABEL",
     "BADGE_PASS_COLOR",
     "CLASS_NAME",
+    "EFFECT_KEY_SCOPE_NOTE",
     "EFFECT_TEMPLATE_NOTE",
     "REPORT_SCHEMA",
     "SUITE_NAME",

--- a/src/ctrlrun/verify/scenarios.py
+++ b/src/ctrlrun/verify/scenarios.py
@@ -51,8 +51,14 @@ from ..authority import (
     Subject,
     contained_dimension,
 )
-from ..control import Control, context, protect
-from ..effect import EffectRecord, EffectState, resolve_effect_key, resolve_resource
+from ..control import Control, context, idempotency_token, protect
+from ..effect import (
+    EffectRecord,
+    EffectState,
+    idempotency_token_for,
+    resolve_effect_key,
+    resolve_resource,
+)
 from ..errors import (
     ActionDenied,
     AmbiguousEffect,
@@ -2300,6 +2306,128 @@ class Engine:
         finally:
             for store in opened:
                 store.close()
+
+    # --- G14: the provider token changes across a renewal ---------------------------------
+
+    def g14(self) -> GuaranteeResult:
+        """SPEC-v0.7 §8.9. As G5, it needs one action with an `effect:` template.
+
+        The observable is the renewal: attempt 1's executor reads the token and reports that
+        nothing happened, attempt 2's reads it and commits, the two differ, and each is the
+        derivation from its own receipt's `effect_key` and `attempt`. That last clause is what a
+        kernel returning a fresh random string on every read would fail.
+
+        The control runs **first**, and catches the two kernels the observable cannot: one whose
+        answer moves within a single attempt, and one that sets the context variable and never
+        resets it. The second would pass the observable, because every executor would still read
+        its own attempt's value; it fails where a caller outside any attempt is handed the last
+        attempt's token.
+        """
+        selection = self.select(needs_effect=True)
+        if selection is None:
+            return self.na(
+                "G14",
+                self.unselected(reg.NO_EFFECT_TEMPLATE),
+                **self.unselected_detail(reg.EFFECT_TEMPLATE_NOTE),
+            )
+        control, store, recorder, _ = self._control_for("G14", selection)
+
+        def body(detail: dict[str, Any]) -> None:
+            key = str(selection.effect_key)
+            failed_attempt: list[str] = []
+
+            def read_twice_then_report_nothing() -> Any:
+                failed_attempt.append(idempotency_token())
+                failed_attempt.append(idempotency_token())
+                raise NotExecuted("ctrlrun-verify: the remote did nothing")
+
+            first = selection.build()
+            with suppress(NotExecuted):
+                self.execute(
+                    control,
+                    first,
+                    _Executor(read_twice_then_report_nothing),
+                    key,
+                    self.approve(control, store, first, selection),
+                )
+            _expect_control(
+                len(failed_attempt) == 2 and failed_attempt[0] == failed_attempt[1],
+                "one attempt reads one token, however often it asks",
+                f"the executor read {failed_attempt!r}",
+            )
+            answered: list[object] = []
+            try:
+                answered.append(idempotency_token())
+            except InvalidArgument:
+                pass
+            except Exception as raised:
+                answered.append(raised)
+            _expect_control(
+                not answered,
+                "the accessor outside any executor raises InvalidArgument",
+                f"a caller outside every attempt was answered with {answered[0]!r}"
+                if answered
+                else "",
+            )
+            failed = store.get_effect(key)
+            _expect_control(
+                failed is not None and failed.state is EffectState.FAILED,
+                "an executor that raises NotExecuted leaves the record FAILED and renewable",
+                f"the record is {None if failed is None else failed.state}",
+            )
+
+            renewed: list[str] = []
+
+            def read_then_commit() -> Any:
+                renewed.append(idempotency_token())
+                return f"{APPROVER}-result"
+
+            retry = selection.build()
+            admitted = self.execute(
+                control,
+                retry,
+                _Executor(read_then_commit),
+                key,
+                self.approve(control, store, retry, selection),
+            )
+            _expect_control(
+                admitted.result is ReceiptResult.COMMITTED and len(renewed) == 1,
+                "the renewal after NotExecuted is admitted and executes",
+                f"it ended {admitted.result} after {len(renewed)} reads",
+            )
+            _expect(
+                failed_attempt[0] != renewed[0],
+                "the renewal carries a different token from the attempt that failed",
+                "both attempts were given the same token, which a provider would answer with "
+                "the cached failure of the first",
+            )
+            ran = sorted(
+                (
+                    receipt
+                    for receipt in store.receipts()
+                    if receipt.effect_key == key
+                    and receipt.result in (ReceiptResult.FAILED, ReceiptResult.COMMITTED)
+                ),
+                key=lambda receipt: receipt.attempt or 0,
+            )
+            derived = [
+                idempotency_token_for(str(receipt.effect_key), receipt.attempt or 0)
+                for receipt in ran
+            ]
+            _expect(
+                derived == [failed_attempt[0], renewed[0]],
+                "each attempt's token is the derivation from its own receipt",
+                f"the receipts of attempts {[receipt.attempt for receipt in ran]} re-derive "
+                f"{derived!r}, and the executors read "
+                f"{[failed_attempt[0], renewed[0]]!r}",
+            )
+            detail["attempts"] = [receipt.attempt for receipt in ran]
+            detail["summary"] = "attempt 1 and its renewal carry different tokens"
+
+        try:
+            return self.graded("G14", selection, store, recorder, body)
+        finally:
+            store.close()
 
 
 @dataclass(frozen=True)

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -1,0 +1,837 @@
+"""The provider idempotency token. Build-list item 3 of v0.7; SPEC-v0.7 §4, §8.3 T232-T239.
+
+**The token is derived from `(effect_key, attempt)`, never from the effect key alone** (§4.1).
+A token stable across `v0.1 §5.4`'s renewal would be answered by the provider with its cached
+failure, so the one retry the kernel permits because the executor proved nothing happened would
+never reach the provider. T232 is the test this item exists for.
+
+Nothing here says the token makes a retry safe. After `AMBIGUOUS` the kernel still refuses a
+blind retry; the token is a deterministic handle for reconciliation to observe *with* (§4.7).
+
+The tests that need a server skip without `CTRLRUN_TEST_POSTGRES`. The derivation, the accessor's
+refusals, the renewal on the two shipped backends, the resumed leg and G14 all run without one.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import uuid
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from ctrlrun import (
+    Action,
+    Control,
+    InMemoryStateStore,
+    InvalidArgument,
+    NotExecuted,
+    Policy,
+    Principal,
+    SQLiteStateStore,
+    Suspended,
+    context,
+    idempotency_token,
+    protect,
+)
+from ctrlrun.effect import EffectState, idempotency_token_for
+from ctrlrun.receipt import ReceiptResult
+from ctrlrun.verify import Status
+from ctrlrun.verify import guarantees as reg
+from ctrlrun.verify import run as run_verify
+
+URL = os.environ.get("CTRLRUN_TEST_POSTGRES")
+
+postgres = pytest.mark.skipif(
+    not URL, reason="CTRLRUN_TEST_POSTGRES is not set; no server to run against"
+)
+
+#: §4.2's worked example, pinned so a change to the derivation is a red test (T235).
+PINNED_KEY = "refund:txn_1"
+PINNED_TOKEN = "382ee448-97da-8107-b674-8c253650d93f"
+PINNED_ATTEMPT_2 = "28bb40af-814c-8fb6-ba63-e8663b1c036d"
+PINNED_OTHER_KEY = "89977bc9-d128-8ae8-871f-f5265155e60f"
+
+ALLOW = """
+schema: ctrlrun.policy/v1
+actions:
+  stripe.refund:
+    decision: allow
+"""
+
+OBSERVE = """
+schema: ctrlrun.policy/v3
+mode: observe
+actions:
+  stripe.refund:
+    decision: allow
+"""
+
+CONTINUATION = "opaque-state-from-the-server"
+
+
+def an_action(payment_id: str = "txn_1") -> Action:
+    return Action(
+        "stripe.refund", {"payment_id": payment_id, "amount": 200}, Principal("refund-agent")
+    )
+
+
+@pytest.fixture
+def sqlite_store(tmp_path):
+    store = SQLiteStateStore(tmp_path / "state.db")
+    yield store
+    store.close()
+
+
+@pytest.fixture(params=["in-memory", "sqlite"])
+def store(request, tmp_path):
+    opened = (
+        InMemoryStateStore()
+        if request.param == "in-memory"
+        else SQLiteStateStore(tmp_path / "state.db")
+    )
+    yield opened
+    opened.close()
+
+
+@pytest.fixture
+def pg_schema():
+    """A schema of this test's own, dropped afterwards."""
+    from ctrlrun.postgres import PostgresStateStore
+
+    assert URL
+    name = f"token_{uuid.uuid4().hex[:12]}"
+    PostgresStateStore.create_schema(URL, name)
+    opened: list = []
+    yield name, opened
+    for store in opened:
+        store.close()
+    PostgresStateStore.drop_schema(URL, name)
+
+
+def _pg_store(pg_schema):
+    from ctrlrun.postgres import PostgresStateStore
+
+    name, opened = pg_schema
+    store = PostgresStateStore(URL, schema=name)
+    opened.append(store)
+    return store
+
+
+def _control(store, policy: str = ALLOW) -> Control:
+    return Control(Policy.from_yaml(policy), store)
+
+
+def _receipts_for(store, key: str) -> list:
+    return [receipt for receipt in store.receipts() if receipt.effect_key == key]
+
+
+# --- T232: a FAILED renewal changes the token -------------------------------------------------
+
+
+def _renewal(control, key: str = PINNED_KEY) -> list[str]:
+    """Attempt 1 reads the token and reports nothing happened; attempt 2 reads it and commits."""
+    read: list[str] = []
+
+    def failing():
+        read.append(idempotency_token())
+        raise NotExecuted("the remote did nothing")
+
+    def committing():
+        read.append(idempotency_token())
+        return "ok"
+
+    with pytest.raises(NotExecuted):
+        control.execute(an_action(), failing, key)
+    control.execute(an_action(), committing, key)
+    return read
+
+
+def test_T232_a_failed_renewal_changes_the_token(store):
+    """**The test item 3 exists for.** SPEC-v0.7 §4.1, §8.3.
+
+    A token stable here is a token the provider answers with the cached failure of the attempt
+    that failed, for the one retry `v0.1 §5.4` permits *because the executor proved nothing
+    happened*.
+    """
+    control = _control(store)
+
+    read = _renewal(control)
+
+    assert len(read) == 2, "both attempts ran and both read a token"
+    assert read[0] != read[1], "the renewal is a new attempt and must carry a new token"
+    assert store.get_effect(PINNED_KEY).state is EffectState.COMMITTED
+    receipts = _receipts_for(store, PINNED_KEY)
+    assert [receipt.attempt for receipt in receipts] == [1, 2]
+    assert [idempotency_token_for(r.effect_key, r.attempt) for r in receipts] == read
+
+
+@postgres
+def test_T232_a_failed_renewal_changes_the_token_on_postgres(pg_schema):
+    store = _pg_store(pg_schema)
+    control = _control(store)
+
+    read = _renewal(control)
+
+    assert read[0] != read[1]
+    receipts = _receipts_for(store, PINNED_KEY)
+    assert [receipt.attempt for receipt in receipts] == [1, 2]
+    assert [idempotency_token_for(r.effect_key, r.attempt) for r in receipts] == read
+
+
+def test_T232_the_two_attempts_are_the_derivation_of_their_own_numbers(store):
+    """The mutant this catches: a kernel returning a fresh random string on every read."""
+    control = _control(store)
+
+    read = _renewal(control)
+
+    assert read == [
+        idempotency_token_for(PINNED_KEY, 1),
+        idempotency_token_for(PINNED_KEY, 2),
+    ]
+    assert read == [PINNED_TOKEN, PINNED_ATTEMPT_2]
+
+
+# --- T233: stable within one attempt, across Control.resume -----------------------------------
+
+
+def test_T233_two_reads_in_one_executor_are_equal(store):
+    control = _control(store)
+    read: list[str] = []
+
+    control.execute(
+        an_action(), lambda: read.extend([idempotency_token(), idempotency_token()]), PINNED_KEY
+    )
+
+    assert read[0] == read[1]
+
+
+def test_T233_a_resumed_leg_reads_the_same_token(store):
+    """`Control.resume` does not change `attempt` (§4.4), so it does not change the token.
+
+    If resume ever changes the attempt, this is the test that says so.
+    """
+    control = _control(store)
+    read: list[str] = []
+
+    def suspending():
+        read.append(idempotency_token())
+        raise Suspended(CONTINUATION)
+
+    with pytest.raises(Suspended):
+        control.execute(an_action(), suspending, PINNED_KEY)
+    before = store.get_effect(PINNED_KEY).attempt
+
+    def resumed():
+        read.append(idempotency_token())
+        return "ok"
+
+    receipt = control.resume(CONTINUATION, resumed)
+
+    assert read[0] == read[1], "a resumed leg is the same attempt with the same token"
+    assert store.get_effect(PINNED_KEY).attempt == before == receipt.attempt == 1
+    assert receipt.result is ReceiptResult.COMMITTED
+
+
+# --- T234: two keys at one attempt differ -----------------------------------------------------
+
+
+def test_T234_two_keys_at_one_attempt_differ():
+    assert idempotency_token_for("refund:txn_1", 1) != idempotency_token_for("refund:txn_2", 1)
+
+
+def test_T234_two_keys_at_one_attempt_differ_through_the_accessor(store):
+    control = _control(store)
+    read: list[str] = []
+
+    for key in ("refund:txn_1", "refund:txn_2"):
+        control.execute(an_action(), lambda: read.append(idempotency_token()), key)
+
+    assert read[0] != read[1]
+    assert read == [PINNED_TOKEN, PINNED_OTHER_KEY]
+
+
+# --- T235: a pure function, pinned ------------------------------------------------------------
+
+
+def test_T235_the_derivation_is_pinned_as_a_literal():
+    """§4.2's worked example. A change to the derivation is a red test, not a silent change."""
+    assert idempotency_token_for("refund:txn_1", 1) == "382ee448-97da-8107-b674-8c253650d93f"
+    assert idempotency_token_for("refund:txn_1", 2) == "28bb40af-814c-8fb6-ba63-e8663b1c036d"
+    assert idempotency_token_for("refund:txn_2", 1) == "89977bc9-d128-8ae8-871f-f5265155e60f"
+
+
+def test_T235_the_token_is_a_uuid_of_version_8_and_the_rfc_9562_variant():
+    parsed = uuid.UUID(PINNED_TOKEN)
+
+    assert parsed.version == 8, "RFC 9562: a name-based UUID from SHA-256 is in the v8 space"
+    assert (parsed.int >> 62) & 0b11 == 0b10, "variant 10"
+    assert len(PINNED_TOKEN) == 36
+    assert PINNED_TOKEN.isascii() and PINNED_TOKEN.lower() == PINNED_TOKEN
+
+
+def test_T235_another_process_derives_the_same_string():
+    """A pure function of two values: another process, with no store and no `Control`, agrees."""
+    finished = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from ctrlrun.effect import idempotency_token_for as t;"
+            "print(t('refund:txn_1', 1), t('refund:txn_1', 2))",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert finished.returncode == 0, finished.stderr
+    assert finished.stdout.split() == [PINNED_TOKEN, PINNED_ATTEMPT_2]
+
+
+def test_T235_the_same_pair_against_sqlite_gives_the_pinned_string(sqlite_store):
+    control = _control(sqlite_store)
+    read: list[str] = []
+
+    control.execute(an_action(), lambda: read.append(idempotency_token()), PINNED_KEY)
+
+    assert read == [PINNED_TOKEN]
+
+
+@postgres
+def test_T235_the_same_pair_against_postgres_gives_the_pinned_string(pg_schema):
+    control = _control(_pg_store(pg_schema))
+    read: list[str] = []
+
+    control.execute(an_action(), lambda: read.append(idempotency_token()), PINNED_KEY)
+
+    assert read == [PINNED_TOKEN]
+
+
+@pytest.mark.parametrize(
+    ("key", "attempt", "names"),
+    [
+        (PINNED_KEY, 1.0, "attempt=1.0"),
+        (PINNED_KEY, True, "attempt=True"),
+        (PINNED_KEY, 0, "attempt=0"),
+        (PINNED_KEY, -1, "attempt=-1"),
+        ("", 1, "effect_key=''"),
+        (None, 1, "effect_key=None"),
+    ],
+)
+def test_T235_the_derivation_refuses_what_it_cannot_name(key, attempt, names):
+    """**The `bool` row is load-bearing**: `canonical_bytes` accepts `True`, since `bool` is a
+    subclass of `int` and JSON has `true`, so without the function's own check
+    `idempotency_token_for(key, True)` would return a token nobody's attempt has (§4.2).
+
+    The message is asserted and not only the type. Three guards refuse here, and a test that read
+    the type alone could not tell you which one ran, or notice a guard that had stopped running
+    because an earlier one happened to cover its case.
+    """
+    with pytest.raises(InvalidArgument) as raised:
+        idempotency_token_for(key, attempt)
+
+    assert names in str(raised.value)
+
+
+def test_T235_the_bool_refusal_is_the_functions_own():
+    """Without this the `bool` row above is a negative test against behaviour the library
+    refuses anyway. `canonical_bytes` **accepts** a `bool`, so the refusal has to be the
+    function's own check and the row is load-bearing (§4.2)."""
+    from ctrlrun.action import canonical_bytes
+
+    assert canonical_bytes({"attempt": True}) == b'{"attempt":true}'
+
+
+# --- T236: outside an executor it fails closed ------------------------------------------------
+
+
+def test_T236_at_the_top_level_it_fails_closed():
+    with pytest.raises(InvalidArgument) as raised:
+        idempotency_token()
+
+    assert not isinstance(raised.value, NotExecuted), (
+        "NotExecuted would be turned into a FAILED record and a permitted retry (§4.3)"
+    )
+
+
+def test_T236_inside_evaluate_it_fails_closed(store):
+    """`evaluate` runs no executor and holds no attempt, so there is no token to name."""
+    control = _control(store)
+    control.evaluate(an_action())
+
+    with pytest.raises(InvalidArgument):
+        idempotency_token()
+
+    assert list(store.receipts()) == []
+    assert store.get_effect(PINNED_KEY) is None
+
+
+def test_T236_an_action_with_no_effect_key_fails_closed(store):
+    control = _control(store)
+    raised: list[BaseException] = []
+
+    def executor():
+        try:
+            idempotency_token()
+        except BaseException as exc:
+            raised.append(exc)
+        return "ok"
+
+    receipt = control.execute(an_action(), executor)
+
+    assert len(raised) == 1
+    assert isinstance(raised[0], InvalidArgument)
+    assert not isinstance(raised[0], NotExecuted)
+    assert receipt.result is ReceiptResult.COMMITTED
+
+
+def test_T236_an_observe_mode_attempt_that_holds_nothing_fails_closed(store):
+    """§4.3. Handing it attempt 1's token would name the real holder's attempt."""
+    store.reserve_effect(PINNED_KEY, "someone-else", timedelta(minutes=5))
+    store.begin_execution(PINNED_KEY, "someone-else")
+    before = store.get_effect(PINNED_KEY)
+    control = _control(store, OBSERVE)
+    raised: list[BaseException] = []
+
+    def executor():
+        try:
+            idempotency_token()
+        except BaseException as exc:
+            raised.append(exc)
+        return "ok"
+
+    control.execute(an_action(), executor, PINNED_KEY)
+
+    assert len(raised) == 1, "the observe-mode executor ran and asked"
+    assert isinstance(raised[0], InvalidArgument)
+    assert not isinstance(raised[0], NotExecuted)
+    assert store.get_effect(PINNED_KEY) == before, "the real holder's record is untouched"
+
+
+def test_T236_an_observe_mode_attempt_that_holds_its_key_is_answered(store):
+    """The control for the test above: observe mode reserves, and a held attempt has a token."""
+    control = _control(store, OBSERVE)
+    read: list[str] = []
+
+    control.execute(an_action(), lambda: read.append(idempotency_token()), PINNED_KEY)
+
+    assert read == [PINNED_TOKEN]
+
+
+def test_T236_a_thread_without_the_context_fails_closed(store):
+    """A context variable does not cross a thread unless the caller copies it, and a missing
+    value is refused rather than guessed (§4.3)."""
+    control = _control(store)
+    raised: list[BaseException] = []
+    read: list[str] = []
+
+    def executor():
+        read.append(idempotency_token())
+
+        def elsewhere():
+            try:
+                idempotency_token()
+            except BaseException as exc:
+                raised.append(exc)
+
+        thread = threading.Thread(target=elsewhere)
+        thread.start()
+        thread.join(timeout=10)
+        assert not thread.is_alive(), "the thread finished rather than hanging the suite"
+        return "ok"
+
+    control.execute(an_action(), executor, PINNED_KEY)
+
+    assert read == [PINNED_TOKEN], "the executor's own read still answers"
+    assert len(raised) == 1
+    assert isinstance(raised[0], InvalidArgument)
+    assert not isinstance(raised[0], NotExecuted)
+    assert store.get_effect(PINNED_KEY).state is EffectState.COMMITTED
+
+
+def test_T236_after_an_executor_returns_the_token_is_gone(store):
+    """The leak this closes: a context variable set and never reset hands the next caller the
+    last attempt's token. G14's control catches the same thing (§8.9)."""
+    control = _control(store)
+
+    control.execute(an_action(), lambda: idempotency_token(), PINNED_KEY)
+
+    with pytest.raises(InvalidArgument):
+        idempotency_token()
+
+
+def test_T236_after_an_executor_raised_the_token_is_gone(store):
+    control = _control(store)
+
+    with pytest.raises(NotExecuted):
+        control.execute(
+            an_action(),
+            lambda: (_ for _ in ()).throw(NotExecuted("nothing ran")),
+            PINNED_KEY,
+        )
+
+    with pytest.raises(InvalidArgument):
+        idempotency_token()
+
+
+# --- T237: the zero-argument executor is unchanged --------------------------------------------
+
+
+def test_T237_a_0_6_1_executor_runs_untouched_through_protect(store):
+    control = _control(store)
+    calls: list[tuple] = []
+
+    @protect("stripe.refund", effect="refund:{payment_id}", control=control)
+    def issue_refund(payment_id: str, amount: int) -> str:
+        calls.append((payment_id, amount))
+        return "re_1"
+
+    with context(agent="refund-agent"):
+        assert issue_refund(payment_id="txn_1", amount=200) == "re_1"
+
+    assert calls == [("txn_1", 200)]
+    assert store.get_effect(PINNED_KEY).state is EffectState.COMMITTED
+
+
+def test_T237_a_0_6_1_executor_runs_untouched_through_execute(store):
+    control = _control(store)
+
+    receipt = control.execute(an_action(), lambda: "re_1", PINNED_KEY)
+
+    assert receipt.result is ReceiptResult.COMMITTED
+    assert receipt.attempt == 1
+
+
+def test_T237_a_0_6_1_executor_runs_untouched_through_an_adapter(store):
+    """The adapter surface of `v0.5`: an interrupt provider answering a `wait=True` tool."""
+    from ctrlrun.adapter import ApprovalAnswer, InterruptApprovalProvider, PendingApproval
+
+    class Interrupt:
+        framework = "double"
+        carries_approved_arguments = True
+
+        def __init__(self) -> None:
+            self.calls: list[PendingApproval] = []
+
+        def interrupt(self, pending: PendingApproval) -> ApprovalAnswer:
+            self.calls.append(pending)
+            return ApprovalAnswer(
+                granted=True,
+                approver="double:interrupt",
+                approved_arguments=dict(pending.arguments),
+            )
+
+    interrupt = Interrupt()
+    control = Control(
+        Policy.from_yaml(
+            "schema: ctrlrun.policy/v1\nactions:\n  stripe.refund:\n    decision: approve\n"
+        ),
+        store,
+        InterruptApprovalProvider(store, interrupt),
+    )
+    calls: list[tuple] = []
+
+    @protect("stripe.refund", effect="refund:{payment_id}", wait=True, control=control)
+    def issue_refund(payment_id: str, amount: int) -> str:
+        calls.append((payment_id, amount))
+        return "re_1"
+
+    with context(agent="refund-agent"):
+        assert issue_refund(payment_id="txn_1", amount=200) == "re_1"
+
+    assert calls == [("txn_1", 200)]
+    assert len(interrupt.calls) == 1
+
+
+def test_T237_a_0_6_1_executor_runs_untouched_through_the_gateway(sqlite_store):
+    """The gateway builds its own zero-argument executor; nothing about it changes (§4.3)."""
+    pytest.importorskip("httpx", reason="the gateway extra is not installed")
+    from ctrlrun.gateway.outcome import UpstreamResult
+    from ctrlrun.gateway.server import Gateway, GatewayConfig
+
+    policy = """
+schema: ctrlrun.policy/v2
+actions:
+  mcp.acme.create_refund:
+    effect: "refund:{payment_id}"
+    decision: allow
+"""
+    reply = json.dumps(
+        {"jsonrpc": "2.0", "id": 1, "result": {"resultType": "complete", "content": []}}
+    ).encode()
+
+    def forwarder(body, headers, *, fresh):
+        return (
+            UpstreamResult(result_type="complete"),
+            reply,
+            200,
+            {"Content-Type": "application/json"},
+        )
+
+    gateway = Gateway(
+        GatewayConfig(
+            upstream="http://127.0.0.1:1/mcp", alias="acme", principal_header="X-Agent", port=0
+        ),
+        Control(Policy.from_yaml(policy), sqlite_store),
+        forwarder,
+    )
+    call = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "create_refund", "arguments": {"payment_id": "txn_1", "amount": 200}},
+    }
+
+    response = gateway.handle(
+        json.dumps(call).encode(),
+        {
+            "MCP-Protocol-Version": "2026-07-28",
+            "Mcp-Method": "tools/call",
+            "Mcp-Name": "create_refund",
+            "X-Agent": "refund-agent",
+        },
+    )
+
+    assert response.status == 200, response
+    assert sqlite_store.get_effect(PINNED_KEY).state is EffectState.COMMITTED
+    assert [receipt.result for receipt in sqlite_store.receipts()] == [ReceiptResult.COMMITTED]
+
+
+# --- T238: a receipt re-derives its token -----------------------------------------------------
+
+
+def test_T238_every_receipt_of_an_attempt_that_ran_re_derives_its_token(store):
+    """§4.5. The token is not a receipt field because it is derivable from two that are."""
+    control = _control(store)
+    renewal = _renewal(control)
+
+    resumed: list[str] = []
+
+    def suspending():
+        resumed.append(idempotency_token())
+        raise Suspended(CONTINUATION)
+
+    with pytest.raises(Suspended):
+        control.execute(an_action("txn_9"), suspending, "refund:txn_9")
+    control.resume(CONTINUATION, lambda: resumed.append(idempotency_token()) or "ok")
+
+    read = {PINNED_KEY: renewal, "refund:txn_9": resumed}
+    ran = [
+        receipt
+        for receipt in store.receipts()
+        if receipt.result in (ReceiptResult.COMMITTED, ReceiptResult.FAILED)
+    ]
+    assert len(ran) == 3
+    for receipt in ran:
+        derived = idempotency_token_for(receipt.effect_key, receipt.attempt)
+        assert derived in read[receipt.effect_key], (
+            f"{receipt.effect_key} attempt {receipt.attempt} re-derives a token no executor read"
+        )
+    assert set(resumed) == {idempotency_token_for("refund:txn_9", 1)}
+
+
+# --- T239: G14 in verify ----------------------------------------------------------------------
+
+WITH_EFFECTS = """
+schema: ctrlrun.policy/v3
+mode: enforce
+actions:
+  acme.refund:
+    effect: "refund:{payment_id}"
+    resource: "payment:{payment_id}"
+    rules:
+      - when: { amount_gte: 0, amount_lte: 1000 }
+        decision: allow
+      - decision: deny
+  acme.read:
+    decision: allow
+"""
+
+NO_EFFECTS = """
+schema: ctrlrun.policy/v3
+mode: enforce
+actions:
+  acme.read:
+    decision: allow
+"""
+
+
+def _write(directory: Path, document: str) -> Path:
+    path = directory / "ctrlrun.yaml"
+    path.write_text(document, encoding="utf-8")
+    return path
+
+
+def _by_id(report):
+    return {result.id: result for result in report.guarantees}
+
+
+def _g14(tmp_path, document: str = WITH_EFFECTS):
+    report = run_verify(_write(tmp_path, document), only=("G14",))
+    return next(result for result in report.guarantees if result.id == "G14")
+
+
+def test_T239_G14_is_in_the_catalogue():
+    assert reg.CATALOGUE == "ctrlrun.guarantees/v3"
+    assert "G14" in reg.BY_ID
+    assert reg.BY_ID["G14"].descends_from, "a guarantee names the tests it is the deployed form of"
+
+
+def test_T239_G14_passes_against_a_document_with_an_effect_template(tmp_path):
+    result = _g14(tmp_path)
+
+    assert result.status is Status.PASS, (result.reason, result.counterexample)
+
+
+def test_T239_G14_is_not_applicable_where_no_action_declares_an_effect(tmp_path):
+    result = _g14(tmp_path, NO_EFFECTS)
+
+    assert result.status is Status.NOT_APPLICABLE
+    assert result.reason == reg.NO_EFFECT_TEMPLATE
+    assert result.status is not Status.PASS
+
+
+def _leak_the_context(monkeypatch):
+    """A kernel that sets the token and never resets it (§8.9).
+
+    It passes the observable: each executor still reads its own attempt's value. What it fails
+    is the control, where a caller outside any attempt is handed the last attempt's token.
+    """
+    from contextlib import contextmanager
+
+    from ctrlrun import control as control_module
+
+    @contextmanager
+    def leaking(held_key, attempt):
+        if held_key is not None:
+            control_module._IDEMPOTENCY_TOKEN.set(idempotency_token_for(held_key, attempt))
+        yield
+
+    monkeypatch.setattr(control_module, "_attempt_token", leaking)
+
+
+def _move_within_the_attempt(monkeypatch):
+    """An accessor whose answer moves within one attempt: the two reads differ.
+
+    Patched where the scenario reads it, as `_break_the_executor` patches what G1 to G5 run,
+    because the control's claim is about what the scenario observes.
+    """
+    from ctrlrun.verify import scenarios
+
+    counter = [0]
+
+    def moving() -> str:
+        counter[0] += 1
+        return f"ctrlrun-verify-moving-{counter[0]}"
+
+    monkeypatch.setattr(scenarios, "idempotency_token", moving)
+
+
+@pytest.mark.parametrize(
+    "break_it", [_leak_the_context, _move_within_the_attempt], ids=["leak", "moves"]
+)
+def test_T239_a_broken_positive_control_is_a_failure(tmp_path, monkeypatch, break_it):
+    """§1.3's guard, for G14. A control that does not behave as specified is FAIL with
+    `reason: "control failed"`, never PASS and never N/A."""
+    from ctrlrun.control import _IDEMPOTENCY_TOKEN
+
+    break_it(monkeypatch)
+    try:
+        result = _g14(tmp_path)
+    finally:
+        # The leak is the point of the mutant, so this test undoes it rather than leaving the
+        # next test in this process holding an attempt's token.
+        _IDEMPOTENCY_TOKEN.set(None)
+
+    if result.status is not Status.FAIL:
+        raise AssertionError(f"G14 reported {result.status} with a broken control")
+    assert result.reason == reg.CONTROL_FAILED
+    assert result.counterexample is not None
+
+
+def _flat(text: str) -> str:
+    """The report wraps its notes, so a phrase is matched against one line of words."""
+    return " ".join(text.split())
+
+
+def test_T239_the_effect_key_scope_note_is_printed_once(tmp_path):
+    """§4.6. The kernel sees one store and cannot check that two stores sharing a provider
+    account never produce one effect-key string for two different effects. Verify says so."""
+    report = run_verify(_write(tmp_path, WITH_EFFECTS))
+
+    flat = _flat(report.to_text())
+
+    assert flat.count("a token is unique only as far as your effect keys are") == 1
+    assert "nothing here can check that" in flat
+
+
+def test_T239_the_note_is_absent_where_G14_is_not_graded(tmp_path):
+    report = run_verify(_write(tmp_path, NO_EFFECTS))
+
+    assert "a token is unique only as far as" not in _flat(report.to_text())
+
+
+def test_T239_the_note_is_absent_where_G14_was_not_selected(tmp_path):
+    """`--only G1` grades no token, so the note is about nothing that ran (§4.6)."""
+    report = run_verify(_write(tmp_path, WITH_EFFECTS), only=("G1",))
+
+    assert _by_id(report)["G14"].status is Status.SKIPPED
+    assert "a token is unique only as far as" not in _flat(report.to_text())
+
+
+# --- the surface (§9.1, §9.2) -----------------------------------------------------------------
+
+
+def test_the_accessor_is_re_exported_at_package_import():
+    import ctrlrun
+
+    assert ctrlrun.idempotency_token is idempotency_token
+    assert "idempotency_token" in ctrlrun.__all__
+
+
+def test_the_token_is_not_a_receipt_field(store):
+    """§4.5. Storing it would be a second copy of a fact that could disagree with the first."""
+    control = _control(store)
+    control.execute(an_action(), lambda: "ok", PINNED_KEY)
+
+    (receipt,) = store.receipts()
+
+    assert "idempotency" not in json.dumps(receipt.to_dict())
+    assert idempotency_token_for(receipt.effect_key, receipt.attempt) == PINNED_TOKEN
+
+
+def test_the_domain_tag_is_versioned():
+    """§4.2. A later derivation cannot collide with this one, and a token can never equal a
+    hash computed over the same pair for another purpose."""
+    import hashlib
+
+    from ctrlrun.action import canonical_bytes
+
+    undomained = hashlib.sha256(
+        canonical_bytes({"effect_key": PINNED_KEY, "attempt": 1})
+    ).hexdigest()
+
+    assert PINNED_TOKEN.replace("-", "") != undomained[:32]
+
+
+def test_nothing_but_the_pair_reaches_the_derivation(store):
+    """§4.6. The token is a function of `(effect_key, attempt)` and nothing else, which is why
+    two stores that share a provider account derive identical tokens wherever their effect-key
+    strings coincide, and why the effect key must name its effect uniquely across them."""
+    first = _control(store)
+    read: list[str] = []
+    first.execute(an_action(), lambda: read.append(idempotency_token()), PINNED_KEY)
+
+    second = Control(Policy.from_yaml(ALLOW), InMemoryStateStore())
+    second.execute(
+        Action("stripe.refund", {"payment_id": "txn_1", "amount": 999}, Principal("other-agent")),
+        lambda: read.append(idempotency_token()),
+        PINNED_KEY,
+    )
+
+    assert read[0] == read[1] == PINNED_TOKEN

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -167,13 +167,15 @@ def test_T101_a_policy_with_no_approve_rule_makes_G1_and_G2_not_applicable(tmp_p
         # The `else` branch: either one reported `pass` is the defect this test exists for.
         assert results[gid].status is not Status.PASS
     assert report.applicable == report.passed + report.failed
-    # Ten in the catalogue; G1 and G2 for the missing approve band, G8 and G9 for the
-    # missing authority section. Six applicable, and the count is over those six.
-    # And G13, which is N/A on every SQLite run: SQLite has no clock of its own (SPEC-v0.7 §8.9).
-    assert report.applicable == 7
+    # G1 and G2 for the missing approve band, G8 and G9 for the missing authority section,
+    # and G13, which is N/A on every SQLite run: SQLite has no clock of its own (SPEC-v0.7
+    # §8.9). The rest are applicable, G14 among them, and the count is over those.
+    assert report.applicable == 8
     assert report.not_applicable == 5
     text = report.to_text()
-    assert "8/8" not in text
+    # The fraction is passes over applicable and never the catalogue size: with five N/As a
+    # thirteen-guarantee catalogue must not report thirteen over thirteen.
+    assert f"{len(reg.GUARANTEES)}/{len(reg.GUARANTEES)}" not in text
     assert f"{report.passed}/{report.applicable} declared guarantees pass." in text
     assert "5 not applicable: G1, G2, G8, G9, G13." in text
 
@@ -861,16 +863,17 @@ def test_observe_mode_is_refused_before_any_scenario_runs(tmp_path):
     assert "observe" in str(refused.value)
 
 
-def test_the_v1_payments_template_reports_six_over_six_with_six_not_applicable():
+def test_the_v1_payments_template_reports_six_over_six():
     """The definition of done, dogfooded rather than described (SPEC-v0.4 §4.1)."""
     report = run(V1_PAYMENTS)
 
     assert report.exit_code == 0
-    assert (report.passed, report.applicable, report.not_applicable) == (6, 6, 6)
+    assert (report.passed, report.applicable, report.not_applicable) == (6, 6, 7)
     text = report.to_text()
     assert "6/6 declared guarantees pass." in text
-    # G13 is N/A on SQLite, which has no clock of its own (SPEC-v0.7 §8.9).
-    assert "6 not applicable: G3, G4, G5, G8, G9, G13." in text
+    # G13 is N/A on SQLite, which has no clock of its own, and G14 joins G3, G4 and G5 where
+    # the effect template lives in the @protect decorator verify does not read (SPEC-v0.7 §8.9).
+    assert "7 not applicable: G3, G4, G5, G8, G9, G13, G14." in text
     assert "10/10" not in text
 
 

--- a/tests/test_verify_action.py
+++ b/tests/test_verify_action.py
@@ -152,12 +152,12 @@ def test_T118_the_two_configurations_really_do_report_those_shapes():
     templates = run(V1_PAYMENTS)
 
     assert authority.badge is not None
-    assert authority.badge["message"] == "verified 11/11"
+    assert authority.badge["message"] == "verified 12/12"
     # G13 only: SQLite has no clock of its own to diverge from (SPEC-v0.7 §8.9).
     assert authority.not_applicable == 1
     assert templates.badge is not None
     assert templates.badge["message"] == "verified 6/6"
-    assert templates.not_applicable == 6
+    assert templates.not_applicable == 7
 
 
 def test_T118_the_action_uploads_the_report_and_writes_a_job_summary():
@@ -210,7 +210,7 @@ def test_T119_the_colour_is_about_failures_and_has_no_amber_for_not_applicable(
     from ctrlrun.verify import scenarios
 
     passing = run(V1_PAYMENTS)
-    assert passing.not_applicable == 6
+    assert passing.not_applicable == 7
     assert passing.badge is not None
     assert passing.badge["color"] == BADGE_PASS_COLOR
 

--- a/tests/test_verify_authority.py
+++ b/tests/test_verify_authority.py
@@ -92,8 +92,8 @@ def test_T108_the_authority_example_exercises_G7_G8_and_G9():
     assert results["G9"].detail["dimensions_exercised"] == list(DIMENSIONS)
     assert results["G9"].detail["dimensions_unconstrained"] == []
     assert report.exit_code == 0
-    assert report.passed == 11
-    assert report.applicable == 11
+    assert report.passed == 12
+    assert report.applicable == 12
 
 
 def test_T108_G8_asserts_the_denial_by_reason_and_not_by_type(tmp_path, monkeypatch):

--- a/tests/test_verify_report.py
+++ b/tests/test_verify_report.py
@@ -106,10 +106,11 @@ def test_T113_the_summary_is_the_last_line_and_names_the_not_applicable_ids(tmp_
 
     assert last == report.summary_line()
     assert last.startswith(f"{report.passed}/{report.applicable} declared guarantees pass.")
-    # G13 is N/A on every SQLite run (SPEC-v0.7 §8.9): SQLite has no clock of its own.
-    assert "6 not applicable: G3, G4, G5, G8, G9, G13." in last
-    # The fraction is passes over applicable. A report with six N/As does not say 12/12.
-    assert "12/12" not in text
+    # G13 is N/A on every SQLite run (SPEC-v0.7 §8.9): SQLite has no clock of its own, and
+    # G14 needs the effect template this document keeps in the @protect decorator.
+    assert "7 not applicable: G3, G4, G5, G8, G9, G13, G14." in last
+    # The fraction is passes over applicable. A report with seven N/As does not say 13/13.
+    assert "13/13" not in text
 
 
 def test_T113_a_failing_report_names_the_subject_and_prints_the_counterexample(
@@ -132,9 +133,9 @@ def test_T113_a_failing_report_names_the_subject_and_prints_the_counterexample(
 @pytest.mark.parametrize(
     ("document", "expected"),
     [
-        (ALL_APPLICABLE, "9/9 declared guarantees pass. 3 not applicable"),
-        (WITH_NOT_APPLICABLE, "6/6 declared guarantees pass. 6 not applicable"),
-        (EMPTY, "0/0 declared guarantees pass. 12 not applicable"),
+        (ALL_APPLICABLE, "10/10 declared guarantees pass. 3 not applicable"),
+        (WITH_NOT_APPLICABLE, "6/6 declared guarantees pass. 7 not applicable"),
+        (EMPTY, "0/0 declared guarantees pass. 13 not applicable"),
     ],
     ids=["passing", "some-na", "all-na"],
 )
@@ -438,14 +439,14 @@ def test_T116_exit_3_for_an_internal_error(tmp_path, monkeypatch):
     assert "internal error" in result.stderr
 
 
-def test_T116_a_run_with_six_not_applicable_still_exits_0(tmp_path, monkeypatch):
+def test_T116_a_run_with_seven_not_applicable_still_exits_0(tmp_path, monkeypatch):
     """N/A never changes the exit code by itself."""
     monkeypatch.chdir(tmp_path)
 
     result = _cli(tmp_path, WITH_NOT_APPLICABLE)
 
     assert result.exit_code == 0
-    assert "6 not applicable" in result.stdout
+    assert "7 not applicable" in result.stdout
 
 
 def test_T116_json_and_junit_can_be_combined(tmp_path, monkeypatch):


### PR DESCRIPTION
v0.7 item 3 (SPEC-v0.7 §4, G14). A provider idempotency token derived from the effect key **and the attempt number**, reachable from inside an executor.

## What it does

- `ctrlrun.effect.idempotency_token_for(effect_key, attempt)`: SHA-256 over `canonical_bytes` of the pair under `IDEMPOTENCY_SCHEMA = "ctrlrun.idempotency/v1"`, truncated to 16 octets, version-8 and variant-10 nibbles, rendered as a 36-character UUID. It fits the documented limits of Stripe (255), Adyen (64), Square (45) and PayPal (38).
- `ctrlrun.idempotency_token()` reads a context variable bound around `executor()` only, and only where the attempt holds its reservation. Outside an executor it fails closed with `InvalidArgument`. The zero-argument executor signature does not change, so a 0.6.1 executor upgrades without a line moving.
- **G14** in verify, with its control outside the executor, and a printed note that the kernel cannot check effect-key uniqueness across deployments (SPEC §4.6).

## Why the attempt number

`effect_key` alone is stable across `v0.1 §5.4`'s renewal, so a provider would replay its cached failure for the one retry the kernel permits, the retry it permits *because the executor proved nothing happened*. A safety mechanism defeating a safety mechanism. T232 drives a `FAILED` renewal and asserts the token differs between attempt n and n+1.

The token is a deterministic handle for reconciliation to observe with. It never makes a retry safe: after `AMBIGUOUS` the kernel still refuses blind retry, and that does not change.

## Merge order: after item 3a

On Postgres, attempt numbers can still repeat, and a lost-`COMMIT` re-issue can return a stale number, until **item 3a** (`v0.7/3a-attempt-integrity`, in review) merges. The token's per-dispatch uniqueness rests on both. **This item is sound only once 3a merges, and 3a merges first.** T232 does not open that window and does not claim to; T246 and T246b are 3a's.

## Evidence

- Gate: 3005 passed / 67 skipped without Postgres, 3078 passed with. Baseline was 2945/65 and 3016.
- 60 tests (T232 to T239). Mutation table: 14 rows, all killed. Two equivalent mutants are stated rather than claimed.
- **M9 caught a defect in this item's own test**: the observe-mode case called `execute` without an effect key, so it exercised the keyless path instead of the refused-reservation window (mutation pattern 4). Fixed, and M9 then kills.
- The three worked values in SPEC §4.2 came out of the code byte for byte, including the pinned `382ee448-97da-8107-b674-8c253650d93f`, so a change to the derivation is a red test.

## Open

G14's spec text also names a `max_attempts` N/A, but that key is item 4's and does not exist yet. This PR implements only the G5-shaped N/A; item 4 adds the ceiling clause and its precedence rule (SPEC §9.6 item 5 already assigns it there).

The `api`, `readiness` and `badges` generators drift; item 6 regenerates them. The `docs` job is not a required check.
