### PR TITLE
Attempt numbers never repeat, and an outcome is never lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,17 @@ any change to one appears here.
   now catches every `CTRLRunError` from an outcome write, writes the receipt and the event whatever
   the store answered, names the refusal in both, and re-raises the caller's own exception. Nothing
   is reconciled on a record the attempt could not mark.
+- **Two bounds on the Postgres store's re-issues reset each other.** The stale re-issue and the
+  lost-commit re-issue of `docs/SPEC-v0.6.md` §4.3.2 each carry a flag that permits one attempt,
+  and neither passed the other's flag on, so a lost `COMMIT` inside a re-issue and a re-issue
+  inside a lost `COMMIT` alternated without end: a review drove both halves at once and reached
+  `RecursionError`, which is outside this library's closed set of errors, so no caller can
+  classify it and the record is left stranded. Both flags now travel through both re-issues.
+- **A receipt for an outcome the store refused did not say what the executor had done.** An
+  executor that returned normally and one that raised `NotExecuted` produced identical receipts,
+  naming the store's refusal and nothing else. For the first the remote very likely acted and for
+  the second it very likely did not, and with the effect record carrying neither, that is the one
+  fact whoever runs `ctrlrun resolve` has to go on. The receipt now carries both.
 - **A lapsed Postgres approval could be marked expired over a consumption.** `_expire` wrote
   `status = expired` on `approval_id` alone, from a read that saw `granted` past `expires_at`, so a
   consumption committing in between was overwritten and an approval that authorised a real effect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,11 +37,40 @@ any change to one appears here.
   wrote back the attempt number it had read. A caller that retries one `Action` reuses its
   `action_id`, so the same `action_id` and state could come round again at a newer attempt between
   the read and the write. A human's `ctrlrun resolve` decided on attempt 1 then wrote `FAILED` at
-  1 over attempt 2's unknown outcome, and the next renewal handed out attempt 2 a second time. Every
-  write to an effect record is now also conditioned on the attempt it read, and a write whose
-  record moved is refused with `DuplicateEffect` and leaves the newer attempt as it is. The fix
-  for the renewal above depends on this one: it holds only because the number can no longer move
-  backwards.
+  1 over attempt 2's unknown outcome, and the next renewal handed out attempt 2 a second time.
+  **On Postgres**, every write to an effect record is now also conditioned on the attempt it read,
+  and a write whose record moved is re-read rather than landed (SQLite's writes are already inside
+  the `BEGIN IMMEDIATE` that holds their read, and are unchanged). The fix for the renewal above
+  depends on this one: it holds only because the number can no longer move backwards. What this
+  closes is the race between a write's own read and its write. The window a *human* stands in is
+  longer, because `ctrlrun resolve` carries no attempt number: someone who inspected attempt 1 can
+  still resolve attempt 2's ambiguity. An attempt argument on the CLI would close that, and it is
+  not in this change.
+- **A Postgres write that carried an outcome could be refused and drop it.** With the condition
+  above in place, a `commit_effect` or `mark_ambiguous` whose record moved under it wrote nothing
+  and raised, so the effect record, which is what gates the next renewal, said nothing about an
+  attempt that may have acted: a review measured a renewal to a third attempt with a committed
+  refund recorded on no record at all. Both are now re-issued once against the re-read, so the
+  outcome lands on the record as it stands. `begin_execution` and `fail_effect` are still refused
+  there, because `FAILED` asserts that nothing happened and the newer attempt may be running.
+- **A refused write on a moved record claimed the wrong thing.** All of these were
+  `DuplicateEffect(state="in_progress")`, which means *another attempt holds a live reservation*,
+  and after a stale `resolve_effect` the record is `AMBIGUOUS` at a newer attempt, which is nobody's
+  reservation. The refusal now takes its type from what the re-read found, `AmbiguousEffect` or
+  `DuplicateEffect` with `committed` or `in_progress`, and its message names the move.
+- **An unknown outcome could vanish when the store refused to record it**, on both backends and
+  since before 0.6. `Control` caught two store refusals around its outcome writes, and a record a
+  human resolved `FAILED` while the attempt was still running answers a third: an executor that
+  raised `TimeoutError` then produced no receipt and no `EXECUTION_AMBIGUOUS` event, and the caller
+  was handed a store error about its own effect key instead of its executor's exception. `Control`
+  now catches every `CTRLRunError` from an outcome write, writes the receipt and the event whatever
+  the store answered, names the refusal in both, and re-raises the caller's own exception. Nothing
+  is reconciled on a record the attempt could not mark.
+- **A lapsed Postgres approval could be marked expired over a consumption.** `_expire` wrote
+  `status = expired` on `approval_id` alone, from a read that saw `granted` past `expires_at`, so a
+  consumption committing in between was overwritten and an approval that authorised a real effect
+  read `expired`. It is now conditioned on the status it read, as every other write on that table
+  already was.
 - **After a lost `COMMIT`, a Postgres reservation could return an attempt number it did not
   write.** Where a reservation's `COMMIT` was lost and the re-read found the write absent, 0.6.1
   re-issued it and then returned the reservation it had first planned, discarding the re-issue's.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ any change to one appears here.
   the attempt it was planned from, with the row count checked, and a stale renewal is refused with
   `DuplicateEffect`. SQLite carries the same condition, where it was already unreachable because
   `BEGIN IMMEDIATE` holds the read and the write together.
+- **A stale Postgres write could put an older attempt number back** (`docs/SPEC-v0.7.md` §5.6).
+  0.6.1's compare-and-set under `resolve_effect`, `extend_lease`, `hold_continuation`, the kept
+  `AMBIGUOUS` write and the four transitions matched `effect_key`, `action_id` and `state`, and
+  wrote back the attempt number it had read. A caller that retries one `Action` reuses its
+  `action_id`, so the same `action_id` and state could come round again at a newer attempt between
+  the read and the write. A human's `ctrlrun resolve` decided on attempt 1 then wrote `FAILED` at
+  1 over attempt 2's unknown outcome, and the next renewal handed out attempt 2 a second time. Every
+  write to an effect record is now also conditioned on the attempt it read, and a write whose
+  record moved is refused with `DuplicateEffect` and leaves the newer attempt as it is. The fix
+  for the renewal above depends on this one: it holds only because the number can no longer move
+  backwards.
 - **After a lost `COMMIT`, a Postgres reservation could return an attempt number it did not
   write.** Where a reservation's `COMMIT` was lost and the re-read found the write absent, 0.6.1
   re-issued it and then returned the reservation it had first planned, discarding the re-issue's.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,26 @@ any change to one appears here.
   build (uv's CPython 3.14 on macOS) aborted inside `ensurepip`, so all five release fixtures
   errored before a release was installed. The fixture now symlinks, as `python -m venv` does on
   POSIX.
+- **The Postgres store could hand out one attempt number twice** (`docs/SPEC-v0.7.md` §5.6).
+  0.6.1's renewal after `FAILED` read the record with a plain `SELECT` and then updated it on
+  `effect_key` and `state = 'failed'` alone. So a renewal planned against attempt *k* could land
+  after another process had renewed to *k+1*, run and failed, and write *k+1* a second time: two
+  dispatches, and two receipts, under one attempt number. The `UPDATE` is now also conditioned on
+  the attempt it was planned from, with the row count checked, and a stale renewal is refused with
+  `DuplicateEffect`. SQLite carries the same condition, where it was already unreachable because
+  `BEGIN IMMEDIATE` holds the read and the write together.
+- **After a lost `COMMIT`, a Postgres reservation could return an attempt number it did not
+  write.** Where a reservation's `COMMIT` was lost and the re-read found the write absent, 0.6.1
+  re-issued it and then returned the reservation it had first planned, discarding the re-issue's.
+  If another process had renewed, or inserted, and failed in between, the caller and its receipt
+  held attempt *k+1* while the record held *k+2*, and *k+1* was a number another dispatch had
+  already been handed. The reservation methods now return what the re-issue wrote.
+- **A lost `COMMIT` on a Postgres renewal could take another process's reservation for its own.**
+  0.6.1's re-read accepted any `RESERVED` record carrying the renewal's `action_id` as proof the
+  commit had landed. `docs/SPEC-v0.6.md` §4.3.3 had already ruled that out on the insert path,
+  because `action_id` is caller-supplyable, and a caller that rebuilt the same `Action` renews
+  under the same one. Two processes then held one attempt. The renewal's re-read now applies the
+  same whole-row identity check, and a row that is not its own write is refused.
 
 ### Documentation
 

--- a/docs/SPEC-v0.6.md
+++ b/docs/SPEC-v0.6.md
@@ -804,6 +804,12 @@ The shape of one reservation, inside one transaction:
    `DuplicateEffect(state=in_progress)`, because the record changed under us. SQLite already does
    exactly this, and the `WHERE` clause is the same one.
 
+*Amended by `SPEC-v0.7.md` §5.6 (its §9.6, item 8):* step 6's `UPDATE` is also conditioned on the
+attempt the plan renewed from, and every later compare-and-set below (`_transition`, and the write
+under `resolve_effect`, `extend_lease`, `hold_continuation` and §4.2.2's kept `AMBIGUOUS` write) on the
+attempt it read, because each writes that number back and `action_id` and `state` alone can come round
+again at a newer attempt. §12.3a there says what 0.6.1 did without it.
+
 **The retry at step 5 is bounded at one**, and the bound is not a performance choice. A second
 zero would mean the winner's record vanished between the re-read and the insert, which nothing in
 this protocol can do — there is no `DELETE` on `effects` anywhere in the codebase — so a second
@@ -1016,6 +1022,11 @@ A store that takes any branch of §4.3.2 MUST say which one, on the `ctrlrun.pos
 | `a2.row1.landed` | Table A2: the record is in the state we were writing, and ours; the commit landed |
 | `a2.row2.reissue` | Table A2: the record is still in a pre-state the operation may be issued from; the conditional `UPDATE` is re-issued |
 | `a2.row3.refuse` | Table A2: anything else; back through the same predicate, which refuses |
+
+*Amended by `SPEC-v0.7.md` §12.3a (its §9.6, item 8):* on a **renewal**, `a2.row1.landed` now requires
+§4.3.3's whole-row identity, as `a1.row1.ours` does, rather than `RESERVED` under our `action_id`: a
+second process renewing under the same `action_id` produced exactly that record. Anything else a
+renewal's re-read finds, other than `FAILED`, is `a2.row3.refuse`.
 
 **`a2.row2.reissue` does not mean "still ours", and saying so would claim more than the code
 checks.** On a *transition* the row is ours — `action_id` and a pre-state in `expected`. On a

--- a/docs/SPEC-v0.7.md
+++ b/docs/SPEC-v0.7.md
@@ -1087,11 +1087,23 @@ changes a store.**
 'failed'` (`postgres.py:787-800`). Between the read and the `UPDATE`, another process can renew to *k+1*,
 run, fail and commit, leaving the record `FAILED` again; the stale `UPDATE` then matches and writes *k+1*
 a second time. Item 3a conditions it on the attempt it planned from:
-`… WHERE effect_key = %s AND state = 'failed' AND attempt = %s`. That closes this race completely rather
-than narrowing it, because the attempt number is monotonic: only a renewal changes it, and every other
-transition carries it through unchanged (`state.py:281-342`, `_transitioned` and `_resolved`). A stale
-renewal then matches no row and is refused exactly as a lost renewal race is refused today
-(`postgres.py:802-807`).
+`… WHERE effect_key = %s AND state = 'failed' AND attempt = %s`. A stale renewal then matches no row and is
+refused exactly as a lost renewal race is refused today (`postgres.py:802-807`).
+
+**That closes the race only if the attempt number is monotonic, and on Postgres it was not.** Only a renewal
+changes the number, and every other transition computes the same number (`state.py:281-342`, `_transitioned`
+and `_resolved`); but on Postgres each of them *writes* that number back, from its own earlier read, under a
+`WHERE` on `effect_key`, `action_id` and `state` alone (`_write_effect`, under `resolve_effect`, `extend_lease`,
+`hold_continuation` and §4.2.2's kept `AMBIGUOUS` write; `_transition`, under `begin_execution`,
+`commit_effect`, `fail_effect` and `mark_ambiguous`). A caller that retries one `Action` object reuses its
+`action_id`, so `(action_id, state)` can come round again at a newer attempt between the read and the write,
+and the stale write then puts the older number back: a human's `resolve_effect` decided on `AMBIGUOUS` at 1
+lands on `AMBIGUOUS` at 2 and writes `FAILED` at **1**, and the next renewal hands out 2 a second time. Item 3a's
+independent review reproduced it. So every `UPDATE` on `effects` is conditioned on the attempt it read as well,
+with the row count checked as before: a write whose row moved matches nothing, re-reads, and is refused. With
+that, and only with it, the number moves only by a renewal, and the renewal's condition closes the race rather
+than narrowing it. There are three `UPDATE`s on the table and one `INSERT`, which lands only where there is no
+row, and all four are covered (§12.3a).
 
 **The lost `COMMIT`.** Where the reservation's `COMMIT` is lost, `_authorize_and_reserve` re-reads and,
 where the write did not land, re-issues the operation through `_authorize_and_reserve(..., retrying=True)`
@@ -1742,6 +1754,14 @@ of a window nobody opened.) In both, the attempt the reservation method returns 
 record, and mutating that path's resolve function back to returning the original plan's reservation makes its
 variant fail with the two numbers differing.
 
+#### T246c: No stale write moves an attempt number backwards
+The shape of T246, for every Postgres write that is not a renewal, under an `action_id` the caller reuses. With
+the proxy the tests own, the write's `UPDATE` is held after its read while another process brings the record
+back to the same `action_id` and state at attempt 2; released, it is refused, and the record keeps attempt 2.
+Three variants, one per statement: `resolve_effect` (the review's reproduction), the §4.2.2 `AMBIGUOUS` write
+by a contender that is not the owner, and `mark_ambiguous` through the transition compare-and-set. Each was red
+on 0.6.1's store with the record rewound to attempt 1. Added by item 3a after its review (§12.3a).
+
 ### 8.3 Item 3: The idempotency token (§4)
 
 #### T232: A `FAILED` renewal changes the token
@@ -2344,7 +2364,8 @@ Each in the item that makes it true, and each recorded here so it can be found.
    and **`v0.6 §4.3.2`'s lost-commit re-issue** returns the reservation it wrote rather than the one first
    planned (**item 3a**, its own pull request with an independent review, stacked before item 3; §5.6).
    **Table A2 row 1 on a renewal** applies `v0.6 §4.3.3`'s whole-row identity check, which only the insert
-   path applied before (item 3a, §12.3a).
+   path applied before, and **every other compare-and-set on `effects`** is conditioned on the attempt it read
+   (item 3a, §5.6, §12.3a). `SPEC-v0.6.md` §4.2 and §4.3.4 carry pointers here.
 
 ---
 
@@ -2371,8 +2392,10 @@ own, and none of them is configurable.
 | A reservation assigned an attempt number above the ceiling | Executor not called; record released `FAILED`; `blocked` receipt; `ActionDenied(reason="attempt_ceiling")` (§5.5) |
 | A crash between that reservation and its release | `AMBIGUOUS` once the lease lapses; a human or a hook resolves it; never `FAILED` (§5.2) |
 | A Postgres renewal planned against a stale attempt number | Matches no row; refused (§5.6, item 3a) |
+| Any other Postgres write to an effect record whose attempt moved since its read, `action_id` and state unchanged | Matches no row; re-read; `DuplicateEffect(state=in_progress)`; the newer attempt is left as it is (§5.6, T246c, item 3a) |
 | A lost `COMMIT` on a reservation, resolved by re-issuing it | The attempt the re-issue wrote is the one returned, never the one first planned (§5.6, item 3a) |
 | A lost `COMMIT` on a Postgres renewal whose re-read finds our `action_id` on a row that is not our own write | Not ours: `a2.row3.refuse`, refused through `plan_reservation`; nothing returned (§12.3a, item 3a) |
+| A lost `COMMIT` on a Postgres insert whose re-read finds another attempt's record the planner would renew over | `a1.row3.refuse`; `DuplicateEffect(state=in_progress)`; nothing returned (§12.3a, item 3a) |
 | A store whose `clock_skew` is not a `ClockSkew`, or whose read raises | Ignored with a log line; the action is unaffected (§3.6) |
 | A stored receipt document with an added key, a changed or removed `schema`, or an unknown one | A hash mismatch: `content_altered` at its `seq`. `receipts()` does not raise, and no reader surfaces an undeclared key (§6.11) |
 | A presented approval whose fingerprint differs from the recheck | `ApprovalMismatch(reason="precondition_changed")`; nothing reserved; approval `granted` (§6.3) |
@@ -2464,6 +2487,37 @@ in separate OS processes against a local Postgres, with the parent holding the p
 Both reservation methods, `reserve_effect` and `consume_approval_and_reserve`, run through every window,
 because §5.5 says *every* reservation method returns the number it wrote.
 
+**The independent review found the premise of the renewal fix false, and it was.** §5.6's first draft argued
+that conditioning the renewal on its planned-from attempt closed the race *because the attempt number is
+monotonic*. On Postgres it was not: `_write_effect` and `_transition` wrote back the attempt they had read,
+under a `WHERE` on `effect_key`, `action_id` and `state`, and a caller that retries one `Action` object reuses
+its `action_id`, so that pair comes round again at a newer attempt. The reviewer held a `resolve_effect`'s
+`UPDATE` with this item's own proxy while a second human resolved attempt 1, the owner retried, and attempt 2
+timed out; released, the stale resolution wrote `FAILED` at 1 over `AMBIGUOUS` at 2, and the next renewal handed
+out attempt 2 again. That is two dispatches under one number and one token, a ceiling of N admitting N+1, and
+attempt 2's unknown outcome settled by a human who had read attempt 1's record: a double-execution risk present
+since 0.6. SQLite and the in-memory store never had it, since their read and write are one critical section.
+Every `UPDATE` on `effects` in `postgres.py` was checked, and there are three: the renewal (conditioned by the
+first fix), `_write_effect` (under `resolve_effect`, `extend_lease`, `hold_continuation` and §4.2.2's kept
+`AMBIGUOUS` write) and `_transition` (under `begin_execution`, `commit_effect`, `fail_effect`, `mark_ambiguous`
+and Table A2's re-issue). The one `INSERT` lands only where no row exists. Both compare-and-sets are now
+conditioned on the attempt they read; a moved row matches nothing, is re-read, and `_checked` either refuses it
+or, where it still carries our `action_id` in an expected state at another attempt, the `DuplicateEffect` after
+it does. T246c holds each of the three shapes that reach them (`resolve_effect`; the `AMBIGUOUS` write by a
+contender that is not the owner; `mark_ambiguous`), and each was red on the store before this fix, the record
+rewound to attempt 1. `extend_lease` and `hold_continuation` share `_write_effect`'s statement, so its mutant is
+killed by the first two; the other three transitions share `_transition`'s, killed by the third.
+
+**What that does not close, stated rather than implied.** The attempt number is now monotonic, so no two
+reservations of one key carry the same number. What `action_id` reuse still leaves open is **attribution**, and
+on every backend, not only Postgres: a transition names its holder by `action_id` alone, because the frozen
+protocol gives it nothing else, so a *late* transition from attempt 1 (its lease lapsed, a human resolved it
+`FAILED`, and the same `Action` was retried) reads attempt 2's record, finds its own `action_id` in the state it
+expects, and writes attempt 2's outcome. It writes the number it read, so no number repeats; the outcome is
+recorded against the wrong attempt. It needs a human to have resolved an attempt that was still running, which
+is a claim of non-execution the human made, and no store can see through it. It is not item 3a's to fix, and a
+fix would need an attempt on every transition, which is a protocol change.
+
 **A third path, found while building: the renewal's "landed" row trusted `action_id`.** Table A2 row 1 on a
 renewal (`_resolve_lost_renewal`) concluded that a lost `COMMIT` had landed from two facts: the record was
 `RESERVED`, and it carried the renewal's `action_id`. `v0.6 §4.3.3` explains why that is not enough and applied
@@ -2491,21 +2545,31 @@ and reaching it needs a hook in shipping code (`v0.6 §2.5`). It cannot lose a `
 both properties in the `retry-table` case, which already asserts that the returned attempt and the stored
 attempt agree on the path it can reach. T246 and T246b are the only tests of the defence, as §5.6 anticipated.
 
-**Two lines no test reaches, stated as such.** SQLite's `AND attempt = ?` is an equivalent mutant: with it
-removed the whole suite passes, Postgres included, because `BEGIN IMMEDIATE` holds the read and the write
-together (§5.6). And `_resolve_lost_renewal` now ends in a refusal after `a2.row3.refuse` for the case where
-`plan_reservation` grants. That case is unreachable, because the only record the planner grants over that a
-store writes is `FAILED`, which re-issued a line earlier. It is there because the function must return a
-reservation it wrote or raise, and the insert path ends the same way. Replacing it with `return reservation`
-fails no test, and the mutation table says so.
+**Two lines no test reaches, stated as such, and one that a test now does.** SQLite's `AND attempt = ?` is an
+equivalent mutant: with it removed the whole suite passes, Postgres included, because `BEGIN IMMEDIATE` holds the
+read and the write together (§5.6). And `_resolve_lost_renewal` ends in a refusal after `a2.row3.refuse` for the
+case where `plan_reservation` grants. That case is unreachable, because the only record the planner grants over
+that a store writes is `FAILED`, which re-issued a line earlier; it is there because the function must return a
+reservation it wrote or raise. Replacing it with `return reservation` fails no test, and the mutation table says
+so. The first draft of this paragraph said the insert path "ends the same way", and the review showed that its
+line is **reachable**: a rival inserts attempt 1 and fails it between the lost `COMMIT` and the re-read, the
+re-read finds `FAILED` at 1 under the rival, and the planner grants a renewal over it, so the refusal is that
+last line's alone. Replaced with `return reservation`, it handed the held process attempt 1 on a record it never
+wrote and failed none of 112 Postgres tests. T246b's `insert-refuse` variant is that interleaving, and it kills
+the mutant.
 
-**The proxy grew a mode, not a sibling.** `failure_injection.Proxy` gained `hold_when`: a predicate over each
-parsed client message, which holds the first match (one statement, on one connection) until `release()`.
+**The proxy grew a mode, not a sibling.** `failure_injection.Proxy` gained `arm(predicate)`: a predicate over
+each parsed client message, which holds the first match (one statement, on one connection) until `release()`.
 `partition` already held traffic, but on every connection at once and at a moment the test chose rather than at
 a statement. The predicate reads SQL from the Parse message, never from a Bind parameter, for the reason
-`is_commit` parses frames, and a fixture test pins that. The tests that hold a statement assert that the hold
-fired, so a statement psycopg had already prepared, which carries no text, would fail them rather than pass
-them.
+`is_commit` parses frames, and a fixture test pins that. psycopg sends a query's text only until it has run
+that query five times on one connection and then executes a prepared statement with none, so a predicate sees
+only a query's first few executions; every held statement here is within them, and every test that holds one
+asserts the hold fired. The first version was an attribute, `hold_when`, and one-shot without saying so: its
+events were never cleared, so a second hold on one proxy reported itself held at once and forwarded its
+statement, the review found. Items 3 and 4 will reuse it, so `arm()` clears `holding` in place, gives each
+arming its own release event, and refuses to arm while a hold is armed or held; a server-free fixture test arms
+it twice over real loopback sockets.
 
 ### 12.3 Item 3: the idempotency token
 

--- a/docs/SPEC-v0.7.md
+++ b/docs/SPEC-v0.7.md
@@ -2554,6 +2554,15 @@ retry beside a running dispatch; `begin_execution` claims a reservation this att
 an outcome to the newer attempt is the residual below; dropping it is a lost outcome, and between the two the
 fail-closed direction is to land it.
 
+**The bound has its own test, at the store's own read, because no proxy can drive it.** A second move under the
+re-issue needs a rival interleaved *inside* the re-issue, and a hold fires once. `v0.6`'s T155f is the precedent
+for what an unbounded re-issue costs: driven by a proxy that swallowed every `COMMIT`, the lost-commit path
+recursed 96 deep and escaped as `RecursionError`, outside the error taxonomy. So the stale re-issue's bound is
+driven by subclassing the store's own `_read_effect` to report the record one attempt further on every read,
+which is a rival that never stops moving and makes every conditional `UPDATE` miss. Bounded, the call refuses
+and writes nothing; unbounded, it recurses until Python stops it, which is what removing the flag produces and
+what the mutation table records.
+
 **The refusal now takes its type from what the re-read found.** Every one of these was
 `DuplicateEffect(state=in_progress)`, which `errors.py` defines as *another attempt holds a live reservation*.
 After a stale `resolve_effect` the record is `AMBIGUOUS` at the newer attempt, which is nobody's reservation, so

--- a/docs/SPEC-v0.7.md
+++ b/docs/SPEC-v0.7.md
@@ -2570,7 +2570,8 @@ The first is the interleaving: the obvious every-other-read pattern ends bounded
 compose, so the patterns come from a search over this proxy, and there are two, because `(0, 0, 1, 0)` is the
 one that catches the restage failing to pass `retrying` on and `(1, 0, 0, 0)` is the one that catches the
 lost-commit re-issue failing to pass `restaged` on. The second is the assertion. Dropping **both** flags
-recurses; dropping **one** does not recurse at all on any pattern of four reads or fewer, it simply permits one
+recurses; dropping **one** does not recurse at all on any pattern of six reads or fewer, measured rather than
+sampled, it simply permits one
 re-issue more than the bound allows, and that extra level terminates. So a test asserting only *"this did not
 blow the stack"* would be green for each flag taken alone, which is precisely the pair of mutants that say each
 is load-bearing. Each bound permits one re-issue, so three is the deepest nesting any interleaving may reach,
@@ -2693,7 +2694,12 @@ attempt agree on the path it can reach. T246 and T246b are the only tests of the
 
 **Two lines no test reaches, stated as such, and one that a test now does.** SQLite's `AND attempt = ?` is an
 equivalent mutant: with it removed the whole suite passes, Postgres included, because `BEGIN IMMEDIATE` holds the
-read and the write together (§5.6). And `_resolve_lost_renewal` ends in a refusal after `a2.row3.refuse` for the
+read and the write together (§5.6). So is `carries_outcome` at the re-issue's guard: reverting it to the older
+`state in _OUTCOMES` condition fails no test, because the only two callers reaching those states pass
+`carries_outcome=True` and nothing else transitions to `COMMITTED` or `AMBIGUOUS` through `_transition`. It is
+kept for the reason the paragraph above gives, that a future outcome-carrying transition must opt in deliberately
+rather than inherit the re-issue, and it is declared here as an equivalent mutant rather than counted as a
+mutation row, because a row that cannot fail is the false green this list exists to prevent. And `_resolve_lost_renewal` ends in a refusal after `a2.row3.refuse` for the
 case where `plan_reservation` grants. That case is unreachable, because the only record the planner grants over
 that a store writes is `FAILED`, which re-issued a line earlier; it is there because the function must return a
 reservation it wrote or raise. Replacing it with `return reservation` fails no test, and the mutation table says

--- a/docs/SPEC-v0.7.md
+++ b/docs/SPEC-v0.7.md
@@ -2563,10 +2563,19 @@ halves at once, every `COMMIT` lost and a record that keeps moving, and measured
 which is T155f's failure mode arriving by another door and outside the closed set of errors, so no caller can
 classify it. Both flags now travel through both re-issues. The composition is the property, not either flag, and
 its test drives both halves the way each is driven alone: the real proxy at `drop_before_commit = 1000` for the
-lost `COMMIT`, and the seam below for the record that moves. **The interleaving matters**: the obvious
-every-other-read pattern ends bounded even when the flags do not compose, and the pattern a search found,
-`(0, 0, 1, 0)`, does not. A test that had picked the obvious one would have been mutation pattern 4 one layer up
-from the store.
+lost `COMMIT`, and the seam below for the record that moves.
+
+**Two things about that test were measured rather than assumed, and both would have made it a false green.**
+The first is the interleaving: the obvious every-other-read pattern ends bounded even when the flags do not
+compose, so the patterns come from a search over this proxy, and there are two, because `(0, 0, 1, 0)` is the
+one that catches the restage failing to pass `retrying` on and `(1, 0, 0, 0)` is the one that catches the
+lost-commit re-issue failing to pass `restaged` on. The second is the assertion. Dropping **both** flags
+recurses; dropping **one** does not recurse at all on any pattern of four reads or fewer, it simply permits one
+re-issue more than the bound allows, and that extra level terminates. So a test asserting only *"this did not
+blow the stack"* would be green for each flag taken alone, which is precisely the pair of mutants that say each
+is load-bearing. Each bound permits one re-issue, so three is the deepest nesting any interleaving may reach,
+and the test asserts that: a fourth level means a bound was cleared, whether or not that pattern went on
+forever.
 
 **The re-issue is asked for at the call site rather than inferred from the state it writes.** It was keyed on
 the target state, `COMMITTED` or `AMBIGUOUS`, which is right for every path there is today and wrong the moment

--- a/docs/SPEC-v0.7.md
+++ b/docs/SPEC-v0.7.md
@@ -2554,6 +2554,33 @@ retry beside a running dispatch; `begin_execution` claims a reservation this att
 an outcome to the newer attempt is the residual below; dropping it is a lost outcome, and between the two the
 fail-closed direction is to land it.
 
+**Two bounds that reset each other are not a bound, and that took a third round to see.** `restaged` bounds the
+stale re-issue and `retrying` bounds `v0.6 §4.3.2` Table A2's lost-commit re-issue. Each was tested alone and
+each held alone. Composed, they cleared each other: the restage re-issued without passing `retrying` on, and the
+lost-commit re-issue re-issued without passing `restaged` on, so a `COMMIT` lost inside a restage reset the
+restage bound and a restage inside a lost-commit re-issue reset the lost-commit bound. A review drove both
+halves at once, every `COMMIT` lost and a record that keeps moving, and measured `RecursionError` at 113 deep,
+which is T155f's failure mode arriving by another door and outside the closed set of errors, so no caller can
+classify it. Both flags now travel through both re-issues. The composition is the property, not either flag, and
+its test drives both halves the way each is driven alone: the real proxy at `drop_before_commit = 1000` for the
+lost `COMMIT`, and the seam below for the record that moves. **The interleaving matters**: the obvious
+every-other-read pattern ends bounded even when the flags do not compose, and the pattern a search found,
+`(0, 0, 1, 0)`, does not. A test that had picked the obvious one would have been mutation pattern 4 one layer up
+from the store.
+
+**The re-issue is asked for at the call site rather than inferred from the state it writes.** It was keyed on
+the target state, `COMMITTED` or `AMBIGUOUS`, which is right for every path there is today and wrong the moment
+a transition to one of those states is somebody's *decision* rather than an executor's outcome. A human's
+resolution is exactly that, and it reaches `_write_effect` today, but `_transition` is generic and the next
+transition to land there would have inherited the re-issue silently. `commit_effect` and `mark_ambiguous` now
+pass `carries_outcome=True`, and the state set survives as an assertion: a caller that claims to carry an
+outcome into any other state is a wiring bug rather than a re-issue.
+
+**A restage that then refuses says so.** The line naming it was written after the nested call returned, so it
+appeared only when the re-issue succeeded, and the case an operator would actually go looking for, a stale
+outcome that was re-issued and still refused, left no line at all. It is written before the re-issue now, which
+is `v0.6 §4.3.4`'s rule applied to a branch that section does not enumerate: which branch ran is observable.
+
 **The bound has its own test, at the store's own read, because no proxy can drive it.** A second move under the
 re-issue needs a rival interleaved *inside* the re-issue, and a hold fires once. `v0.6`'s T155f is the precedent
 for what an unbounded re-issue costs: driven by a proxy that swallowed every `COMMIT`, the lost-commit path
@@ -2579,11 +2606,22 @@ while the attempt was still running answers `InvalidArgument`, which escaped. Th
 about its own effect key instead of its executor's exception: the unknown outcome existed nowhere. The store's
 answer to an outcome write may be a refusal; the evidence may not. `Control` now catches every `CTRLRunError`
 from the three outcome writes, writes the event and the receipt whatever the answer was, and **names the
-refusal in them**, because where the store would not take the outcome the effect record does not carry it and
+refusal in them**, with what the executor did beside it: an executor that returned leaves a remote that very
+likely acted and one that raised `NotExecuted` leaves a remote that very likely did not, and recording only the
+refusal made those two receipts identical for whoever runs `ctrlrun resolve`, because where the store would not take the outcome the effect record does not carry it and
 the receipt is the only place it exists. The caller's own exception propagates, and eager reconciliation stays
 gated on the write having landed, so nothing is retried on the strength of a refused outcome write. What the
 record says afterwards is the human's claim, not this attempt's, and that is the one thing the evidence can
-still contradict. T246d is the test, on both backends.
+still contradict. T246d is the test, on both backends and for all three outcomes.
+
+**What the wider catch also absorbs, said plainly.** Each of those three `except` clauses wraps exactly one
+store call, so no approval, authority or reservation refusal passes through it. But `CTRLRunError` includes
+`InvalidArgument`, and a mis-wired `held_key` raises `InvalidArgument("no reservation for effect ...")`, which
+now becomes an `ambiguous` receipt naming the refusal rather than an exception at the caller. That is the right
+trade and it is a trade: a wiring bug on this path surfaces in the evidence instead of at the call site, and it
+surfaces as an unknown outcome, which is the fail-closed reading of *the store would not record what the
+executor did*. The receipt names the exception type, so the bug is legible; what it no longer does is stop the
+attempt from being recorded at all.
 
 **What that does not close, stated without softening, because the first draft of this paragraph softened it in
 three places.** The attempt number is now monotonic, so no two reservations of one key carry the same number.
@@ -2592,11 +2630,20 @@ transition names its holder by `action_id` alone, so attempt 1's write, arriving
 contender ambiguated the record and the same `Action` was retried, reads attempt 2's record, finds its own id
 in a state it expects, and lands there. Three corrections to how that was stated:
 
-- **It is not only misattribution.** A late `commit_effect` or `mark_ambiguous` records the wrong attempt's
-  outcome, which is bad evidence. A late `fail_effect` is worse than that: it writes `FAILED` over attempt 2
-  **while attempt 2 is executing**, and `FAILED` is the one state that permits a renewal, so attempt 3 may be
-  dispatched beside a dispatch that is still running. That is a concurrent double execution, and calling it
-  attribution would be this repository's own prevention-versus-attribution error.
+- **It is not only misattribution.** A late `commit_effect` records the wrong attempt's outcome, which is bad
+  evidence. A late `fail_effect` is worse: it writes `FAILED` over attempt 2 **while attempt 2 is executing**,
+  and `FAILED` is the one state that permits a renewal, so attempt 3 may be dispatched beside a dispatch that is
+  still running. That is a concurrent double execution, and calling it attribution would be this repository's
+  own prevention-versus-attribution error.
+- **And `mark_ambiguous` reaches the same place in one more step, which is why the asymmetry above is argued on
+  this ground and not on the state's name.** A late or re-issued `mark_ambiguous` lands `AMBIGUOUS` on attempt
+  2; the write succeeded, so `Control` counts the outcome as recorded and eager reconciliation runs; a hook
+  answering `not_executed` resolves the record `FAILED`, because the hook is asked about the **effect key** and
+  not about the attempt; and attempt 3 may then be reserved while attempt 2 is still executing. The step that
+  `fail_effect` takes in one, `mark_ambiguous` takes in two, and the second is taken by a hook that cannot see
+  which attempt it is answering about. Recording the unknown outcome is still right, and the store must still
+  never drop it; what the pair shows is that the residual is about attempt *identity* and is not closed by
+  refusing one transition.
 - **It does not need a human.** A reconcile hook answering `not_executed` moves an `AMBIGUOUS` record to
   `FAILED` with no person involved (`control.py`, `_reconciled`), so the sequence runs unattended.
 - **There is a fix inside the frozen protocol, and it is declined here rather than unavailable.** A store-side

--- a/docs/SPEC-v0.7.md
+++ b/docs/SPEC-v0.7.md
@@ -2343,6 +2343,8 @@ Each in the item that makes it true, and each recorded here so it can be found.
 8. **`v0.6 §4.2`'s renewal compare-and-set** is conditioned on the planned-from attempt as well as the state,
    and **`v0.6 §4.3.2`'s lost-commit re-issue** returns the reservation it wrote rather than the one first
    planned (**item 3a**, its own pull request with an independent review, stacked before item 3; §5.6).
+   **Table A2 row 1 on a renewal** applies `v0.6 §4.3.3`'s whole-row identity check, which only the insert
+   path applied before (item 3a, §12.3a).
 
 ---
 
@@ -2370,6 +2372,7 @@ own, and none of them is configurable.
 | A crash between that reservation and its release | `AMBIGUOUS` once the lease lapses; a human or a hook resolves it; never `FAILED` (§5.2) |
 | A Postgres renewal planned against a stale attempt number | Matches no row; refused (§5.6, item 3a) |
 | A lost `COMMIT` on a reservation, resolved by re-issuing it | The attempt the re-issue wrote is the one returned, never the one first planned (§5.6, item 3a) |
+| A lost `COMMIT` on a Postgres renewal whose re-read finds our `action_id` on a row that is not our own write | Not ours: `a2.row3.refuse`, refused through `plan_reservation`; nothing returned (§12.3a, item 3a) |
 | A store whose `clock_skew` is not a `ClockSkew`, or whose read raises | Ignored with a log line; the action is unaffected (§3.6) |
 | A stored receipt document with an added key, a changed or removed `schema`, or an unknown one | A hash mismatch: `content_altered` at its `seq`. `receipts()` does not raise, and no reader surfaces an undeclared key (§6.11) |
 | A presented approval whose fingerprint differs from the recheck | `ApprovalMismatch(reason="precondition_changed")`; nothing reserved; approval `granted` (§6.3) |
@@ -2453,6 +2456,56 @@ decided, not afterwards.
 ### 12.2 Item 2: the transport classifier
 
 ### 12.3a Item 3a: attempt numbers never repeat
+
+Both defects §5.6 names were reproduced before they were fixed, each by a test that was red on 0.6.1's
+store for the reason it names: T246 with two reservations carrying attempt 2; T246b's renewal variant with the
+method returning 2 while the record held 3; T246b's insert variant with 1 returned and 2 stored. All of them run
+in separate OS processes against a local Postgres, with the parent holding the proxy, and every wait bounded.
+Both reservation methods, `reserve_effect` and `consume_approval_and_reserve`, run through every window,
+because §5.5 says *every* reservation method returns the number it wrote.
+
+**A third path, found while building: the renewal's "landed" row trusted `action_id`.** Table A2 row 1 on a
+renewal (`_resolve_lost_renewal`) concluded that a lost `COMMIT` had landed from two facts: the record was
+`RESERVED`, and it carried the renewal's `action_id`. `v0.6 §4.3.3` explains why that is not enough and applied
+the fix to the insert path only: `action_id` is caller-supplyable, and a caller that rebuilt the same `Action`
+after a restart renews under the same one. So a renewal whose `COMMIT` was lost, followed by a second process
+renewing the key under the same `action_id`, left the first concluding the row was its own write: two
+dispatches holding one attempt, and a number returned that the method never wrote, which is §5.5's MUST
+failing on the third branch of the same function. The row now applies §4.3.3's check, `_is_our_own_write`,
+against the row the renewal would have written, so a rival's lease or `updated_at` makes it `a2.row3.refuse`.
+The identical-in-every-column residual §4.3.3 states is unchanged, and it needs a clock frozen across processes.
+The test is T246b's third variant, `landed`. It was red on 0.6.1 in both methods, and a check on `attempt`
+alone would not pass it, because the rival renewed to the same number. §9.6 item 8 and §10 carry the row.
+
+**The planned-from attempt is the plan's, and T246 opens two windows to show it.** `_reserve_locked` reads the
+record a second time, for `created_at`, between `_plan`'s read and the `UPDATE`. A condition taken from that
+second read would pass a test that holds only the `UPDATE`, because both reads precede the hold and see the same
+record. So T246 runs at two points: holding the `UPDATE` (§8.3a's window) and holding the second read, where
+that read sees the rival's attempt. The condition is `reservation.attempt - 1`, which is the attempt
+`plan_reservation` renewed from (`effect.py`, `record.attempt + 1`). Taking it from the second read fails the
+second window and passes the first.
+
+**The store conformance suite gains no case: `v0.6 §2.4` holds here.** Its barrier releases contenders
+together and cannot stop one between its `SELECT` and its `UPDATE`, because that is inside `reserve_effect`
+and reaching it needs a hook in shipping code (`v0.6 §2.5`). It cannot lose a `COMMIT` either. The suite states
+both properties in the `retry-table` case, which already asserts that the returned attempt and the stored
+attempt agree on the path it can reach. T246 and T246b are the only tests of the defence, as §5.6 anticipated.
+
+**Two lines no test reaches, stated as such.** SQLite's `AND attempt = ?` is an equivalent mutant: with it
+removed the whole suite passes, Postgres included, because `BEGIN IMMEDIATE` holds the read and the write
+together (§5.6). And `_resolve_lost_renewal` now ends in a refusal after `a2.row3.refuse` for the case where
+`plan_reservation` grants. That case is unreachable, because the only record the planner grants over that a
+store writes is `FAILED`, which re-issued a line earlier. It is there because the function must return a
+reservation it wrote or raise, and the insert path ends the same way. Replacing it with `return reservation`
+fails no test, and the mutation table says so.
+
+**The proxy grew a mode, not a sibling.** `failure_injection.Proxy` gained `hold_when`: a predicate over each
+parsed client message, which holds the first match (one statement, on one connection) until `release()`.
+`partition` already held traffic, but on every connection at once and at a moment the test chose rather than at
+a statement. The predicate reads SQL from the Parse message, never from a Bind parameter, for the reason
+`is_commit` parses frames, and a fixture test pins that. The tests that hold a statement assert that the hold
+fired, so a statement psycopg had already prepared, which carries no text, would fail them rather than pass
+them.
 
 ### 12.3 Item 3: the idempotency token
 

--- a/docs/SPEC-v0.7.md
+++ b/docs/SPEC-v0.7.md
@@ -1100,10 +1100,26 @@ and `_resolved`); but on Postgres each of them *writes* that number back, from i
 and the stale write then puts the older number back: a human's `resolve_effect` decided on `AMBIGUOUS` at 1
 lands on `AMBIGUOUS` at 2 and writes `FAILED` at **1**, and the next renewal hands out 2 a second time. Item 3a's
 independent review reproduced it. So every `UPDATE` on `effects` is conditioned on the attempt it read as well,
-with the row count checked as before: a write whose row moved matches nothing, re-reads, and is refused. With
-that, and only with it, the number moves only by a renewal, and the renewal's condition closes the race rather
-than narrowing it. There are three `UPDATE`s on the table and one `INSERT`, which lands only where there is no
-row, and all four are covered (§12.3a).
+with the row count checked as before, and a write whose row moved matches nothing and is re-read. With that, and
+only with it, the number moves only by a renewal, and the renewal's condition closes the race rather than
+narrowing it. There are three `UPDATE`s on the table and one `INSERT`, which lands only where there is no row,
+and all four are covered (§12.3a).
+
+**What the re-read then does is not the same answer for all of them, and the difference is an outcome.**
+`commit_effect` and `mark_ambiguous` carry what the executor did, or the fact that nobody knows; refusing them
+writes nothing, and the effect record, which is what gates the next renewal, is then silent about an attempt
+that may have acted. They are **re-issued once** against the re-read where it says the record is still this
+attempt's and still in a state the write may be made from, so the outcome lands on the newer attempt.
+`begin_execution` and `fail_effect` are refused there, because `FAILED` asserts that nothing happened and
+attempt 2 is running. Everything else, `resolve_effect` and §4.2.2's kept `AMBIGUOUS` write among them, is
+refused with the type the re-read's record earns and a message naming the move (§12.3a, T246c).
+
+**And this is a store-level race, not the human's.** Conditioning `resolve_effect` on the attempt it read closes
+the milliseconds between that read and its own write. The window a person actually stands in is longer: they
+inspect, they decide, they run `ctrlrun resolve`, and the attempt can move between the inspection and the
+command. `resolve_effect` carries no attempt number and does not look at `action_id`, so a human who read
+attempt 1 can still resolve attempt 2's ambiguity with no `action_id` reuse anywhere. An attempt argument on the
+CLI and on the operator tool would close that one, and it is a follow-up rather than part of item 3a (§12.3a).
 
 **The lost `COMMIT`.** Where the reservation's `COMMIT` is lost, `_authorize_and_reserve` re-reads and,
 where the write did not land, re-issues the operation through `_authorize_and_reserve(..., retrying=True)`
@@ -1754,13 +1770,25 @@ of a window nobody opened.) In both, the attempt the reservation method returns 
 record, and mutating that path's resolve function back to returning the original plan's reservation makes its
 variant fail with the two numbers differing.
 
-#### T246c: No stale write moves an attempt number backwards
+#### T246c: No stale write moves an attempt number backwards, and no outcome is dropped instead
 The shape of T246, for every Postgres write that is not a renewal, under an `action_id` the caller reuses. With
 the proxy the tests own, the write's `UPDATE` is held after its read while another process brings the record
-back to the same `action_id` and state at attempt 2; released, it is refused, and the record keeps attempt 2.
-Three variants, one per statement: `resolve_effect` (the review's reproduction), the §4.2.2 `AMBIGUOUS` write
-by a contender that is not the owner, and `mark_ambiguous` through the transition compare-and-set. Each was red
-on 0.6.1's store with the record rewound to attempt 1. Added by item 3a after its review (§12.3a).
+back to the same `action_id` and a state the write may be made from, at attempt 2. Released, it never rewinds
+the record, and what it does instead depends on what it carries: `commit_effect` and `mark_ambiguous` are
+re-issued once against the re-read, so the outcome lands at attempt 2; `begin_execution` and `fail_effect` are
+refused, because `FAILED` asserts that nothing happened and attempt 2 is running; `resolve_effect` and the
+§4.2.2 `AMBIGUOUS` write by a contender are refused, typed by what the re-read found and naming the move. Each
+variant ends by asserting that no further attempt may be taken. Every one was red before its fix: first with
+the record rewound to attempt 1, and then, for the two that carry an outcome, with the outcome dropped and a
+further attempt permitted. Added by item 3a after its reviews (§12.3a).
+
+#### T246d: An unknown outcome the store refuses to record is never lost
+Through `Control.execute`, on **both backends**, with no proxy: the executor runs past its lease, a contender
+makes the lapsed record `AMBIGUOUS`, a human resolves it `FAILED` while the attempt is still running, and the
+executor then raises `TimeoutError`. `mark_ambiguous` is refused with `InvalidArgument`, which is not a refusal
+`Control` used to catch. The caller gets its own `TimeoutError`, one `ambiguous` receipt is written naming both
+the executor's exception and the store's refusal, and the `EXECUTION_AMBIGUOUS` event is appended. Red before
+the fix with no receipt, no event and `InvalidArgument` reaching the caller (§12.3a).
 
 ### 8.3 Item 3: The idempotency token (§4)
 
@@ -2392,7 +2420,11 @@ own, and none of them is configurable.
 | A reservation assigned an attempt number above the ceiling | Executor not called; record released `FAILED`; `blocked` receipt; `ActionDenied(reason="attempt_ceiling")` (§5.5) |
 | A crash between that reservation and its release | `AMBIGUOUS` once the lease lapses; a human or a hook resolves it; never `FAILED` (§5.2) |
 | A Postgres renewal planned against a stale attempt number | Matches no row; refused (§5.6, item 3a) |
-| Any other Postgres write to an effect record whose attempt moved since its read, `action_id` and state unchanged | Matches no row; re-read; `DuplicateEffect(state=in_progress)`; the newer attempt is left as it is (§5.6, T246c, item 3a) |
+| A Postgres `commit_effect` or `mark_ambiguous` whose record moved since its read, still this attempt's and still in a state it may be written from | Matches no row; re-read; **re-issued once** against the re-read, so the outcome lands on the newer attempt and is never dropped (§5.6, T246c, item 3a) |
+| A Postgres `begin_execution` or `fail_effect` in the same position | Matches no row; re-read; refused, typed by what the re-read found, naming the move; nothing written, and the running attempt is left alone (§5.6, T246c) |
+| Any other Postgres write to an effect record whose attempt moved since its read (`resolve_effect`, `extend_lease`, `hold_continuation`, the kept `AMBIGUOUS` write) | Matches no row; re-read; refused, typed by what the re-read found; nothing written (§5.6, T246c, item 3a) |
+| A store refusal to an executor's outcome write, of any type | The `EXECUTION_AMBIGUOUS` event and the `ambiguous` receipt are written anyway and name the refusal; the caller's own exception propagates; nothing is reconciled on a record this attempt could not mark (§12.3a, item 3a) |
+| A Postgres approval expiry whose approval was answered or consumed since its read | Matches no row; the approval keeps what the other writer wrote; the refusal that asked for the expiry is raised as before (§12.3a, item 3a) |
 | A lost `COMMIT` on a reservation, resolved by re-issuing it | The attempt the re-issue wrote is the one returned, never the one first planned (§5.6, item 3a) |
 | A lost `COMMIT` on a Postgres renewal whose re-read finds our `action_id` on a row that is not our own write | Not ours: `a2.row3.refuse`, refused through `plan_reservation`; nothing returned (§12.3a, item 3a) |
 | A lost `COMMIT` on a Postgres insert whose re-read finds another attempt's record the planner would renew over | `a1.row3.refuse`; `DuplicateEffect(state=in_progress)`; nothing returned (§12.3a, item 3a) |
@@ -2501,22 +2533,71 @@ Every `UPDATE` on `effects` in `postgres.py` was checked, and there are three: t
 first fix), `_write_effect` (under `resolve_effect`, `extend_lease`, `hold_continuation` and §4.2.2's kept
 `AMBIGUOUS` write) and `_transition` (under `begin_execution`, `commit_effect`, `fail_effect`, `mark_ambiguous`
 and Table A2's re-issue). The one `INSERT` lands only where no row exists. Both compare-and-sets are now
-conditioned on the attempt they read; a moved row matches nothing, is re-read, and `_checked` either refuses it
-or, where it still carries our `action_id` in an expected state at another attempt, the `DuplicateEffect` after
-it does. T246c holds each of the three shapes that reach them (`resolve_effect`; the `AMBIGUOUS` write by a
-contender that is not the owner; `mark_ambiguous`), and each was red on the store before this fix, the record
-rewound to attempt 1. `extend_lease` and `hold_continuation` share `_write_effect`'s statement, so its mutant is
-killed by the first two; the other three transitions share `_transition`'s, killed by the third.
+conditioned on the attempt they read; a moved row matches nothing and is re-read. T246c holds each shape that
+reaches them, and each was red on the store before this fix with the record rewound to attempt 1.
+`extend_lease` and `hold_continuation` share `_write_effect`'s statement, so its mutant is killed by the
+`resolve_effect` and contender-`AMBIGUOUS` variants; the four transitions share `_transition`'s.
 
-**What that does not close, stated rather than implied.** The attempt number is now monotonic, so no two
-reservations of one key carry the same number. What `action_id` reuse still leaves open is **attribution**, and
-on every backend, not only Postgres: a transition names its holder by `action_id` alone, because the frozen
-protocol gives it nothing else, so a *late* transition from attempt 1 (its lease lapsed, a human resolved it
-`FAILED`, and the same `Action` was retried) reads attempt 2's record, finds its own `action_id` in the state it
-expects, and writes attempt 2's outcome. It writes the number it read, so no number repeats; the outcome is
-recorded against the wrong attempt. It needs a human to have resolved an attempt that was still running, which
-is a claim of non-execution the human made, and no store can see through it. It is not item 3a's to fix, and a
-fix would need an attempt on every transition, which is a protocol change.
+**And the refusal that replaced the rewind dropped outcomes, which the second review round caught.** A write
+whose row has moved is re-read and run through `_checked`, and where the record is still this attempt's and
+still in a state the write may be made from, the predicate *passes*: only the attempt moved. The first fix then
+raised and wrote nothing, and for `commit_effect` and `mark_ambiguous` that is a lost outcome, not a refusal.
+The reviewer measured it: attempt 1's `commit_effect` refused, the record left `EXECUTING` at attempt 2, attempt
+2 reporting `NotExecuted`, and a renewal to attempt 3 with attempt 1's commit recorded on no effect record at
+all. For a refund that had landed, attempt 3 is a second refund. The effect record is what gates the next
+renewal, so a write that carries an outcome may not simply decline to land. Both outcome transitions are now
+**re-issued once** against the re-read, bounded by a `restaged` flag as Table A2's re-issue is bounded by
+`retrying`, so the stale write lands exactly where the same call a moment later would have landed it: on the
+newer attempt. `begin_execution` and `fail_effect` are still refused, and the asymmetry is the argument.
+`FAILED` asserts that *nothing happened*, so re-issuing attempt 1's over attempt 2 in flight would permit a
+retry beside a running dispatch; `begin_execution` claims a reservation this attempt no longer holds. Attributing
+an outcome to the newer attempt is the residual below; dropping it is a lost outcome, and between the two the
+fail-closed direction is to land it.
+
+**The refusal now takes its type from what the re-read found.** Every one of these was
+`DuplicateEffect(state=in_progress)`, which `errors.py` defines as *another attempt holds a live reservation*.
+After a stale `resolve_effect` the record is `AMBIGUOUS` at the newer attempt, which is nobody's reservation, so
+the type was false and a caller reading `in_progress` would wait for a dispatch that is not running. `_moved`
+picks `AmbiguousEffect` for an `AMBIGUOUS` record, `DuplicateEffect(committed)` for a committed one and
+`in_progress` otherwise, and the message names the move: *moved from attempt 1 (ambiguous) to attempt 2
+(ambiguous) since it was read; nothing was written*.
+
+**An unknown outcome is never lost, whatever the store answers.** The same review drove the case through
+`Control` on SQLite, where none of this item's races exist, and found something older and worse. `Control`
+caught `DuplicateEffect` and `AmbiguousEffect` around its outcome writes; a record a human resolved `FAILED`
+while the attempt was still running answers `InvalidArgument`, which escaped. The result was an executor's
+`TimeoutError` producing **no receipt, no `EXECUTION_AMBIGUOUS` event**, and the caller handed a store error
+about its own effect key instead of its executor's exception: the unknown outcome existed nowhere. The store's
+answer to an outcome write may be a refusal; the evidence may not. `Control` now catches every `CTRLRunError`
+from the three outcome writes, writes the event and the receipt whatever the answer was, and **names the
+refusal in them**, because where the store would not take the outcome the effect record does not carry it and
+the receipt is the only place it exists. The caller's own exception propagates, and eager reconciliation stays
+gated on the write having landed, so nothing is retried on the strength of a refused outcome write. What the
+record says afterwards is the human's claim, not this attempt's, and that is the one thing the evidence can
+still contradict. T246d is the test, on both backends.
+
+**What that does not close, stated without softening, because the first draft of this paragraph softened it in
+three places.** The attempt number is now monotonic, so no two reservations of one key carry the same number.
+What a reused `action_id` still leaves open is which attempt a *late* write is about, on **every backend**: a
+transition names its holder by `action_id` alone, so attempt 1's write, arriving after its lease lapsed, a
+contender ambiguated the record and the same `Action` was retried, reads attempt 2's record, finds its own id
+in a state it expects, and lands there. Three corrections to how that was stated:
+
+- **It is not only misattribution.** A late `commit_effect` or `mark_ambiguous` records the wrong attempt's
+  outcome, which is bad evidence. A late `fail_effect` is worse than that: it writes `FAILED` over attempt 2
+  **while attempt 2 is executing**, and `FAILED` is the one state that permits a renewal, so attempt 3 may be
+  dispatched beside a dispatch that is still running. That is a concurrent double execution, and calling it
+  attribution would be this repository's own prevention-versus-attribution error.
+- **It does not need a human.** A reconcile hook answering `not_executed` moves an `AMBIGUOUS` record to
+  `FAILED` with no person involved (`control.py`, `_reconciled`), so the sequence runs unattended.
+- **There is a fix inside the frozen protocol, and it is declined here rather than unavailable.** A store-side
+  memo of the attempt each reservation wrote, keyed by `(effect_key, action_id)` and seeded by `reserve_effect`,
+  `consume_approval_and_reserve` and `take_continuation`, would let every transition condition on the attempt
+  the caller actually holds without touching a frozen signature. It is declined in item 3a because it is a
+  schema change: a table or a column, a migration, the store conformance suite, and a rule for what a memo that
+  is missing means, which is a specification amendment of its own and is the shape v0.9's budgets will need
+  anyway. Item 3a's subject is the attempt number, and this is the attempt *identity*. Stated here so the next
+  milestone inherits the argument rather than the surprise.
 
 **A third path, found while building: the renewal's "landed" row trusted `action_id`.** Table A2 row 1 on a
 renewal (`_resolve_lost_renewal`) concluded that a lost `COMMIT` had landed from two facts: the record was
@@ -2558,6 +2639,16 @@ last line's alone. Replaced with `return reservation`, it handed the held proces
 wrote and failed none of 112 Postgres tests. T246b's `insert-refuse` variant is that interleaving, and it kills
 the mutant.
 
+**One write on `approvals` was not a compare-and-set, and the round-2 survey found it.** `_expire` marks a
+lapsed approval `expired` from a read that saw it `granted` past `expires_at`, and matched on `approval_id`
+alone. A consumption committing between that read and that write was overwritten, so an approval that
+authorised a real effect read `expired` and the evidence said a human's yes had never been spent. `v0.6 §4.2.2`
+keeps that write deliberately, as evidence; evidence that overwrites newer evidence is worse than none. It now
+carries the status it read, as `_consume_locked`, `grant_approval` and `deny_approval` already did, and a row
+count of zero needs no refusal because the caller is being refused anyway by the verdict that asked for the
+write. Its test holds the expiring `UPDATE` while another process, whose clock is still inside the approval's
+life, consumes it. SQLite's expiry is inside the same `BEGIN IMMEDIATE` as its read and was never exposed.
+
 **The proxy grew a mode, not a sibling.** `failure_injection.Proxy` gained `arm(predicate)`: a predicate over
 each parsed client message, which holds the first match (one statement, on one connection) until `release()`.
 `partition` already held traffic, but on every connection at once and at a moment the test chose rather than at
@@ -2569,7 +2660,14 @@ asserts the hold fired. The first version was an attribute, `hold_when`, and one
 events were never cleared, so a second hold on one proxy reported itself held at once and forwarded its
 statement, the review found. Items 3 and 4 will reuse it, so `arm()` clears `holding` in place, gives each
 arming its own release event, and refuses to arm while a hold is armed or held; a server-free fixture test arms
-it twice over real loopback sockets.
+it twice over real loopback sockets. Round 2 found the hole that was left: `release()` called while a hold was
+armed but had not fired pre-released it, so the statement went straight through with `holding` set and `holds`
+counting a window that never opened, which is the same lie in a narrower form and exactly what a `finally` that
+releases would have produced. It now releases only a hold that has actually fired, under the lock `_holds` uses,
+and the fixture test releases into an armed-but-unfired hold and then asserts the statement is still held. The
+same round measured the prepare threshold rather than reading it off the default: a query's text travels on its
+first six executions on one connection, executions 1 to 5 as unnamed Parses and 6 as the named Parse that
+prepares it, and `statement_of`'s docstring says so.
 
 ### 12.3 Item 3: the idempotency token
 

--- a/src/ctrlrun/conformance/store/suites.py
+++ b/src/ctrlrun/conformance/store/suites.py
@@ -436,6 +436,15 @@ def reservation_e1_cross_process(backend: StoreBackend, processes: int = CONTEND
 
 @case("retry-table", "the retry table of v0.1 §5.4, every row")
 def reservation_retry_table(backend: StoreBackend, processes: int = CONTENDERS) -> CaseResult:
+    """`v0.1 §5.4`, every row, and SPEC-v0.7 §5.6's two properties where this suite can reach them.
+
+    **No two reservations of one key carry the same attempt number, and the number a reservation
+    method returns is the number it wrote.** The `FAILED` row asserts both on the path a suite
+    can drive: the renewal is handed attempt 2 and the record says 2. The windows where a store
+    breaks them are inside one method call, a renewal stalled between its read and its write or
+    a lost `COMMIT`, and `v0.6 §2.4` says why no barrier here reaches them. SPEC-v0.7 §8.3a's
+    T246 and T246b open them against Postgres with a proxy the tests own.
+    """
     title = reservation_retry_table.title
     store = backend.open()
 

--- a/src/ctrlrun/control.py
+++ b/src/ctrlrun/control.py
@@ -1070,11 +1070,16 @@ class Control:
                 # the one outcome that leaves the key retryable (§5.4).
                 try:
                     self._store.fail_effect(held_key, action.action_id, str(exc))
-                except (DuplicateEffect, AmbiguousEffect) as refused:
+                except CTRLRunError as refused:
                     # SPEC: §5.2 — the record moved on while the executor ran: this attempt's
                     # lease lapsed and another declared the effect AMBIGUOUS, which only a
                     # human moves it out of. The store's refusal is what propagates, not the
                     # NotExecuted: an agent that caught that would retry a key it lost.
+                    #
+                    # **Every refusal the store can answer with, not two of them.** A record a
+                    # human resolved while this attempt was still running answers
+                    # `InvalidArgument`, which escaped: no receipt, no event, and the caller
+                    # handed a store error about its own effect key. Found by review, round 2.
                     self._unrecorded(
                         action, evaluation, started_at, held_key, attempt, refused, approval
                     )
@@ -1117,12 +1122,26 @@ class Control:
                 try:
                     self._store.mark_ambiguous(held_key, action.action_id, error)
                     recorded = True
-                except (DuplicateEffect, AmbiguousEffect) as refused:
+                except CTRLRunError as refused:
                     # Recording an unknown outcome must never mask the exception that caused
-                    # it. A store that refuses here has the record in a state a human already
-                    # owns — where this attempt was trying to put it — and the receipt below
-                    # says `ambiguous` either way.
+                    # it, and must never be lost with the refusal either. The receipt and the
+                    # event below are written whatever the store answered, and they carry the
+                    # refusal, because where the store would not take the outcome the effect
+                    # record does not carry it: the evidence is then the only place it exists.
+                    #
+                    # **Every refusal, not two of them, and it is named rather than logged
+                    # away.** `DuplicateEffect` and `AmbiguousEffect` were caught and the
+                    # comment here said the record was in a state "a human already owns"; a
+                    # record a human resolved `FAILED` while this attempt was still running
+                    # answers `InvalidArgument` instead, which escaped this handler entirely,
+                    # so an unknown outcome reached no receipt and no event and the caller was
+                    # handed a store error in place of its executor's exception. Found by
+                    # review, round 2 (SPEC-v0.7 §12.3a).
                     _LOG.warning("%s: effect %s: %s", action.name, effect_key, refused)
+                    error = _storable(
+                        f"{error} (the effect record does not carry this outcome: the store "
+                        f"refused the write with {type(refused).__name__}: {refused})"
+                    )
             self._append(
                 EventType.EXECUTION_AMBIGUOUS,
                 action,
@@ -1152,7 +1171,7 @@ class Control:
         if held_key is not None:
             try:
                 self._store.commit_effect(held_key, action.action_id, result)
-            except (DuplicateEffect, AmbiguousEffect) as refused:
+            except CTRLRunError as refused:
                 # SPEC: §5.2 — the executor returned, but the key is no longer this attempt's
                 # to commit: the lease lapsed and the record is AMBIGUOUS until a human says
                 # otherwise. What happened at the remote is now as unknown as a timeout, so
@@ -1593,7 +1612,7 @@ class Control:
         started_at: datetime,
         effect_key: str,
         attempt: int,
-        refused: DuplicateEffect | AmbiguousEffect,
+        refused: CTRLRunError,
         approval: Approval | None,
     ) -> None:
         """Record an outcome the store refused to write (SPEC-v0.1 §5.2, §5.5).

--- a/src/ctrlrun/control.py
+++ b/src/ctrlrun/control.py
@@ -1081,7 +1081,14 @@ class Control:
                     # `InvalidArgument`, which escaped: no receipt, no event, and the caller
                     # handed a store error about its own effect key. Found by review, round 2.
                     self._unrecorded(
-                        action, evaluation, started_at, held_key, attempt, refused, approval
+                        action,
+                        evaluation,
+                        started_at,
+                        held_key,
+                        attempt,
+                        refused,
+                        approval,
+                        did=f"the executor raised NotExecuted: {exc}",
                     )
                     raise
             self._append(
@@ -1177,7 +1184,14 @@ class Control:
                 # otherwise. What happened at the remote is now as unknown as a timeout, so
                 # the attempt is recorded `ambiguous` rather than committed.
                 self._unrecorded(
-                    action, evaluation, started_at, held_key, attempt, refused, approval
+                    action,
+                    evaluation,
+                    started_at,
+                    held_key,
+                    attempt,
+                    refused,
+                    approval,
+                    did="the executor returned, so the remote may well have acted",
                 )
                 raise
         self._append(EventType.EXECUTION_COMMITTED, action, {}, effect_key, approval=approval)
@@ -1614,14 +1628,25 @@ class Control:
         attempt: int,
         refused: CTRLRunError,
         approval: Approval | None,
+        *,
+        did: str,
     ) -> None:
         """Record an outcome the store refused to write (SPEC-v0.1 §5.2, §5.5).
 
         The executor finished, but the effect record moved on while it ran, so what happened
         at the remote is exactly as unknown as a timeout: `ambiguous`, whatever the executor
         returned or raised. A terminal action still gets its receipt (§6.1).
+
+        **`did` is what the executor did, and it belongs in the receipt beside the refusal.**
+        Recording only the refusal made two receipts identical that a human must be able to tell
+        apart: an executor that *returned* leaves a remote that very likely acted, and one that
+        raised `NotExecuted` leaves a remote that very likely did not. With the effect record
+        carrying neither, the receipt is the only place that fact exists, and whoever runs
+        `ctrlrun resolve` on this key has nothing else to go on. Found by review, round 3.
         """
-        error = f"{type(refused).__name__}: {refused}"
+        error = _storable(
+            f"{did}, and the outcome write was refused: {type(refused).__name__}: {refused}"
+        )
         self._append(
             EventType.EXECUTION_AMBIGUOUS, action, {"error": error}, effect_key, approval=approval
         )

--- a/src/ctrlrun/postgres.py
+++ b/src/ctrlrun/postgres.py
@@ -601,24 +601,20 @@ class PostgresStateStore:
                 raise
             if effect_key is None or plan.reservation is None:
                 raise
-            if plan.renews:
-                self._resolve_lost_renewal(
-                    effect_key,
-                    plan.reservation,
-                    now,
-                    approval_id=approval_id,
-                    action_hash=action_hash,
-                    lease=lease,
-                )
-            else:
-                self._resolve_lost_insert(
-                    effect_key,
-                    plan.reservation,
-                    now,
-                    approval_id=approval_id,
-                    action_hash=action_hash,
-                    lease=lease,
-                )
+            # SPEC-v0.7 §5.6: the reservation returned is the one on the record. Returning
+            # `plan.reservation` here after a re-issue handed the caller the number first
+            # planned while the store held the number the re-issue wrote, which another process
+            # had already been handed.
+            resolve = self._resolve_lost_renewal if plan.renews else self._resolve_lost_insert
+            written = resolve(
+                effect_key,
+                plan.reservation,
+                now,
+                approval_id=approval_id,
+                action_hash=action_hash,
+                lease=lease,
+            )
+            return (approved.as_approval() if approved is not None else None), written
         return (approved.as_approval() if approved is not None else None), plan.reservation
 
     def _resolve_lost_renewal(
@@ -630,13 +626,14 @@ class PostgresStateStore:
         approval_id: str | None,
         action_hash: str | None,
         lease: timedelta,
-    ) -> None:
-        """§4.3.2 Table **A2**, for the one reservation that is an `UPDATE`.
+    ) -> Reservation:
+        """§4.3.2 Table **A2**, for the one reservation that is an `UPDATE`. Returns the
+        reservation on the record, which after a re-issue is the re-issue's (SPEC-v0.7 §5.6).
 
         A renewal's pre-state is `FAILED` (`v0.1 §5.4`'s one automatic retry). If the commit
         landed the record is ours and `RESERVED`; if it did not, the record is still `FAILED` and
         the renewal simply re-issues -- safe because that `UPDATE` is conditional on
-        `state = 'failed'`.
+        `state = 'failed'` and on the attempt it was planned from.
 
         Routing a renewal through Table A1 turned a **proven non-execution** into a refusal
         carrying a `state` that misdescribed the record: the collapse §4.3.2 exists to forbid,
@@ -645,9 +642,14 @@ class PostgresStateStore:
         found = self._fresh_read_effect(effect_key)
         if found is None:
             raise InvalidArgument(f"no reservation for effect {effect_key!r}")
-        if found.action_id == reservation.action_id and found.state is EffectState.RESERVED:
+        # §4.3.3's identity check, which the insert path had and this one did not. `RESERVED`
+        # under our `action_id` is not proof the commit landed: `action_id` is caller-supplyable,
+        # so another process renewing under the same one produced exactly that record, and 0.6.1
+        # concluded it was ours. Both processes then held one attempt, and the number returned
+        # was one this method never wrote. Building item 3a found it (SPEC-v0.7 §12.3a).
+        if _is_our_own_write(found, _reserved(reservation, found, now)):
             _took(A2_LANDED, effect_key)
-            return  # the commit landed
+            return reservation  # the commit landed, and this is the row it wrote
         if found.state is EffectState.FAILED:
             # Re-issue the SAME operation, approval included. Passing `None, None` here was the
             # double-spend `_resolve_lost_insert`'s comment describes, in the branch that
@@ -658,14 +660,22 @@ class PostgresStateStore:
             # different effect key. `v0.1 §4.2 A2` is that an approval is single-use and
             # consumed atomically with the reservation; this failed it open.
             _took(A2_REISSUE, effect_key)
-            self._authorize_and_reserve(
+            _, reissued = self._authorize_and_reserve(
                 approval_id, action_hash, effect_key, reservation.action_id, lease, retrying=True
             )
-            return
+            return _only(reissued, "reservation")
         _took(A2_REFUSE, effect_key)
         plan = plan_reservation(found, effect_key, reservation.action_id, lease, now)
         if plan.refusal is not None:
             raise plan.refusal
+        # `FAILED` is the only record `plan_reservation` grants over, and it re-issued above. A
+        # grant here would be a record nothing in this protocol writes, so refuse rather than
+        # return a reservation nobody wrote.
+        raise DuplicateEffect(
+            f"effect {effect_key!r} could not be resolved after a lost commit",
+            state=IN_PROGRESS_EFFECT,
+            effect_key=effect_key,
+        )
 
     def _resolve_lost_insert(
         self,
@@ -676,8 +686,9 @@ class PostgresStateStore:
         approval_id: str | None,
         action_hash: str | None,
         lease: timedelta,
-    ) -> None:
-        """§4.3.2 Table A1: what a lost `COMMIT` on the reservation `INSERT` means.
+    ) -> Reservation:
+        """§4.3.2 Table A1: what a lost `COMMIT` on the reservation `INSERT` means. Returns the
+        reservation on the record, which after a re-issue is the re-issue's (SPEC-v0.7 §5.6).
 
         The first row is an **identity check on the whole row we attempted to write**, not a match
         on `action_id` -- and the difference is a double execution. `Action.action_id` is
@@ -693,15 +704,19 @@ class PostgresStateStore:
             # operation was a double-spend: the effect was reserved, the caller was handed an
             # `Approval`, and the approval row was still `granted`, so the same approval then
             # authorised a second effect key. Found by review.
+            #
+            # And return what the re-issue wrote. It plans afresh, so if another process inserted
+            # and failed between the re-read and the re-issue's own read, it renews, and its
+            # number is not the one first planned (SPEC-v0.7 §5.6).
             _took(A1_REINSERT, effect_key)
-            self._authorize_and_reserve(
+            _, reissued = self._authorize_and_reserve(
                 approval_id, action_hash, effect_key, reservation.action_id, lease, retrying=True
             )
-            return
+            return _only(reissued, "reservation")
         expected = _reserved(reservation, None, now)
         if _is_our_own_write(found, expected):
             _took(A1_OURS, effect_key)
-            return  # the commit landed; we hold it
+            return reservation  # the commit landed; we hold it
         _took(A1_REFUSE, effect_key)
         plan = plan_reservation(found, effect_key, reservation.action_id, lease, now)
         if plan.refusal is not None:
@@ -777,6 +792,17 @@ class PostgresStateStore:
         if renews:
             # Only a FAILED record is renewable (§5.4); the WHERE clause says so again, so a
             # record that changed under us refuses instead of overwriting an attempt.
+            #
+            # **And only the FAILED record it was planned from** (SPEC-v0.7 §5.6). `_plan` read
+            # with a plain SELECT under READ COMMITTED, so between that read and this write
+            # another process can renew to the same number, run, fail and commit, leaving the
+            # record FAILED again. On `state` alone this matched it and wrote that number a
+            # second time: two dispatches, one attempt. `plan_reservation` renews to
+            # `record.attempt + 1` (effect.py), so the planned-from attempt is one below the
+            # reservation's, and it is taken from the plan, never from `previous`, which is a
+            # second read and may already be the newer record. The attempt number only ever
+            # moves by a renewal, so this closes the race rather than narrowing it.
+            planned_from = reservation.attempt - 1
             with connection.cursor() as cursor:
                 cursor.execute(
                     # `resolved_by` is cleared with them, and its own line says why: a human
@@ -787,7 +813,7 @@ class PostgresStateStore:
                     f"UPDATE {self._q}.effects SET "
                     f"state=%s, action_id=%s, attempt=%s, lease_expires_at=%s, "
                     "result_json=NULL, error=NULL, resolved_by=NULL, updated_at=%s "
-                    "WHERE effect_key=%s AND state=%s",
+                    "WHERE effect_key=%s AND state=%s AND attempt=%s",
                     (
                         str(record.state),
                         record.action_id,
@@ -796,6 +822,7 @@ class PostgresStateStore:
                         _iso(now),
                         record.effect_key,
                         str(EffectState.FAILED),
+                        planned_from,
                     ),
                 )
                 updated = cursor.rowcount

--- a/src/ctrlrun/postgres.py
+++ b/src/ctrlrun/postgres.py
@@ -8,8 +8,9 @@ processes* -- has to be re-earned.
 **The mechanism.** `UNIQUE(effect_key)` plus `INSERT … ON CONFLICT DO NOTHING`, under `READ
 COMMITTED`, which is Postgres's default and which this store does **not** set. The guarantee is
 the unique index, not the isolation level. Every later transition is a compare-and-set --
-`UPDATE … WHERE effect_key = %s AND state = %s AND action_id = %s` -- with **the row count
-checked**.
+`UPDATE … WHERE effect_key = %s AND state = %s AND action_id = %s AND attempt = %s` -- with **the
+row count checked**. The attempt is SPEC-v0.7 §5.6's: every write is conditioned on the attempt
+number it read, so none can put an older one back.
 
 **The decisions stay where they are.** `plan_reservation`, `plan_lease_extension`,
 `check_consumable` and `check_answerable` are pure functions in `effect.py` and `approval.py`, and
@@ -203,6 +204,12 @@ def _is_our_own_write(found: EffectRecord, expected: EffectRecord) -> bool:
     here are what make the *realistic* collision detectable: a second attempt under the same id
     at any other instant, with any other lease, or at a different `attempt` number, differs in a
     column and is refused. SPEC-v0.6 §4.3.3 carries the argument.
+
+    **On the renewal path `created_at` separates nothing**, and the paragraph above should not be
+    read as if it did there. A renewal keeps the record's `created_at` (`_reserved` takes it from
+    the record it renews), so the expected row takes it from the record the re-read found and it
+    is equal by construction. What tells a rival's renewal from ours is `attempt`,
+    `lease_expires_at` and `updated_at` (SPEC-v0.7 §12.3a).
     """
     return (
         found.effect_key == expected.effect_key
@@ -800,8 +807,11 @@ class PostgresStateStore:
             # second time: two dispatches, one attempt. `plan_reservation` renews to
             # `record.attempt + 1` (effect.py), so the planned-from attempt is one below the
             # reservation's, and it is taken from the plan, never from `previous`, which is a
-            # second read and may already be the newer record. The attempt number only ever
-            # moves by a renewal, so this closes the race rather than narrowing it.
+            # second read and may already be the newer record. That closes the race rather than
+            # narrowing it only because the attempt number only ever moves by a renewal, and that
+            # is true only because every other `UPDATE` on this table is conditioned on the
+            # attempt it read as well (`_write_effect`, `_transition`). At 0.6.1 they were not,
+            # and a stale one could write an older number back (T246c).
             planned_from = reservation.attempt - 1
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -908,6 +918,15 @@ class PostgresStateStore:
 
         `was` is the record this write was planned against. It is optional only so the one caller
         that has already established the pre-state under a row lock need not repeat it.
+
+        **And on the attempt it was planned against** (SPEC-v0.7 §5.6). The `SET` writes the
+        attempt number it read, so a condition on `action_id` and `state` alone let a stale write
+        put an older number back: a caller that retries one `Action` reuses its `action_id`, so
+        `AMBIGUOUS` at 1 could become `AMBIGUOUS` at 2 under the same id between this read and
+        this write, and a `resolve_effect` decided on attempt 1 then wrote `FAILED` at **1** over
+        it. The next renewal handed out 2 again. A review reproduced it; T246c is the test.
+        `resolve_effect`, `extend_lease`, `hold_continuation` and §4.2.2's kept `AMBIGUOUS` write
+        all come here.
         """
         expected = was if was is not None else record
         with connection.cursor() as cursor:
@@ -915,7 +934,7 @@ class PostgresStateStore:
                 f"UPDATE {self._q}.effects SET "
                 f"state=%s, action_id=%s, attempt=%s, lease_expires_at=%s, "
                 "result_json=%s, error=%s, updated_at=%s, resolved_by=%s "
-                "WHERE effect_key=%s AND action_id=%s AND state=%s",
+                "WHERE effect_key=%s AND action_id=%s AND state=%s AND attempt=%s",
                 (
                     str(record.state),
                     record.action_id,
@@ -928,6 +947,7 @@ class PostgresStateStore:
                     record.effect_key,
                     expected.action_id,
                     str(expected.state),
+                    expected.attempt,
                 ),
             )
             if cursor.rowcount != 1:
@@ -992,11 +1012,14 @@ class PostgresStateStore:
             )
             moved = _transitioned(record, state, now, result=result, error=error)
             with connection.cursor() as cursor:
+                # Conditioned on the attempt read, as `_write_effect` is and for its reason: the
+                # `SET` writes that number back, and `action_id` and `state` can come round again
+                # at a newer attempt under a reused `action_id` (SPEC-v0.7 §5.6, T246c).
                 cursor.execute(
                     f"UPDATE {self._q}.effects SET "
                     f"state=%s, action_id=%s, attempt=%s, lease_expires_at=%s, "
                     "result_json=%s, error=%s, updated_at=%s "
-                    "WHERE effect_key=%s AND action_id=%s AND state=%s",
+                    "WHERE effect_key=%s AND action_id=%s AND state=%s AND attempt=%s",
                     (
                         str(moved.state),
                         moved.action_id,
@@ -1008,6 +1031,7 @@ class PostgresStateStore:
                         effect_key,
                         action_id,
                         str(record.state),
+                        record.attempt,
                     ),
                 )
                 updated = cursor.rowcount

--- a/src/ctrlrun/postgres.py
+++ b/src/ctrlrun/postgres.py
@@ -1026,13 +1026,32 @@ class PostgresStateStore:
         self._transition(effect_key, action_id, EffectState.EXECUTING, _RESERVED)
 
     def commit_effect(self, effect_key: str, action_id: str, result: Any) -> None:
-        self._transition(effect_key, action_id, EffectState.COMMITTED, _EXECUTING, result=result)
+        # `carries_outcome`: what the executor did, so a record that moved under this write is
+        # re-issued against rather than refused (SPEC-v0.7 §5.6). It is passed here, at the call
+        # site, and never inferred from the target state: `_transition` is generic, and a later
+        # transition to `COMMITTED` or `AMBIGUOUS` that is somebody's *decision* rather than an
+        # executor's outcome -- a human's resolution is exactly that -- must not inherit it.
+        self._transition(
+            effect_key,
+            action_id,
+            EffectState.COMMITTED,
+            _EXECUTING,
+            result=result,
+            carries_outcome=True,
+        )
 
     def fail_effect(self, effect_key: str, action_id: str, error: str) -> None:
         self._transition(effect_key, action_id, EffectState.FAILED, _EXECUTING, error=error)
 
     def mark_ambiguous(self, effect_key: str, action_id: str, error: str) -> None:
-        self._transition(effect_key, action_id, EffectState.AMBIGUOUS, _UNFINISHED, error=error)
+        self._transition(
+            effect_key,
+            action_id,
+            EffectState.AMBIGUOUS,
+            _UNFINISHED,
+            error=error,
+            carries_outcome=True,
+        )
 
     def _transition(
         self,
@@ -1045,6 +1064,7 @@ class PostgresStateStore:
         error: str | None = None,
         retrying: bool = False,
         restaged: bool = False,
+        carries_outcome: bool = False,
     ) -> None:
         """One compare-and-set, with the row count checked (§4.2).
 
@@ -1093,7 +1113,10 @@ class PostgresStateStore:
                 found = _checked(
                     self._read_effect(connection, effect_key), effect_key, action_id, expected, now
                 )
-                if state in _OUTCOMES and not restaged:
+                # The set is the assertion, not the condition: only these two states can carry
+                # an executor's outcome, and a caller that says otherwise is a wiring bug.
+                assert not carries_outcome or state in _OUTCOMES, state
+                if carries_outcome and not restaged:
                     # The predicate passed: the record is still ours and still in a state this
                     # transition may be made from, and only the attempt or the pre-state moved
                     # under us. **An outcome is not dropped here** (SPEC-v0.7 §5.6). Refusing
@@ -1114,6 +1137,25 @@ class PostgresStateStore:
                 raise _moved(found, record, effect_key)
         except _Restage as moved:
             self._rollback(connection)
+            # Logged **before** the re-issue, not after it. Logging afterwards told the operator
+            # about a restage only when it went on to succeed, so a restage that then refused left
+            # no line at all and §4.3.4's rule -- which branch ran is observable -- did not hold
+            # for the one case worth reading a log about. Found by review, round 3.
+            _LOG.warning(
+                "effect %r moved to attempt %s while %s was being recorded; re-issuing the "
+                "outcome against the record as it now stands (SPEC-v0.7 5.6)",
+                effect_key,
+                moved.found.attempt,
+                state,
+                extra={"effect_key": effect_key, "attempt": moved.found.attempt, "restage": True},
+            )
+            # **Both bounds travel, and neither resets the other.** `retrying` is passed on
+            # because this re-issue's own `COMMIT` can be lost, and a lost commit that re-entered
+            # here with `retrying` cleared alternated with the restage bound forever: a review
+            # composed the two halves -- every `COMMIT` lost, and a record that keeps moving --
+            # and measured `RecursionError` at 113 deep, which is T155f's failure mode returning
+            # by another door. Every loop in this project is bounded, and two bounds that reset
+            # each other are not a bound.
             self._transition(
                 effect_key,
                 action_id,
@@ -1121,15 +1163,9 @@ class PostgresStateStore:
                 expected,
                 result=result,
                 error=error,
+                retrying=retrying,
                 restaged=True,
-            )
-            _LOG.warning(
-                "effect %r moved to attempt %s while %s was being recorded; the outcome was "
-                "re-issued against the record as it now stands (SPEC-v0.7 5.6)",
-                effect_key,
-                moved.found.attempt,
-                state,
-                extra={"effect_key": effect_key, "attempt": moved.found.attempt},
+                carries_outcome=carries_outcome,
             )
             return
         except AmbiguousWrite:
@@ -1149,7 +1185,16 @@ class PostgresStateStore:
                 # could classify it -- leaving the record stranded `EXECUTING`. Found by review.
                 # *Every loop in this project is bounded*, and a re-read path is a loop.
                 raise
-            self._resolve_lost_update(effect_key, action_id, state, expected, result, error)
+            self._resolve_lost_update(
+                effect_key,
+                action_id,
+                state,
+                expected,
+                result,
+                error,
+                restaged=restaged,
+                carries_outcome=carries_outcome,
+            )
 
     def _resolve_lost_update(
         self,
@@ -1159,6 +1204,9 @@ class PostgresStateStore:
         expected: frozenset[EffectState],
         result: Any,
         error: str | None,
+        *,
+        restaged: bool = False,
+        carries_outcome: bool = False,
     ) -> None:
         """§4.3.2 Table A2: a lost `COMMIT` on a compare-and-set.
 
@@ -1181,8 +1229,18 @@ class PostgresStateStore:
             return  # the commit landed
         if found.action_id == action_id and found.state in expected:
             _took(A2_REISSUE, effect_key)
+            # `restaged` travels with `retrying` for the reason the restage handler passes
+            # `retrying` on: a bound that another path clears is not a bound (SPEC-v0.7 §12.3a).
             self._transition(
-                effect_key, action_id, state, expected, result=result, error=error, retrying=True
+                effect_key,
+                action_id,
+                state,
+                expected,
+                result=result,
+                error=error,
+                retrying=True,
+                restaged=restaged,
+                carries_outcome=carries_outcome,
             )
             return
         _took(A2_REFUSE, effect_key)

--- a/src/ctrlrun/postgres.py
+++ b/src/ctrlrun/postgres.py
@@ -50,6 +50,7 @@ from .approval import (
     check_consumable,
 )
 from .effect import (
+    COMMITTED_EFFECT,
     DEFAULT_LEASE,
     IN_PROGRESS_EFFECT,
     LEASE_EXPIRED,
@@ -61,6 +62,7 @@ from .effect import (
     plan_reservation,
 )
 from .errors import (
+    AmbiguousEffect,
     ApprovalMismatch,
     CTRLRunError,
     DuplicateEffect,
@@ -155,6 +157,17 @@ def _psycopg() -> Any:
     return psycopg
 
 
+class _Restage(Exception):  # noqa: N818 - errors.py's convention: no suffix
+    """Internal: the conditional `UPDATE` matched nothing and the record is still one this
+    outcome may be written to, at another attempt. Raised inside the transaction so the ordinary
+    handler rolls it back, and caught immediately outside it, because the re-issue opens a
+    transaction of its own on the same connection (SPEC-v0.7 §5.6)."""
+
+    def __init__(self, found: EffectRecord) -> None:
+        super().__init__(f"effect {found.effect_key!r} moved to attempt {found.attempt}")
+        self.found = found
+
+
 # `errors.py`'s convention: this codebase's exception names carry no suffix.
 class AmbiguousWrite(CTRLRunError):  # noqa: N818
     """A `COMMIT` whose outcome the store could not observe (SPEC-v0.6 §4.3 Table A).
@@ -220,6 +233,31 @@ def _is_our_own_write(found: EffectRecord, expected: EffectRecord) -> bool:
         and found.created_at == expected.created_at
         and found.updated_at == expected.updated_at
     )
+
+
+#: The outcome transitions. A stale one is re-issued against the re-read rather than refused,
+#: because refusing it drops what the executor said (SPEC-v0.7 §5.6, §12.3a).
+_OUTCOMES: Final = frozenset({EffectState.COMMITTED, EffectState.AMBIGUOUS})
+
+
+def _moved(found: EffectRecord, was: EffectRecord, effect_key: str) -> CTRLRunError:
+    """The refusal a record that moved between the read and the write earns (SPEC-v0.7 §5.6).
+
+    **The type comes from what the re-read found, and the message says what moved.** Every one of
+    these used to be `DuplicateEffect(state=in_progress)`, which `errors.py` defines as *another
+    attempt holds a live reservation*: after a stale `resolve_effect` the record is `AMBIGUOUS` at
+    a newer attempt, which is nobody's reservation, and a caller reading `in_progress` would wait
+    for a dispatch that is not running. Found by review, round 2.
+    """
+    moved = (
+        f"effect {effect_key!r} moved from attempt {was.attempt} ({was.state}) to attempt "
+        f"{found.attempt} ({found.state}) since it was read; nothing was written"
+    )
+    if found.state is EffectState.AMBIGUOUS:
+        return AmbiguousEffect(moved, effect_key=effect_key, action_id=found.action_id)
+    if found.state is EffectState.COMMITTED:
+        return DuplicateEffect(moved, state=COMMITTED_EFFECT, effect_key=effect_key)
+    return DuplicateEffect(moved, state=IN_PROGRESS_EFFECT, effect_key=effect_key)
 
 
 class PostgresStateStore:
@@ -737,26 +775,40 @@ class PostgresStateStore:
     def _consumable(
         self, connection: Any, approval_id: str, action_hash: str, now: datetime
     ) -> ApprovalRecord:
-        verdict = check_consumable(
-            self._read_approval(connection, approval_id), approval_id, action_hash, now
-        )
+        # The record is read here rather than inside the call, because `ApprovalVerdict` carries
+        # exactly one of `record` and `refusal`, so a refusal that asks for the expiry write
+        # carries no record to take the status from.
+        found = self._read_approval(connection, approval_id)
+        verdict = check_consumable(found, approval_id, action_hash, now)
         if verdict.refusal is not None:
-            if verdict.expire:
+            if verdict.expire and found is not None:
                 # §4.2.2's second kept write: a lapsed approval is evidence. Its own transaction,
-                # ordered before the refusing one.
-                self._expire(approval_id)
+                # ordered before the refusing one, and conditional on the status it read.
+                self._expire(approval_id, found.status)
             raise verdict.refusal
         return _only(verdict.record, "approval record")
 
-    def _expire(self, approval_id: str) -> None:
+    def _expire(self, approval_id: str, was: ApprovalStatus) -> None:
+        """§4.2.2's second kept write, as a compare-and-set on the status it was planned against.
+
+        **Unconditional, this corrupted evidence.** The status comes from a plain `SELECT` that
+        saw `granted` past `expires_at`; a consumption committing between that read and this write
+        was overwritten, so an approval that authorised a real effect read `expired` and the
+        evidence said a human's yes had never been spent. Every other write on this table is
+        already a compare-and-set (`_consume_locked`, `grant_approval`, `deny_approval`); this one
+        was the exception, found by review, round 2 (SPEC-v0.7 §12.3a). A row count of zero needs
+        no refusal: the approval was answered or spent by somebody else, and the caller is being
+        refused anyway by the verdict that asked for this write.
+        """
         connection = self._connect()
         connection.execute("BEGIN")
         self._use_schema(connection)
         try:
             with connection.cursor() as cursor:
                 cursor.execute(
-                    f"UPDATE {self._q}.approvals SET status = %s WHERE approval_id = %s",
-                    (str(ApprovalStatus.EXPIRED), approval_id),
+                    f"UPDATE {self._q}.approvals SET status = %s WHERE approval_id = %s "
+                    "AND status = %s",
+                    (str(ApprovalStatus.EXPIRED), approval_id, str(was)),
                 )
             self._commit(connection)
         finally:
@@ -963,11 +1015,10 @@ class PostgresStateStore:
                     frozenset({expected.state}),
                     self._clock(),
                 )
-                raise DuplicateEffect(
-                    f"effect {record.effect_key!r} was taken by another attempt",
-                    state=IN_PROGRESS_EFFECT,
-                    effect_key=record.effect_key,
-                )
+                # The predicate passed, so the record is still ours and still in the state this
+                # write was planned against: what moved is the attempt. `_moved` says so, and
+                # takes its type from the record rather than calling everything in_progress.
+                raise _moved(found, expected, record.effect_key)
 
     # --- transitions (SPEC-v0.6 §4.2, §4.3.2 Table A2) ----------------------------------
 
@@ -993,6 +1044,7 @@ class PostgresStateStore:
         result: Any = None,
         error: str | None = None,
         retrying: bool = False,
+        restaged: bool = False,
     ) -> None:
         """One compare-and-set, with the row count checked (§4.2).
 
@@ -1038,14 +1090,48 @@ class PostgresStateStore:
             if updated != 1:
                 # The record changed between the read and the write. Re-plan through the same
                 # predicate rather than guessing.
-                _checked(
+                found = _checked(
                     self._read_effect(connection, effect_key), effect_key, action_id, expected, now
                 )
-                raise DuplicateEffect(
-                    f"effect {effect_key!r} was taken by another attempt",
-                    state=IN_PROGRESS_EFFECT,
-                    effect_key=effect_key,
-                )
+                if state in _OUTCOMES and not restaged:
+                    # The predicate passed: the record is still ours and still in a state this
+                    # transition may be made from, and only the attempt or the pre-state moved
+                    # under us. **An outcome is not dropped here** (SPEC-v0.7 §5.6). Refusing
+                    # wrote nothing, and the effect record is what gates the next renewal: a
+                    # review measured a renewal to attempt 3 with attempt 1's `commit_effect`
+                    # recorded on no record at all, which for a refund that had landed is a
+                    # second refund. Re-issued once against the re-read, the outcome lands on the
+                    # newer attempt, which is where the same call a moment later would have put
+                    # it; attributing it there is §12.3a's residual, losing it is not.
+                    #
+                    # `begin_execution` and `fail_effect` are NOT re-issued, and the difference
+                    # is the point: `FAILED` asserts that nothing happened, so re-issuing attempt
+                    # 1's over attempt 2 in flight would permit a retry beside a running dispatch.
+                    #
+                    # `restaged` bounds this at one, as `retrying` bounds the lost-commit re-read:
+                    # a record that moves again under the re-issue is refused rather than chased.
+                    raise _Restage(found)
+                raise _moved(found, record, effect_key)
+        except _Restage as moved:
+            self._rollback(connection)
+            self._transition(
+                effect_key,
+                action_id,
+                state,
+                expected,
+                result=result,
+                error=error,
+                restaged=True,
+            )
+            _LOG.warning(
+                "effect %r moved to attempt %s while %s was being recorded; the outcome was "
+                "re-issued against the record as it now stands (SPEC-v0.7 5.6)",
+                effect_key,
+                moved.found.attempt,
+                state,
+                extra={"effect_key": effect_key, "attempt": moved.found.attempt},
+            )
+            return
         except AmbiguousWrite:
             raise
         except BaseException:
@@ -1274,10 +1360,11 @@ class PostgresStateStore:
         self._commit(connection)
 
     def _answerable(self, connection: Any, approval_id: str, now: datetime) -> ApprovalRecord:
-        verdict = check_answerable(self._read_approval(connection, approval_id), approval_id, now)
+        found = self._read_approval(connection, approval_id)
+        verdict = check_answerable(found, approval_id, now)
         if verdict.refusal is not None:
-            if verdict.expire:
-                self._expire(approval_id)
+            if verdict.expire and found is not None:
+                self._expire(approval_id, found.status)
             raise verdict.refusal
         return _only(verdict.record, "approval record")
 

--- a/src/ctrlrun/state.py
+++ b/src/ctrlrun/state.py
@@ -1607,6 +1607,11 @@ class SQLiteStateStore:
         if renews:
             # Only a FAILED record is renewable (§5.4); the WHERE clause says so again, so a
             # record that changed under us refuses instead of overwriting an attempt.
+            #
+            # `AND attempt=?`, the attempt the plan renewed from, is SPEC-v0.7 §5.6's condition
+            # for Postgres, kept here for defence in depth and stated as what it is: BEGIN
+            # IMMEDIATE already holds the write lock across the read and this write, so the
+            # stale case cannot happen on this backend and removing the clause fails no test.
             updated = connection.execute(
                 # `resolved_by` is cleared with them, and its own line says why: a human
                 # resolving to FAILED is saying *"this may be retried"*, not committing the
@@ -1615,7 +1620,7 @@ class SQLiteStateStore:
                 # because the resolver used to live inside the `error` this UPDATE clears.
                 "UPDATE effects SET state=?, action_id=?, attempt=?, lease_expires_at=?, "
                 "result_json=NULL, error=NULL, resolved_by=NULL, updated_at=? "
-                "WHERE effect_key=? AND state=?",
+                "WHERE effect_key=? AND state=? AND attempt=?",
                 (
                     str(record.state),
                     record.action_id,
@@ -1624,6 +1629,7 @@ class SQLiteStateStore:
                     _iso(now),
                     record.effect_key,
                     str(EffectState.FAILED),
+                    reservation.attempt - 1,
                 ),
             ).rowcount
             if updated != 1:

--- a/tests/failure_injection.py
+++ b/tests/failure_injection.py
@@ -110,10 +110,12 @@ def statement_of(kind: bytes, body: bytes) -> bytes | None:
     `name NUL query NUL ...`. The Bind carries the arguments, so an effect key that happens to
     contain `UPDATE` is never mistaken for one, for the reason `is_commit` parses frames at all.
 
-    A statement psycopg has already prepared on that connection (its `prepare_threshold`, five
-    executions of one query) is sent with no Parse and so has no text here. The tests that hold
-    a statement use a fresh connection, where the first execution always carries it, and assert
-    that the hold fired.
+    psycopg sends the text with each execution of a query until that query has run
+    `prepare_threshold` times (five by default) on that connection; after that it executes a
+    named prepared statement, whose Execute carries no text, and this returns `None` for it. So a
+    predicate built on this sees only a query's first few executions on a connection. Every
+    statement the tests hold is within those, and every test that holds one asserts the hold
+    fired, so a statement that had already been prepared fails the test rather than passing it.
     """
     if kind == b"Q":
         return body.split(b"\x00", 1)[0]
@@ -127,8 +129,8 @@ def statement_of(kind: bytes, body: bytes) -> bytes | None:
 class Proxy:
     """A TCP relay in front of Postgres, with a switch for each way it can break.
 
-    Four modes, each named for the row of §4.3's Table A it produces, and a fifth, `hold_when`,
-    which produces none and opens a window instead (SPEC-v0.7 §5.6):
+    Four modes, each named for the row of §4.3's Table A it produces, and a fifth, `arm()`, which
+    produces none and opens a window instead (SPEC-v0.7 §5.6):
 
     - `kill_on_commit` -- forward the `COMMIT` to the server, let it land, then drop the client.
       The server very likely committed and the client will never know: **ambiguous**, and the
@@ -147,15 +149,16 @@ class Proxy:
       client sees a stall, not a reset, and `partition = False` genuinely restores the connection,
       which is §4.5's "and restore it". Discarding instead would make the restore unexercisable:
       the query the server never received cannot arrive late.
-    - `hold_when` -- a predicate over each parsed client message, `(type, body)`. The first message
-      it accepts is **held**: the chunk carrying it is not forwarded, `holding` is set, and the
-      pump waits for `release()`. One statement on one connection, where `partition` stops every
-      connection at once. It is what opens a window *inside* a store method, between one
-      statement and the next, which SPEC-v0.7 §5.6's windows need and nothing else here could
+    - `arm(predicate)` -- a predicate over each parsed client message, `(type, body)`. The first
+      message it accepts is **held**: the chunk carrying it is not forwarded, `holding` is set,
+      and the pump waits for `release()`. One statement on one connection, where `partition`
+      stops every connection at once. It is what opens a window *inside* a store method, between
+      one statement and the next, which SPEC-v0.7 §5.6's windows need and nothing else here could
       reach: the statements before it have run, the held one has not, and every other connection
-      carries on. It fires once and clears itself. The chunk is held whole, which for a client
-      that waits for each statement's reply before sending the next (psycopg does) is the held
-      statement's own Parse/Bind/Execute/Sync and nothing else.
+      carries on. It fires once and disarms; `arm()` again for the next window, which it refuses
+      while one is armed or held. The chunk is held whole, which for a client that waits for each
+      statement's reply before sending the next (psycopg does) is the held statement's own
+      Parse/Bind/Execute/Sync and nothing else.
     """
 
     upstream_host: str
@@ -189,8 +192,8 @@ class Proxy:
     #: `COMMIT` would ever be recognised -- a test asserting `commits_seen` would fail loudly, but
     #: this says why. Local connections in CI negotiate no TLS.
     tls_negotiated: bool = False
-    hold_when: Callable[[bytes, bytes], bool] | None = None
-    #: Set the moment `hold_when` fires, so a test waits on the window with a bound rather than
+    _hold_when: Callable[[bytes, bytes], bool] | None = None
+    #: Set the moment an armed hold fires, so a test waits on the window with a bound rather than
     #: sleeping and hoping the statement has arrived.
     holding: threading.Event = field(default_factory=threading.Event)
     #: Messages held, so a test can assert the window it describes was opened.
@@ -228,19 +231,45 @@ class Proxy:
             self.commits_dropped = 0
             self.holds = 0
 
-    def release(self) -> None:
-        """Forward what `hold_when` held. Safe to call when nothing is held, and more than once."""
-        self._released.set()
+    def arm(self, predicate: Callable[[bytes, bytes], bool]) -> None:
+        """Hold the next client message `predicate` accepts, until `release()`.
 
-    def _holds(self, kind: bytes, body: bytes) -> bool:
-        """Does `hold_when` claim this message? At most once: the predicate clears on firing."""
+        **Each arming starts clean.** The first version was one-shot and did not say so: `holding`
+        and the release event were never cleared, so a second hold reported itself held before its
+        statement arrived and forwarded that statement at once, while `holds` counted a window
+        that never opened. `holding` is cleared **in place**, because a test may already be
+        waiting on it for the hold it is about to arm (T246b's insert variant arms from `on_drop`,
+        after it has started waiting). The release event is **replaced**, so a pump still waking
+        from the previous release is released by that one and never by a later one. And it refuses
+        to arm over a hold that is armed and has not fired, or has fired and not been released,
+        rather than silently replacing a window a test is relying on.
+        """
         with self._lock:
-            predicate = self.hold_when
+            if self._hold_when is not None:
+                raise RuntimeError("a hold is already armed and has not fired")
+            if self.holding.is_set() and not self._released.is_set():
+                raise RuntimeError("a statement is still held; release() it before arming again")
+            self.holding.clear()
+            self._released = threading.Event()
+            self._hold_when = predicate
+
+    def release(self) -> None:
+        """Forward what the armed hold held. Safe when nothing is held, and more than once."""
+        with self._lock:
+            released = self._released
+        released.set()
+
+    def _holds(self, kind: bytes, body: bytes) -> threading.Event | None:
+        """If the armed predicate claims this message: disarm, mark it held, and return the event
+        its release will set. `None` otherwise."""
+        with self._lock:
+            predicate = self._hold_when
             if predicate is None or not predicate(kind, body):
-                return False
-            self.hold_when = None
+                return None
+            self._hold_when = None
             self.holds += 1
-            return True
+            self.holding.set()
+            return self._released
 
     def url(self, template: str) -> str:
         """`template` with its host and port pointed at this proxy."""
@@ -309,11 +338,11 @@ class Proxy:
                 injecting is the exact false green this file exists to eliminate.
                 """
                 commit_at = -1
-                hold = False
+                held: threading.Event | None = None
                 if frontend is not None:
                     for kind, body, offset in frontend.feed(data):
-                        if not hold and self._holds(kind, body):
-                            hold = True
+                        if held is None:
+                            held = self._holds(kind, body)
                         if not is_commit(kind, body):
                             continue
                         with self._lock:
@@ -325,14 +354,13 @@ class Proxy:
                     with self._lock:
                         self.tls_negotiated = True
 
-                if hold:
+                if held is not None:
                     # Parsed already, so the frame parser stays aligned; only the forwarding
                     # waits. The server has not seen the held statement and the client is blocked
                     # on its reply, so nothing on this connection moves until `release()`. The
                     # wait ends on `stop()` too, so a test that fails before releasing cannot
                     # leave this pump running.
-                    self.holding.set()
-                    while not self._released.wait(0.2):
+                    while not held.wait(0.2):
                         if self._stop.is_set():
                             return False
 

--- a/tests/failure_injection.py
+++ b/tests/failure_injection.py
@@ -110,12 +110,13 @@ def statement_of(kind: bytes, body: bytes) -> bytes | None:
     `name NUL query NUL ...`. The Bind carries the arguments, so an effect key that happens to
     contain `UPDATE` is never mistaken for one, for the reason `is_commit` parses frames at all.
 
-    psycopg sends the text with each execution of a query until that query has run
-    `prepare_threshold` times (five by default) on that connection; after that it executes a
-    named prepared statement, whose Execute carries no text, and this returns `None` for it. So a
-    predicate built on this sees only a query's first few executions on a connection. Every
-    statement the tests hold is within those, and every test that holds one asserts the hold
-    fired, so a statement that had already been prepared fails the test rather than passing it.
+    psycopg carries the text on a query's **first six executions** on one connection, and a
+    review measured it rather than reading it off the default: executions 1 to 5 are unnamed
+    Parses, execution 6 is the named Parse that prepares it (`prepare_threshold`, five), and from
+    7 on the Bind names the prepared statement and no text travels, so this returns `None`. Every
+    statement the tests hold is the first or second execution of its query on its connection, and
+    every test that holds one asserts `holding.wait(BOUND)`, so a statement that had already been
+    prepared fails the test rather than slipping past it.
     """
     if kind == b"Q":
         return body.split(b"\x00", 1)[0]
@@ -254,8 +255,17 @@ class Proxy:
             self._hold_when = predicate
 
     def release(self) -> None:
-        """Forward what the armed hold held. Safe when nothing is held, and more than once."""
+        """Forward what the armed hold is holding. Safe when nothing is held, and more than once.
+
+        **It releases a hold that has fired, and never one that has not.** Releasing an armed hold
+        before its statement arrived pre-released it: the statement was then forwarded the moment
+        it was parsed, `holding` was set and `holds` counted it, which is the lie `arm()` exists to
+        remove, in a narrower form. A test whose `finally` releases, or which releases the wrong
+        hold, would have opened no window and passed. Found by review, round 2.
+        """
         with self._lock:
+            if not self.holding.is_set():
+                return
             released = self._released
         released.set()
 

--- a/tests/failure_injection.py
+++ b/tests/failure_injection.py
@@ -102,11 +102,33 @@ def is_commit(kind: bytes, body: bytes) -> bool:
     return body.split(b"\x00", 1)[0].strip().upper() == b"COMMIT"
 
 
+def statement_of(kind: bytes, body: bytes) -> bytes | None:
+    """The SQL text one client message carries, or `None` if it carries none.
+
+    A simple Query carries it whole. A parameterised statement, which is how psycopg sends every
+    `cursor.execute` with arguments, is Parse/Bind/Execute, and the text is in the **Parse**:
+    `name NUL query NUL ...`. The Bind carries the arguments, so an effect key that happens to
+    contain `UPDATE` is never mistaken for one, for the reason `is_commit` parses frames at all.
+
+    A statement psycopg has already prepared on that connection (its `prepare_threshold`, five
+    executions of one query) is sent with no Parse and so has no text here. The tests that hold
+    a statement use a fresh connection, where the first execution always carries it, and assert
+    that the hold fired.
+    """
+    if kind == b"Q":
+        return body.split(b"\x00", 1)[0]
+    if kind == b"P":
+        parts = body.split(b"\x00", 2)
+        return parts[1] if len(parts) > 2 else None
+    return None
+
+
 @dataclass
 class Proxy:
     """A TCP relay in front of Postgres, with a switch for each way it can break.
 
-    Four modes, each named for the row of §4.3's Table A it produces:
+    Four modes, each named for the row of §4.3's Table A it produces, and a fifth, `hold_when`,
+    which produces none and opens a window instead (SPEC-v0.7 §5.6):
 
     - `kill_on_commit` -- forward the `COMMIT` to the server, let it land, then drop the client.
       The server very likely committed and the client will never know: **ambiguous**, and the
@@ -125,6 +147,15 @@ class Proxy:
       client sees a stall, not a reset, and `partition = False` genuinely restores the connection,
       which is §4.5's "and restore it". Discarding instead would make the restore unexercisable:
       the query the server never received cannot arrive late.
+    - `hold_when` -- a predicate over each parsed client message, `(type, body)`. The first message
+      it accepts is **held**: the chunk carrying it is not forwarded, `holding` is set, and the
+      pump waits for `release()`. One statement on one connection, where `partition` stops every
+      connection at once. It is what opens a window *inside* a store method, between one
+      statement and the next, which SPEC-v0.7 §5.6's windows need and nothing else here could
+      reach: the statements before it have run, the held one has not, and every other connection
+      carries on. It fires once and clears itself. The chunk is held whole, which for a client
+      that waits for each statement's reply before sending the next (psycopg does) is the held
+      statement's own Parse/Bind/Execute/Sync and nothing else.
     """
 
     upstream_host: str
@@ -158,6 +189,13 @@ class Proxy:
     #: `COMMIT` would ever be recognised -- a test asserting `commits_seen` would fail loudly, but
     #: this says why. Local connections in CI negotiate no TLS.
     tls_negotiated: bool = False
+    hold_when: Callable[[bytes, bytes], bool] | None = None
+    #: Set the moment `hold_when` fires, so a test waits on the window with a bound rather than
+    #: sleeping and hoping the statement has arrived.
+    holding: threading.Event = field(default_factory=threading.Event)
+    #: Messages held, so a test can assert the window it describes was opened.
+    holds: int = 0
+    _released: threading.Event = field(default_factory=threading.Event)
     _lock: threading.Lock = field(default_factory=threading.Lock)
 
     def start(self) -> Proxy:
@@ -188,6 +226,21 @@ class Proxy:
             self.commits_seen = 0
             self.clients_killed = 0
             self.commits_dropped = 0
+            self.holds = 0
+
+    def release(self) -> None:
+        """Forward what `hold_when` held. Safe to call when nothing is held, and more than once."""
+        self._released.set()
+
+    def _holds(self, kind: bytes, body: bytes) -> bool:
+        """Does `hold_when` claim this message? At most once: the predicate clears on firing."""
+        with self._lock:
+            predicate = self.hold_when
+            if predicate is None or not predicate(kind, body):
+                return False
+            self.hold_when = None
+            self.holds += 1
+            return True
 
     def url(self, template: str) -> str:
         """`template` with its host and port pointed at this proxy."""
@@ -256,8 +309,11 @@ class Proxy:
                 injecting is the exact false green this file exists to eliminate.
                 """
                 commit_at = -1
+                hold = False
                 if frontend is not None:
                     for kind, body, offset in frontend.feed(data):
+                        if not hold and self._holds(kind, body):
+                            hold = True
                         if not is_commit(kind, body):
                             continue
                         with self._lock:
@@ -268,6 +324,17 @@ class Proxy:
                     # The server accepted an SSLRequest. Everything after is ciphertext.
                     with self._lock:
                         self.tls_negotiated = True
+
+                if hold:
+                    # Parsed already, so the frame parser stays aligned; only the forwarding
+                    # waits. The server has not seen the held statement and the client is blocked
+                    # on its reply, so nothing on this connection moves until `release()`. The
+                    # wait ends on `stop()` too, so a test that fails before releasing cannot
+                    # leave this pump running.
+                    self.holding.set()
+                    while not self._released.wait(0.2):
+                        if self._stop.is_set():
+                            return False
 
                 dropping = False
                 if commit_at >= 0:

--- a/tests/test_attempt_integrity.py
+++ b/tests/test_attempt_integrity.py
@@ -1481,14 +1481,14 @@ def test_the_two_re_issue_bounds_compose(proxy, schema, moves):
         setup.close()
 
     store = LosesCommitsAndKeepsMoving(proxy.url(URL), schema=schema, clock=lambda: T0)
-    raised: BaseException | None = None
+    raised: Exception | None = None
     try:
         proxy.reset_counters()
         proxy.drop_before_commit = 1000  # every COMMIT from here on, as T155f does
         store.breaking = True
         try:
             store.mark_ambiguous(key, REUSED, "nobody knows what the remote did")
-        except BaseException as broke:
+        except Exception as broke:  # RecursionError is an Exception; the unbounded case raised it
             raised = broke
     finally:
         store.breaking = False

--- a/tests/test_attempt_integrity.py
+++ b/tests/test_attempt_integrity.py
@@ -41,6 +41,7 @@ from typing import Any
 import pytest
 
 from ctrlrun.effect import EffectState
+from ctrlrun.errors import CTRLRunError
 from failure_injection import Proxy, statement_of, upstream_of
 
 URL = os.environ.get("CTRLRUN_TEST_POSTGRES")
@@ -92,7 +93,7 @@ CHILD = textwrap.dedent("""
     log.addHandler(Branches())
     log.setLevel(logging.WARNING)
 
-    OPS = ("reserve", "begin", "fail", "ambiguous", "resolve")
+    OPS = ("reserve", "begin", "fail", "commit", "ambiguous", "resolve")
     for step in job["steps"]:
         if step["op"] not in OPS:
             raise SystemExit("unknown step %r" % step["op"])
@@ -128,6 +129,8 @@ CHILD = textwrap.dedent("""
                     store.begin_execution(key, actor)
                 elif op == "fail":
                     store.fail_effect(key, actor, "the remote refused before acting")
+                elif op == "commit":
+                    store.commit_effect(key, actor, {"refund": "re_1"})
                 elif op == "ambiguous":
                     store.mark_ambiguous(key, actor, "the outcome was lost")
                 else:
@@ -358,15 +361,23 @@ def stored(schema: str, key: str):
         store.close()
 
 
-def effects_statement(verb: bytes, schema: str):
-    """A `Proxy.arm` predicate: a statement on this schema's `effects` table beginning `verb`."""
-    table = f'"{schema}".effects'.encode()
+def table_statement(verb: bytes, schema: str, table_name: str):
+    """A `Proxy.arm` predicate: a statement on one of this schema's tables, beginning `verb`."""
+    table = f'"{schema}".{table_name}'.encode()
 
     def matches(kind: bytes, body: bytes) -> bool:
         text = statement_of(kind, body)
         return text is not None and text.lstrip().upper().startswith(verb) and table in text
 
     return matches
+
+
+def effects_statement(verb: bytes, schema: str):
+    return table_statement(verb, schema, "effects")
+
+
+def approvals_statement(verb: bytes, schema: str):
+    return table_statement(verb, schema, "approvals")
 
 
 # --- the injector's own control -------------------------------------------------------------
@@ -466,6 +477,7 @@ def test_the_hold_can_be_armed_twice_and_refuses_to_arm_over_a_pending_hold():
 
         proxy.arm(statement(b"UPDATE two"))
         assert not proxy.holding.is_set(), "the second hold reported itself held before firing"
+        proxy.release()  # nothing is held yet, so this must not pre-release the armed hold
         client.sendall(framed(b"P", b"\x00UPDATE two\x00\x00\x00"))
         assert proxy.holding.wait(BOUND), "the second hold never fired"
         assert not arrived(b"UPDATE two", 0.5), (
@@ -1013,7 +1025,11 @@ def test_T246c_a_stale_resolve_never_rewinds_a_newer_attempt(proxy, schema, home
         f"{record.attempt}: attempt 2's unknown outcome was overwritten, and a renewal from here "
         "hands out an attempt number that has already been dispatched"
     )
-    assert outcome["error"] == "DuplicateEffect", outcome
+    assert outcome["error"] == "AmbiguousEffect", (
+        f"the stale resolve was refused as {outcome['error']}; the record it found is AMBIGUOUS at "
+        "the newer attempt, which is nobody's live reservation, so in_progress would be false"
+    )
+    assert "moved from attempt 1" in outcome["message"], outcome["message"]
 
 
 @postgres
@@ -1055,45 +1071,250 @@ def test_T246c_a_stale_ambiguate_never_rewinds_a_newer_attempt(proxy, schema, ho
         f"the contender's stale AMBIGUOUS write left the record {found}: attempt 2, in flight, was "
         "rewound to attempt 1"
     )
-    assert outcome["error"] == "DuplicateEffect", outcome
+    assert outcome["error"] == "DuplicateEffect" and outcome["state"] == "in_progress", outcome
+    assert "moved from attempt 1" in outcome["message"], outcome["message"]
 
 
 @postgres
-def test_T246c_a_stale_transition_never_rewinds_a_newer_attempt(proxy, schema, home):
-    """`_transition`, the compare-and-set under `begin`, `commit`, `fail` and `mark_ambiguous`.
+@pytest.mark.parametrize(
+    ("op", "pre", "lands", "tail"),
+    [
+        ("ambiguous", "begin", EffectState.AMBIGUOUS, "AmbiguousEffect"),
+        ("commit", "begin", EffectState.COMMITTED, "DuplicateEffect"),
+        ("fail", "begin", EffectState.EXECUTING, "DuplicateEffect"),
+        ("begin", "", EffectState.RESERVED, "DuplicateEffect"),
+    ],
+)
+def test_T246c_a_stale_transition_lands_its_outcome_or_is_refused(
+    proxy, schema, home, op, pre, lands, tail
+):
+    """`_transition` under a reused `action_id`, held after its read while the record moves on.
 
-    Attempt 1 is `EXECUTING` under a reused `action_id`; its `mark_ambiguous` reads it and the proxy
-    holds the `UPDATE`. Meanwhile the same id fails attempt 1, renews to 2 and begins it. 0.6.1
-    matched `EXECUTING` under that id and wrote `AMBIGUOUS` at **1**.
+    The record cannot be rewound: the `UPDATE` carries the attempt it read. What is left is what
+    the stale write should do instead, and it is not the same answer for all four transitions.
+
+    **An outcome is never dropped.** `commit_effect` and `mark_ambiguous` carry what the executor
+    did, or the fact that nobody knows. Refusing them writes nothing, and then the record, which is
+    what gates the next renewal, carries nothing: a review measured a renewal to attempt 3 with
+    attempt 1's outcome recorded on no record at all, and in the `commit` row attempt 1 had
+    committed at the remote, so attempt 3 would have been a second refund. When the re-read says
+    the record is still ours and still in a state this transition may be made from, the transition
+    is re-issued once against that re-read, so the outcome lands on the newer attempt, exactly
+    where the same call a moment later would have landed it. Attributing it to the newer attempt is
+    the residual (§12.3a); losing it is not a residual, it is a lost outcome.
+
+    **A claim about a *running* attempt is refused.** `fail_effect` asserts that nothing happened,
+    and re-issuing attempt 1's `FAILED` over attempt 2 in flight would permit a retry beside a
+    dispatch that is still running. `begin_execution` claims a reservation this attempt no longer
+    holds. Both are refused, and the record is left as the newer attempt wrote it.
     """
-    key = "refund:stale-transition"
+    key = f"refund:stale-transition-{op}"
     setup = direct(schema)
     try:
         setup.reserve_effect(key, REUSED, LEASE)
-        setup.begin_execution(key, REUSED)
+        if pre:
+            setup.begin_execution(key, REUSED)
     finally:
         setup.close()
+    read_state = EffectState.EXECUTING if pre else EffectState.RESERVED
     later = T0 + timedelta(seconds=2)
+    rival_steps = (
+        [step("fail", key, REUSED, later)]
+        if pre
+        else [
+            step("begin", key, REUSED, later),
+            step("fail", key, REUSED, later),
+        ]
+    )
+    rival_steps += [step("reserve", key, REUSED, later)]
+    if pre:
+        rival_steps += [step("begin", key, REUSED, later)]
     outcome, rival, read = stale_write(
         proxy,
         home,
         schema,
         key,
-        [step("ambiguous", key, REUSED, T0 + timedelta(seconds=1))],
-        [
-            step("fail", key, REUSED, later),
-            step("reserve", key, REUSED, later),
-            step("begin", key, REUSED, later),
-        ],
+        [step(op, key, REUSED, T0 + timedelta(seconds=1))],
+        rival_steps,
     )
-    assert read is not None and (read.state, read.attempt) == (EffectState.EXECUTING, 1), read
-    assert rival["results"][1]["attempt"] == 2
+    assert read is not None and (read.state, read.attempt) == (read_state, 1), read
+    assert rival["results"][-2 if pre else -1]["attempt"] == 2, rival
 
     record = stored(schema, key)
     assert record is not None
     found = (record.state, record.attempt, record.action_id)
-    assert found == (EffectState.EXECUTING, 2, REUSED), (
-        f"attempt 1's stale mark_ambiguous left the record {found}: attempt 2, in flight, was "
-        "rewound to attempt 1"
+    assert found == (lands, 2, REUSED), (
+        f"attempt 1's stale {op} left the record {found}, expected {lands} at attempt 2: an "
+        "outcome was dropped, or a newer attempt was overwritten"
     )
-    assert outcome["error"] == "DuplicateEffect", outcome
+    if op in ("ambiguous", "commit"):
+        assert outcome["error"] is None, (
+            f"the {op} was refused ({outcome['error']}) and wrote nothing, so attempt 1's outcome "
+            "is recorded on no effect record and the next renewal is not gated by it"
+        )
+    else:
+        assert outcome["error"] == "DuplicateEffect" and outcome["state"] == "in_progress", outcome
+        assert "moved from attempt 1" in outcome["message"], outcome["message"]
+
+    # And whatever the record now says, it is not a record another attempt may take.
+    after = direct(schema, T0 + timedelta(seconds=3))
+    try:
+        with pytest.raises(CTRLRunError) as refused:
+            after.reserve_effect(key, "act_next", LEASE)
+    finally:
+        after.close()
+    assert type(refused.value).__name__ == tail, (
+        f"after a stale {op}, a further attempt was refused with {type(refused.value).__name__}, "
+        f"expected {tail}"
+    )
+
+
+@postgres
+def test_a_stale_expire_never_overwrites_a_consumption(proxy, schema, home):
+    """The same shape on `approvals`, found by the round-2 review's survey of every write.
+
+    `_expire` writes `status = expired` from a read that saw `granted` past `expires_at`, on
+    `approval_id` alone. A consumption that commits in between is overwritten, and an approval that
+    authorised a real effect reads `expired`: evidence corruption, and the one write on that table
+    that was not a compare-and-set (`_consume_locked`, `grant_approval` and `deny_approval` all
+    are). Here the expiring store's `UPDATE` is held while another process, whose clock is still
+    inside the approval's life, consumes it and reserves the key.
+    """
+    key = "refund:stale-expire"
+    approval = granted_for(schema, "consume_approval_and_reserve", key)
+    assert approval is not None
+    expired = T0 + timedelta(hours=2)  # past the approval's expires_at
+
+    late = Child(
+        home,
+        "late",
+        url=proxy.url(URL),
+        schema=schema,
+        gated=True,
+        steps=reserving(key, "act_late", expired, approval=approval),
+    )
+    try:
+        late.wait_ready()
+        proxy.reset_counters()
+        proxy.arm(approvals_statement(b"UPDATE", schema))
+        late.go()
+        assert proxy.holding.wait(BOUND), "the expiring UPDATE never reached the proxy"
+        rival = Child(
+            home,
+            "rival",
+            url=URL,
+            schema=schema,
+            gated=False,
+            steps=reserving(key, "act_rival", T0 + timedelta(seconds=2), approval=approval),
+        ).result()
+        assert rival["error"] is None and rival["attempt"] == 1, rival
+        proxy.release()
+        outcome = late.result()
+    finally:
+        proxy.release()
+        late.kill()
+
+    assert outcome["error"] == "ApprovalMismatch", outcome
+    assert approval_status(schema, approval) == "consumed", (
+        "the stale expiry overwrote a consumption: the approval that authorised the rival's "
+        "effect now reads expired, and the evidence says a human's yes was never spent"
+    )
+    record = stored(schema, key)
+    assert record is not None and record.action_id == "act_rival"
+
+
+# --- the outcome itself: never lost, whatever the store answers ------------------------------
+
+
+@pytest.mark.parametrize("backend", ["sqlite", "postgres"])
+def test_an_unknown_outcome_the_store_refuses_to_record_is_never_lost(backend, tmp_path):
+    """`v0.1 §5.5` through `Control`, when the outcome write itself is refused.
+
+    The round-2 review drove this through the public API on SQLite, so the store is not the
+    variable: the executor runs past its lease, a contender finds the lapsed record and makes it
+    `AMBIGUOUS`, a human resolves it `FAILED` while the attempt is *still running*, and only then
+    does the executor raise `TimeoutError`. `mark_ambiguous` is then refused, because `FAILED` is
+    not a state this attempt may move from, and that refusal used to escape `Control`: no receipt,
+    no `EXECUTION_AMBIGUOUS` event, and the caller handed an `InvalidArgument` about its own effect
+    key instead of the exception its executor raised. An unknown outcome vanished, on both
+    backends, and this has nothing to do with the attempt number.
+
+    The store's answer may be a refusal; the evidence may not. The receipt and the event are
+    written whatever the store says, they name the refusal, and the caller gets its own exception
+    back. What the effect record says afterwards is the human's claim and not this attempt's, which
+    is the residual §12.3a states and the reason the receipt has to carry the truth.
+    """
+    from ctrlrun.action import Action, Principal
+    from ctrlrun.control import Control
+    from ctrlrun.policy import Policy
+    from ctrlrun.receipt import EventType, ReceiptResult
+    from ctrlrun.state import SQLiteStateStore
+
+    if backend == "postgres" and not URL:
+        pytest.skip("CTRLRUN_TEST_POSTGRES is not set; no server to run against")
+    now = [T0]
+    name = f"unknown_{uuid.uuid4().hex[:10]}"
+    if backend == "sqlite":
+        path = str(tmp_path / "store.db")
+
+        def open_store():
+            return SQLiteStateStore(path, clock=lambda: now[0])
+    else:
+        from ctrlrun.postgres import PostgresStateStore
+
+        PostgresStateStore.create_schema(URL, name)
+
+        def open_store():
+            return PostgresStateStore(URL, schema=name, clock=lambda: now[0])
+
+    store = open_store()
+    policy = Policy.from_yaml(
+        "schema: ctrlrun.policy/v2\nactions:\n  stripe.refund:\n"
+        '    effect: "refund:{id}"\n    rules:\n      - decision: allow\n'
+    )
+    control = Control(policy, store, clock=lambda: now[0], lease=LEASE)
+    action = Action(
+        name="stripe.refund", arguments={"id": "re_1"}, principal=Principal(agent="agent:a")
+    )
+    ran = []
+
+    def executor():
+        now[0] = T0 + timedelta(minutes=10)  # the lease lapsed while the remote was thinking
+        other = open_store()
+        try:
+            with pytest.raises(CTRLRunError):
+                other.reserve_effect("refund:re_1", "act_contender", LEASE)
+            other.resolve_effect("refund:re_1", EffectState.FAILED, "cli:human")
+        finally:
+            other.close()
+        ran.append("the executor ran, and nobody knows what the remote did")
+        raise TimeoutError("the refund response never arrived")
+
+    try:
+        before = len(store.receipts())
+        with pytest.raises(TimeoutError):
+            control.execute(action, executor, "refund:re_1")
+        assert ran, "the executor never ran; this test is about what happens after it does"
+
+        written = store.receipts()[before:]
+        assert len(written) == 1, (
+            f"{len(written)} receipts for an attempt whose outcome is unknown: the store refused "
+            "the outcome write and the evidence went with it"
+        )
+        assert written[0].result is ReceiptResult.AMBIGUOUS, written[0].result
+        assert "TimeoutError" in (written[0].error or ""), written[0].error
+        assert "refused" in (written[0].error or ""), (
+            f"the receipt says {written[0].error!r}; it must say the outcome could not be written, "
+            "because the effect record does not say it either"
+        )
+        assert EventType.EXECUTION_AMBIGUOUS in [event.type for event in store.events()], (
+            "no EXECUTION_AMBIGUOUS event: the one unknown outcome here is recorded nowhere"
+        )
+        record = store.get_effect("refund:re_1")
+        assert record is not None and record.attempt == 1
+    finally:
+        store.close()
+        if backend == "postgres":
+            from ctrlrun.postgres import PostgresStateStore
+
+            PostgresStateStore.drop_schema(URL, name)

--- a/tests/test_attempt_integrity.py
+++ b/tests/test_attempt_integrity.py
@@ -8,7 +8,7 @@ reused number gives two dispatches one token and lets a ceiling of N admit N+1.
 **Every window here is opened on purpose** (mutation pattern 4). Two processes renewing
 concurrently open none of them: each needs one store stalled at a precise point inside a
 reservation method while a second process renews, runs and fails. The proxy the tests own does the
-stalling, and it holds one statement on one connection (`failure_injection.Proxy.hold_when`) or
+stalling, and it holds one statement on one connection (`failure_injection.Proxy.arm`) or
 swallows one `COMMIT` and acts before the re-read (`drop_before_commit`, `on_drop`).
 
 **What was run, stated first, as `test_cross_host.py` does.** The store under test and the store
@@ -25,11 +25,13 @@ from __future__ import annotations
 
 import json
 import os
+import socket
 import struct
 import subprocess
 import sys
 import tempfile
 import textwrap
+import threading
 import time
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -62,9 +64,9 @@ REPO_SRC = str(Path(__file__).resolve().parents[1] / "src")
 #: keeps that true if they ever stop sharing it.
 METHODS = ["reserve_effect", "consume_approval_and_reserve"]
 
-#: One child: open a store, optionally wait to be told to go, take one reservation, and optionally
-#: run and fail it. It reports the reservation it was handed, or the refusal, and every §4.3.4
-#: branch its store took, as JSON on stdout.
+#: One child: open a store, optionally wait to be told to go, then run a script of store calls,
+#: each at its own frozen instant. It stops at the first refusal and reports every step's outcome
+#: and every §4.3.4 branch its store took, as JSON on stdout.
 CHILD = textwrap.dedent("""
     import json, logging, os, sys, time
     from datetime import datetime, timedelta
@@ -75,6 +77,7 @@ CHILD = textwrap.dedent("""
     assert _WHERE.startswith(os.path.realpath(job["src"])), (
         "the child imported ctrlrun from %s, not the tree under test at %s"
         % (_WHERE, job["src"]))
+    from ctrlrun.effect import EffectState
     from ctrlrun.postgres import PostgresStateStore
 
     branches = []
@@ -89,10 +92,15 @@ CHILD = textwrap.dedent("""
     log.addHandler(Branches())
     log.setLevel(logging.WARNING)
 
-    frozen = datetime.fromisoformat(job["now"])
-    store = PostgresStateStore(job["url"], schema=job["schema"], clock=lambda: frozen)
-    out = {"ctrlrun": _WHERE, "attempt": None, "action_id": None, "error": None,
-           "state": None, "message": None, "branches": branches}
+    OPS = ("reserve", "begin", "fail", "ambiguous", "resolve")
+    for step in job["steps"]:
+        if step["op"] not in OPS:
+            raise SystemExit("unknown step %r" % step["op"])
+    now = [datetime.fromisoformat(job["steps"][0]["now"])]
+    store = PostgresStateStore(job["url"], schema=job["schema"], clock=lambda: now[0])
+    results = []
+    out = {"ctrlrun": _WHERE, "results": results, "branches": branches}
+    lease = timedelta(minutes=5)
     try:
         if job["ready"]:
             # Readiness through the filesystem, as test_cross_host's holders do. The store is
@@ -103,25 +111,58 @@ CHILD = textwrap.dedent("""
                 if time.monotonic() > deadline:
                     raise SystemExit("the child was never told to go")
                 time.sleep(0.01)
-        lease = timedelta(minutes=5)
-        if job["approval_id"]:
-            _, reservation = store.consume_approval_and_reserve(
-                job["approval_id"], job["action_hash"], job["key"], job["action_id"], lease)
-        else:
-            reservation = store.reserve_effect(job["key"], job["action_id"], lease)
-        out["attempt"] = reservation.attempt
-        out["action_id"] = reservation.action_id
-        if job["then_fail"]:
-            store.begin_execution(job["key"], job["action_id"])
-            store.fail_effect(job["key"], job["action_id"], "the remote refused before acting")
-    except Exception as refused:
-        out["error"] = type(refused).__name__
-        out["state"] = getattr(refused, "state", None)
-        out["message"] = str(refused)
+        for step in job["steps"]:
+            now[0] = datetime.fromisoformat(step["now"])
+            op, key, actor = step["op"], step["key"], step["action_id"]
+            done = {"op": op, "attempt": None, "error": None, "state": None, "message": None}
+            results.append(done)
+            try:
+                if op == "reserve":
+                    if step.get("approval_id"):
+                        _, reservation = store.consume_approval_and_reserve(
+                            step["approval_id"], step["action_hash"], key, actor, lease)
+                    else:
+                        reservation = store.reserve_effect(key, actor, lease)
+                    done["attempt"] = reservation.attempt
+                elif op == "begin":
+                    store.begin_execution(key, actor)
+                elif op == "fail":
+                    store.fail_effect(key, actor, "the remote refused before acting")
+                elif op == "ambiguous":
+                    store.mark_ambiguous(key, actor, "the outcome was lost")
+                else:
+                    resolved = store.resolve_effect(key, EffectState(step["to"]), step["resolver"])
+                    done["attempt"] = resolved.attempt
+            except Exception as refused:
+                done["error"] = type(refused).__name__
+                done["state"] = getattr(refused, "state", None)
+                done["message"] = str(refused)
+                break
     finally:
         store.close()
     sys.stdout.write(json.dumps(out))
 """)
+
+
+def step(op: str, key: str, action_id: str, now: datetime, **extra: Any) -> dict[str, Any]:
+    """One store call for a child to make, at its own frozen instant."""
+    return {"op": op, "key": key, "action_id": action_id, "now": now.isoformat(), **extra}
+
+
+def reserving(
+    key: str,
+    action_id: str,
+    now: datetime,
+    *,
+    then_fail: bool = False,
+    approval: tuple[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """A reservation, through the approval when there is one, and optionally a run that fails."""
+    extra = {"approval_id": approval[0], "action_hash": approval[1]} if approval else {}
+    script = [step("reserve", key, action_id, now, **extra)]
+    if then_fail:
+        script += [step("begin", key, action_id, now), step("fail", key, action_id, now)]
+    return script
 
 
 class Child:
@@ -134,13 +175,16 @@ class Child:
         *,
         url: str,
         schema: str,
-        key: str,
-        action_id: str,
-        now: datetime,
         gated: bool,
+        key: str = "",
+        action_id: str = "",
+        now: datetime = T0,
         then_fail: bool = False,
         approval: tuple[str, str] | None = None,
+        steps: list[dict[str, Any]] | None = None,
     ) -> None:
+        if steps is None:
+            steps = reserving(key, action_id, now, then_fail=then_fail, approval=approval)
         script = home / "child.py"
         if not script.exists():
             script.write_text(CHILD, encoding="utf-8")
@@ -161,15 +205,10 @@ class Child:
                     "src": REPO_SRC,
                     "url": url,
                     "schema": schema,
-                    "key": key,
-                    "action_id": action_id,
-                    "now": now.isoformat(),
+                    "steps": steps,
                     "ready": str(self.ready) if gated else None,
                     "go": str(self.go_marker),
                     "bound": BOUND,
-                    "then_fail": then_fail,
-                    "approval_id": approval[0] if approval else None,
-                    "action_hash": approval[1] if approval else None,
                 }
             )
         )
@@ -204,6 +243,12 @@ class Child:
         assert out["ctrlrun"].startswith(REPO_SRC), (
             f"{self.name} imported ctrlrun from {out['ctrlrun']!r}, not the tree under test"
         )
+        # The first step's number, and the first refusal, which is where the script stopped.
+        results = out["results"]
+        refused = next((done for done in results if done["error"]), None)
+        out["attempt"] = results[0]["attempt"] if results else None
+        for field in ("error", "state", "message"):
+            out[field] = refused[field] if refused else None
         return out
 
     def kill(self) -> None:
@@ -314,7 +359,7 @@ def stored(schema: str, key: str):
 
 
 def effects_statement(verb: bytes, schema: str):
-    """A `hold_when` predicate: a statement on this schema's `effects` table beginning `verb`."""
+    """A `Proxy.arm` predicate: a statement on this schema's `effects` table beginning `verb`."""
     table = f'"{schema}".effects'.encode()
 
     def matches(kind: bytes, body: bytes) -> bool:
@@ -328,7 +373,7 @@ def effects_statement(verb: bytes, schema: str):
 
 
 def test_the_hold_trigger_reads_the_parse_and_not_a_bind_parameter():
-    """`hold_when` sees SQL text only where the protocol puts it.
+    """The hold sees SQL text only where the protocol puts it.
 
     No server needed, and the reason is `test_cross_host`'s first control: a trigger that grepped
     the byte stream fired on a Bind parameter. An effect key containing `UPDATE` travels in a Bind
@@ -352,6 +397,90 @@ def test_the_hold_trigger_reads_the_parse_and_not_a_bind_parameter():
     assert matches(*parse)
     assert not matches(*bind)
     assert not effects_statement(b"UPDATE", "other")(*parse), "another schema's table matched"
+
+
+def test_the_hold_can_be_armed_twice_and_refuses_to_arm_over_a_pending_hold():
+    """`Proxy.arm` is reusable, which items 3 and 4 need, and it says no rather than lie.
+
+    No server: a loopback listener stands in for Postgres and records what it receives, over real
+    sockets, so "held" means the bytes did not arrive and "released" means they did. The first
+    version was one-shot: its `holding` and release events were never cleared, so a second hold
+    reported itself held at once and forwarded its statement straight through, with `holds`
+    counting a window that never opened.
+    """
+    upstream = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    upstream.bind(("127.0.0.1", 0))
+    upstream.listen(1)
+    received = bytearray()
+    lock = threading.Lock()
+    stop = threading.Event()
+
+    def serve() -> None:
+        connection, _ = upstream.accept()
+        connection.settimeout(0.1)
+        with connection:
+            while not stop.is_set():
+                try:
+                    data = connection.recv(65536)
+                except TimeoutError:
+                    continue
+                if not data:
+                    return
+                with lock:
+                    received.extend(data)
+
+    def arrived(marker: bytes, within: float) -> bool:
+        deadline = time.monotonic() + within
+        while time.monotonic() < deadline:
+            with lock:
+                if marker in received:
+                    return True
+            time.sleep(0.01)
+        return False
+
+    def framed(kind: bytes, body: bytes) -> bytes:
+        return kind + struct.pack("!i", 4 + len(body)) + body
+
+    def statement(text: bytes):
+        return lambda kind, body: statement_of(kind, body) == text
+
+    server = threading.Thread(target=serve, daemon=True)
+    server.start()
+    proxy = Proxy("127.0.0.1", upstream.getsockname()[1]).start()
+    client = socket.create_connection(("127.0.0.1", proxy.port), timeout=BOUND)
+    try:
+        startup = struct.pack("!i", 196608) + b"user\x00bob\x00\x00"
+        client.sendall(struct.pack("!i", 4 + len(startup)) + startup)
+        assert arrived(b"user\x00bob", BOUND), "the relay is not forwarding at all"
+
+        proxy.arm(statement(b"UPDATE one"))
+        with pytest.raises(RuntimeError):
+            proxy.arm(statement(b"UPDATE other"))  # armed and not yet fired
+        client.sendall(framed(b"P", b"\x00UPDATE one\x00\x00\x00"))
+        assert proxy.holding.wait(BOUND), "the first hold never fired"
+        assert not arrived(b"UPDATE one", 0.5), "the first held statement reached the server"
+        with pytest.raises(RuntimeError):
+            proxy.arm(statement(b"UPDATE other"))  # fired and not yet released
+        proxy.release()
+        assert arrived(b"UPDATE one", BOUND), "the release did not forward the held statement"
+
+        proxy.arm(statement(b"UPDATE two"))
+        assert not proxy.holding.is_set(), "the second hold reported itself held before firing"
+        client.sendall(framed(b"P", b"\x00UPDATE two\x00\x00\x00"))
+        assert proxy.holding.wait(BOUND), "the second hold never fired"
+        assert not arrived(b"UPDATE two", 0.5), (
+            "the second hold forwarded its statement at once: it inherited the first hold's "
+            "release, so a test using it would open no window and pass"
+        )
+        assert proxy.holds == 2
+        proxy.release()
+        assert arrived(b"UPDATE two", BOUND)
+    finally:
+        stop.set()
+        proxy.release()
+        client.close()
+        proxy.stop()
+        upstream.close()
 
 
 # --- T246: a stale renewal never lands ------------------------------------------------------
@@ -411,7 +540,7 @@ def test_T246_a_stale_renewal_on_postgres_never_lands(proxy, schema, home, metho
     try:
         held.wait_ready()
         proxy.reset_counters()
-        proxy.hold_when = held_at(window, schema)
+        proxy.arm(held_at(window, schema))
         held.go()
 
         assert proxy.holding.wait(BOUND), (
@@ -580,7 +709,7 @@ def test_T246b_insert_a_lost_commit_returns_the_attempt_the_re_issue_wrote(
         return seen[0] == 2
 
     def arm_the_hold() -> None:
-        proxy.hold_when = the_re_issues_planning_read
+        proxy.arm(the_re_issues_planning_read)
 
     held = Child(
         home,
@@ -737,3 +866,234 @@ def test_T246b_landed_a_renewal_re_read_that_finds_our_action_id_is_not_proof_it
             "the held process was refused, and its own consumption was rolled back with the lost "
             "COMMIT; the approval must still be there for the attempt that runs"
         )
+
+
+@postgres
+@pytest.mark.parametrize("method", METHODS)
+def test_T246b_insert_refuse_a_rival_that_failed_before_the_re_read_is_not_ours(
+    proxy, schema, home, method
+):
+    """Table A1 row 3 when the rival's record is one the planner would renew over.
+
+    A review found this row's last line untested. The held process's `INSERT` loses its `COMMIT`;
+    before its re-read, another process inserts attempt 1, runs it and fails it. The re-read finds
+    `FAILED` at 1 under the rival: not our write, and a record `plan_reservation` *grants* over,
+    so the refusal is not the planner's but the line after it. Replacing that line with `return
+    reservation` handed the held process attempt 1, the rival's number, on a record it never wrote,
+    and no test failed.
+    """
+    key = f"refund:lost-insert-refuse-{method}"
+    direct(schema).close()  # migrated, and no record: attempt 1 is an INSERT
+    approval = granted_for(schema, method, key)
+    rivals: list[dict[str, Any]] = []
+
+    def another_process_inserts_and_fails() -> None:
+        rivals.append(
+            Child(
+                home,
+                "rival",
+                url=URL,
+                schema=schema,
+                gated=False,
+                steps=reserving(key, "act_rival", T0 + timedelta(seconds=2), then_fail=True),
+            ).result()
+        )
+
+    held = Child(
+        home,
+        "held",
+        url=proxy.url(URL),
+        schema=schema,
+        gated=True,
+        steps=reserving(key, "act_held", T0 + timedelta(seconds=1), approval=approval),
+    )
+    try:
+        held.wait_ready()
+        proxy.reset_counters()
+        proxy.on_drop = another_process_inserts_and_fails
+        proxy.drop_before_commit = 1
+        held.go()
+        outcome = held.result()
+    finally:
+        held.kill()
+
+    assert proxy.commits_dropped == 1, "no COMMIT was swallowed; the window never opened"
+    assert len(rivals) == 1, "the rival never ran between the lost COMMIT and the re-read"
+    assert rivals[0]["error"] is None and rivals[0]["attempt"] == 1, rivals[0]
+    assert outcome["branches"] == ["a1.row3.refuse"], outcome["branches"]
+    assert outcome["attempt"] is None, (
+        f"the held process was handed attempt {outcome['attempt']}, the number the rival ran and "
+        "failed under, for an INSERT that never landed"
+    )
+    assert outcome["error"] == "DuplicateEffect" and outcome["state"] == "in_progress", outcome
+
+    record = stored(schema, key)
+    assert record is not None
+    found = (record.state, record.attempt, record.action_id)
+    assert found == (EffectState.FAILED, 1, "act_rival"), found
+    if approval is not None:
+        assert approval_status(schema, approval) == "granted"
+
+
+# --- T246c: no stale write moves an attempt number backwards ---------------------------------
+
+
+def stale_write(proxy, home, schema: str, key: str, held_steps, rival_steps):
+    """Hold `held_steps`' first `UPDATE` on the effects table while `rival_steps` run, then
+    release it. Returns (what the held process reported, what the rival reported, the record the
+    held process read). The shape of T246, for every write that is not a renewal."""
+    held = Child(home, "held", url=proxy.url(URL), schema=schema, gated=True, steps=held_steps)
+    try:
+        held.wait_ready()
+        proxy.reset_counters()
+        proxy.arm(effects_statement(b"UPDATE", schema))
+        held.go()
+        assert proxy.holding.wait(BOUND), (
+            "the held write's UPDATE never reached the proxy, so the window was never opened"
+        )
+        read = stored(schema, key)
+        rival = Child(
+            home, "rival", url=URL, schema=schema, gated=False, steps=rival_steps
+        ).result()
+        assert rival["error"] is None, f"the rival did not complete its steps: {rival}"
+        assert held.running(), "the held process finished while its UPDATE was being held"
+        proxy.release()
+        outcome = held.result()
+    finally:
+        proxy.release()
+        held.kill()
+    assert proxy.holds == 1
+    return outcome, rival, read
+
+
+REUSED = "act_reused"
+
+
+@postgres
+def test_T246c_a_stale_resolve_never_rewinds_a_newer_attempt(proxy, schema, home):
+    """A review's reproduction, made a test: `resolve_effect` wrote the attempt it had read.
+
+    Attempt 1 is `AMBIGUOUS` under an `action_id` the caller reuses, which is what retrying one
+    `Action` object does. Human H1 reads it to resolve it `FAILED`, and the proxy holds H1's
+    `UPDATE`. Meanwhile H2 resolves it `FAILED`, the owner retries the same `Action`, is handed
+    attempt 2, dispatches and times out: `AMBIGUOUS` at 2 under the same id. 0.6.1's `WHERE
+    effect_key AND action_id AND state` matched that, and H1's write put the record back to
+    `FAILED` at **1**: the next renewal would hand out 2 again, and attempt 2's unknown outcome
+    was settled by a human who had looked at attempt 1.
+    """
+    key = "refund:stale-resolve"
+    setup = direct(schema)
+    try:
+        setup.reserve_effect(key, REUSED, LEASE)
+        setup.begin_execution(key, REUSED)
+        setup.mark_ambiguous(key, REUSED, "attempt 1 timed out")
+    finally:
+        setup.close()
+    later = T0 + timedelta(seconds=3)
+    outcome, rival, read = stale_write(
+        proxy,
+        home,
+        schema,
+        key,
+        [step("resolve", key, REUSED, T0 + timedelta(seconds=1), to="failed", resolver="h1")],
+        [
+            step("resolve", key, REUSED, T0 + timedelta(seconds=2), to="failed", resolver="h2"),
+            step("reserve", key, REUSED, later),
+            step("begin", key, REUSED, later),
+            step("ambiguous", key, REUSED, later),
+        ],
+    )
+    assert read is not None and (read.state, read.attempt) == (EffectState.AMBIGUOUS, 1), read
+    assert rival["results"][1]["attempt"] == 2
+
+    record = stored(schema, key)
+    assert record is not None
+    assert (record.state, record.attempt) == (EffectState.AMBIGUOUS, 2), (
+        f"H1's resolution, decided on attempt 1, left the record {record.state} at "
+        f"{record.attempt}: attempt 2's unknown outcome was overwritten, and a renewal from here "
+        "hands out an attempt number that has already been dispatched"
+    )
+    assert outcome["error"] == "DuplicateEffect", outcome
+
+
+@postgres
+def test_T246c_a_stale_ambiguate_never_rewinds_a_newer_attempt(proxy, schema, home):
+    """§4.2.2's kept write, made by a contender that is not the owner, from a stale read.
+
+    Attempt 1 is `EXECUTING` under a reused `action_id`. A contender whose clock is past the lease
+    reads it, plans the `AMBIGUOUS` write, and the proxy holds that `UPDATE`. Meanwhile the owner
+    fails attempt 1, retries the same `Action` and begins attempt 2, live. 0.6.1's condition matched
+    `EXECUTING` under that id and wrote `AMBIGUOUS` at **1** over attempt 2 in flight.
+    """
+    key = "refund:stale-ambiguate"
+    setup = direct(schema)
+    try:
+        setup.reserve_effect(key, REUSED, LEASE)
+        setup.begin_execution(key, REUSED)
+    finally:
+        setup.close()
+    owner = T0 + timedelta(minutes=8)  # attempt 2's lease runs to 12:13, past the contender's now
+    outcome, rival, read = stale_write(
+        proxy,
+        home,
+        schema,
+        key,
+        [step("reserve", key, "act_contender", T0 + timedelta(minutes=10))],
+        [
+            step("fail", key, REUSED, owner),
+            step("reserve", key, REUSED, owner),
+            step("begin", key, REUSED, owner),
+        ],
+    )
+    assert read is not None and (read.state, read.attempt) == (EffectState.EXECUTING, 1), read
+    assert rival["results"][1]["attempt"] == 2
+
+    record = stored(schema, key)
+    assert record is not None
+    found = (record.state, record.attempt, record.action_id)
+    assert found == (EffectState.EXECUTING, 2, REUSED), (
+        f"the contender's stale AMBIGUOUS write left the record {found}: attempt 2, in flight, was "
+        "rewound to attempt 1"
+    )
+    assert outcome["error"] == "DuplicateEffect", outcome
+
+
+@postgres
+def test_T246c_a_stale_transition_never_rewinds_a_newer_attempt(proxy, schema, home):
+    """`_transition`, the compare-and-set under `begin`, `commit`, `fail` and `mark_ambiguous`.
+
+    Attempt 1 is `EXECUTING` under a reused `action_id`; its `mark_ambiguous` reads it and the proxy
+    holds the `UPDATE`. Meanwhile the same id fails attempt 1, renews to 2 and begins it. 0.6.1
+    matched `EXECUTING` under that id and wrote `AMBIGUOUS` at **1**.
+    """
+    key = "refund:stale-transition"
+    setup = direct(schema)
+    try:
+        setup.reserve_effect(key, REUSED, LEASE)
+        setup.begin_execution(key, REUSED)
+    finally:
+        setup.close()
+    later = T0 + timedelta(seconds=2)
+    outcome, rival, read = stale_write(
+        proxy,
+        home,
+        schema,
+        key,
+        [step("ambiguous", key, REUSED, T0 + timedelta(seconds=1))],
+        [
+            step("fail", key, REUSED, later),
+            step("reserve", key, REUSED, later),
+            step("begin", key, REUSED, later),
+        ],
+    )
+    assert read is not None and (read.state, read.attempt) == (EffectState.EXECUTING, 1), read
+    assert rival["results"][1]["attempt"] == 2
+
+    record = stored(schema, key)
+    assert record is not None
+    found = (record.state, record.attempt, record.action_id)
+    assert found == (EffectState.EXECUTING, 2, REUSED), (
+        f"attempt 1's stale mark_ambiguous left the record {found}: attempt 2, in flight, was "
+        "rewound to attempt 1"
+    )
+    assert outcome["error"] == "DuplicateEffect", outcome

--- a/tests/test_attempt_integrity.py
+++ b/tests/test_attempt_integrity.py
@@ -1,0 +1,739 @@
+"""Attempt numbers never repeat, on Postgres. Item 3a; SPEC-v0.7 §5.6, §8.3a (T246, T246b).
+
+Two properties, and at 0.6.1 neither held on Postgres: **no two reservations of one key carry the
+same attempt number**, and **the number a reservation method returns is the number it wrote**.
+v0.7 makes the attempt number load-bearing twice, in the idempotency token and in the ceiling, so a
+reused number gives two dispatches one token and lets a ceiling of N admit N+1.
+
+**Every window here is opened on purpose** (mutation pattern 4). Two processes renewing
+concurrently open none of them: each needs one store stalled at a precise point inside a
+reservation method while a second process renews, runs and fails. The proxy the tests own does the
+stalling, and it holds one statement on one connection (`failure_injection.Proxy.hold_when`) or
+swallows one `COMMIT` and acts before the re-read (`drop_before_commit`, `on_drop`).
+
+**What was run, stated first, as `test_cross_host.py` does.** The store under test and the store
+that interleaves are **separate OS processes**, each with its own connection, against one local
+Postgres; the parent owns the proxy and only orchestrates. They are not two hosts. Every wait is
+bounded, so a store that never reaches the window fails red rather than hanging.
+
+**SQLite has no row here, and that is not a gap.** Its renewal reads and writes inside one
+`BEGIN IMMEDIATE`, so the stale case is unreachable and the same `AND attempt = ?` is an
+equivalent mutant there; it has no lost-commit path at all (§5.6).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ctrlrun.effect import EffectState
+from failure_injection import Proxy, statement_of, upstream_of
+
+URL = os.environ.get("CTRLRUN_TEST_POSTGRES")
+
+postgres = pytest.mark.skipif(
+    not URL, reason="CTRLRUN_TEST_POSTGRES is not set; no server to run against"
+)
+
+T0 = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+LEASE = timedelta(minutes=5)
+
+#: Every bound in this file. Generous, because a bound that fires is a red test and not a hang.
+BOUND = 60.0
+
+#: The tree under test. The children import it and assert they did, for the reason
+#: `test_cross_host.REPO_SRC` gives: a hardcoded path grades a different checkout.
+REPO_SRC = str(Path(__file__).resolve().parents[1] / "src")
+
+#: Both reservation methods, because §5.5 says *every* reservation method returns the attempt
+#: number it wrote. They share one code path in the store today; the parametrization is what
+#: keeps that true if they ever stop sharing it.
+METHODS = ["reserve_effect", "consume_approval_and_reserve"]
+
+#: One child: open a store, optionally wait to be told to go, take one reservation, and optionally
+#: run and fail it. It reports the reservation it was handed, or the refusal, and every §4.3.4
+#: branch its store took, as JSON on stdout.
+CHILD = textwrap.dedent("""
+    import json, logging, os, sys, time
+    from datetime import datetime, timedelta
+    job = json.loads(sys.stdin.read())
+    sys.path.insert(0, job["src"])
+    import ctrlrun
+    _WHERE = os.path.realpath(ctrlrun.__file__)
+    assert _WHERE.startswith(os.path.realpath(job["src"])), (
+        "the child imported ctrlrun from %s, not the tree under test at %s"
+        % (_WHERE, job["src"]))
+    from ctrlrun.postgres import PostgresStateStore
+
+    branches = []
+
+    class Branches(logging.Handler):
+        def emit(self, record):
+            branch = getattr(record, "branch", None)
+            if branch is not None:
+                branches.append(branch)
+
+    log = logging.getLogger("ctrlrun.postgres")
+    log.addHandler(Branches())
+    log.setLevel(logging.WARNING)
+
+    frozen = datetime.fromisoformat(job["now"])
+    store = PostgresStateStore(job["url"], schema=job["schema"], clock=lambda: frozen)
+    out = {"ctrlrun": _WHERE, "attempt": None, "action_id": None, "error": None,
+           "state": None, "message": None, "branches": branches}
+    try:
+        if job["ready"]:
+            # Readiness through the filesystem, as test_cross_host's holders do. The store is
+            # open, so its migration COMMIT is behind us and the proxy can be armed.
+            os.close(os.open(job["ready"], os.O_CREAT | os.O_EXCL | os.O_WRONLY))
+            deadline = time.monotonic() + job["bound"]
+            while not os.path.exists(job["go"]):
+                if time.monotonic() > deadline:
+                    raise SystemExit("the child was never told to go")
+                time.sleep(0.01)
+        lease = timedelta(minutes=5)
+        if job["approval_id"]:
+            _, reservation = store.consume_approval_and_reserve(
+                job["approval_id"], job["action_hash"], job["key"], job["action_id"], lease)
+        else:
+            reservation = store.reserve_effect(job["key"], job["action_id"], lease)
+        out["attempt"] = reservation.attempt
+        out["action_id"] = reservation.action_id
+        if job["then_fail"]:
+            store.begin_execution(job["key"], job["action_id"])
+            store.fail_effect(job["key"], job["action_id"], "the remote refused before acting")
+    except Exception as refused:
+        out["error"] = type(refused).__name__
+        out["state"] = getattr(refused, "state", None)
+        out["message"] = str(refused)
+    finally:
+        store.close()
+    sys.stdout.write(json.dumps(out))
+""")
+
+
+class Child:
+    """One store in its own OS process. Started at once; `result()` waits for it, bounded."""
+
+    def __init__(
+        self,
+        home: Path,
+        name: str,
+        *,
+        url: str,
+        schema: str,
+        key: str,
+        action_id: str,
+        now: datetime,
+        gated: bool,
+        then_fail: bool = False,
+        approval: tuple[str, str] | None = None,
+    ) -> None:
+        script = home / "child.py"
+        if not script.exists():
+            script.write_text(CHILD, encoding="utf-8")
+        self.name = name
+        self.ready = home / f"{name}.ready"
+        self.go_marker = home / f"{name}.go"
+        self._process = subprocess.Popen(
+            [sys.executable, str(script)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert self._process.stdin is not None
+        self._process.stdin.write(
+            json.dumps(
+                {
+                    "src": REPO_SRC,
+                    "url": url,
+                    "schema": schema,
+                    "key": key,
+                    "action_id": action_id,
+                    "now": now.isoformat(),
+                    "ready": str(self.ready) if gated else None,
+                    "go": str(self.go_marker),
+                    "bound": BOUND,
+                    "then_fail": then_fail,
+                    "approval_id": approval[0] if approval else None,
+                    "action_hash": approval[1] if approval else None,
+                }
+            )
+        )
+        self._process.stdin.close()
+
+    def running(self) -> bool:
+        return self._process.poll() is None
+
+    def wait_ready(self) -> None:
+        deadline = time.monotonic() + BOUND
+        while not self.ready.exists():
+            if not self.running():
+                raise AssertionError(f"{self.name} exited before it was ready: {self._stderr()}")
+            if time.monotonic() > deadline:
+                raise AssertionError(f"{self.name} did not open its store within {BOUND}s")
+            time.sleep(0.01)
+
+    def go(self) -> None:
+        os.close(os.open(self.go_marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY))
+
+    def result(self) -> dict[str, Any]:
+        try:
+            self._process.wait(timeout=BOUND)
+        except subprocess.TimeoutExpired:
+            self.kill()
+            raise AssertionError(f"{self.name} did not finish within {BOUND}s") from None
+        assert self._process.stdout is not None
+        raw = self._process.stdout.read()
+        if not raw.strip():
+            raise AssertionError(f"{self.name} reported nothing: {self._stderr()}")
+        out: dict[str, Any] = json.loads(raw)
+        assert out["ctrlrun"].startswith(REPO_SRC), (
+            f"{self.name} imported ctrlrun from {out['ctrlrun']!r}, not the tree under test"
+        )
+        return out
+
+    def kill(self) -> None:
+        if self.running():
+            self._process.kill()
+            self._process.wait(timeout=BOUND)
+
+    def _stderr(self) -> str:
+        assert self._process.stderr is not None
+        return self._process.stderr.read()[-800:]
+
+
+@pytest.fixture
+def schema():
+    from ctrlrun.postgres import PostgresStateStore
+
+    name = f"attempts_{uuid.uuid4().hex[:12]}"
+    PostgresStateStore.create_schema(URL, name)
+    try:
+        yield name
+    finally:
+        PostgresStateStore.drop_schema(URL, name)
+
+
+@pytest.fixture
+def proxy():
+    host, port = upstream_of(URL)
+    made = Proxy(host, port).start()
+    try:
+        yield made
+    finally:
+        made.release()  # a test that failed while a statement was held must not strand it
+        made.stop()
+
+
+@pytest.fixture
+def home():
+    with tempfile.TemporaryDirectory() as made:
+        yield Path(made)
+
+
+def direct(schema: str, now: datetime = T0):
+    """A store on the server itself, never through the proxy: setup and the final read."""
+    from ctrlrun.postgres import PostgresStateStore
+
+    return PostgresStateStore(URL, schema=schema, clock=lambda: now)
+
+
+def failed_once(schema: str, key: str) -> None:
+    """The pre-state of every renewal here: attempt 1 ran and proved nothing happened."""
+    store = direct(schema)
+    try:
+        store.reserve_effect(key, "act_first", LEASE)
+        store.begin_execution(key, "act_first")
+        store.fail_effect(key, "act_first", "the remote refused before acting")
+    finally:
+        store.close()
+
+
+def granted_for(schema: str, method: str, key: str) -> tuple[str, str] | None:
+    """A granted approval for the held store to spend, when the method under test takes one."""
+    if method != "consume_approval_and_reserve":
+        return None
+    from ctrlrun.action import Action, Principal
+    from ctrlrun.approval import ApprovalRequest
+
+    action = Action(
+        name="stripe.refund",
+        arguments={"payment_id": key, "amount": 2000},
+        principal=Principal(agent="a"),
+    )
+    approval_id = f"apr_{uuid.uuid4().hex[:12]}"
+    store = direct(schema)
+    try:
+        store.put_approval_request(
+            ApprovalRequest(
+                request_id=approval_id,
+                action_hash=action.action_hash,
+                action=action,
+                created_at=T0,
+                expires_at=T0 + timedelta(hours=1),
+            )
+        )
+        store.grant_approval(approval_id, "cli:local")
+    finally:
+        store.close()
+    return approval_id, action.action_hash
+
+
+def approval_status(schema: str, approval: tuple[str, str] | None) -> str | None:
+    if approval is None:
+        return None
+    store = direct(schema)
+    try:
+        record = store.get_approval(approval[0])
+        assert record is not None
+        return str(record.status)
+    finally:
+        store.close()
+
+
+def stored(schema: str, key: str):
+    store = direct(schema)
+    try:
+        return store.get_effect(key)
+    finally:
+        store.close()
+
+
+def effects_statement(verb: bytes, schema: str):
+    """A `hold_when` predicate: a statement on this schema's `effects` table beginning `verb`."""
+    table = f'"{schema}".effects'.encode()
+
+    def matches(kind: bytes, body: bytes) -> bool:
+        text = statement_of(kind, body)
+        return text is not None and text.lstrip().upper().startswith(verb) and table in text
+
+    return matches
+
+
+# --- the injector's own control -------------------------------------------------------------
+
+
+def test_the_hold_trigger_reads_the_parse_and_not_a_bind_parameter():
+    """`hold_when` sees SQL text only where the protocol puts it.
+
+    No server needed, and the reason is `test_cross_host`'s first control: a trigger that grepped
+    the byte stream fired on a Bind parameter. An effect key containing `UPDATE` travels in a Bind
+    and must not look like a statement; the statement itself travels in a Parse.
+    """
+
+    def typed(kind: bytes, body: bytes) -> tuple[bytes, bytes]:
+        framed = kind + struct.pack("!i", 4 + len(body)) + body
+        return framed[0:1], framed[5:]
+
+    parse = typed(b"P", b'\x00UPDATE "s".effects SET state=$1 WHERE effect_key=$2\x00\x00\x00')
+    bind = typed(b"B", b"\x00\x00\x00\x00\x00\x01\x00\x00\x00\x0frefund:UPDATE-me")
+    query = typed(b"Q", b"SELECT 1\x00")
+
+    assert b"UPDATE" in bind[1], "the control is void: this Bind does not contain the word"
+    assert statement_of(*parse) == b'UPDATE "s".effects SET state=$1 WHERE effect_key=$2'
+    assert statement_of(*bind) is None
+    assert statement_of(*query) == b"SELECT 1"
+
+    matches = effects_statement(b"UPDATE", "s")
+    assert matches(*parse)
+    assert not matches(*bind)
+    assert not effects_statement(b"UPDATE", "other")(*parse), "another schema's table matched"
+
+
+# --- T246: a stale renewal never lands ------------------------------------------------------
+
+
+def held_at(window: str, schema: str):
+    """Where T246 stalls the renewal, between the plan's `SELECT` and the `UPDATE`.
+
+    `update` holds the `UPDATE` itself, which is §8.3a's window. `second-read` holds the store's
+    **second** read of the record, which `_reserve_locked` makes (`previous`, for `created_at`)
+    after `_plan`'s and before the `UPDATE`. The fix takes the planned-from attempt from the plan;
+    a fix that took it from that second read would pass the `update` window, because both reads
+    precede it and see the same record, and fail this one, where the second read sees the rival's.
+    """
+    if window == "update":
+        return effects_statement(b"UPDATE", schema)
+    select = effects_statement(b"SELECT", schema)
+    seen = [0]
+
+    def second_read(kind: bytes, body: bytes) -> bool:
+        if not select(kind, body):
+            return False
+        seen[0] += 1
+        return seen[0] == 2
+
+    return second_read
+
+
+@postgres
+@pytest.mark.parametrize("window", ["update", "second-read"])
+@pytest.mark.parametrize("method", METHODS)
+def test_T246_a_stale_renewal_on_postgres_never_lands(proxy, schema, home, method, window):
+    """SPEC-v0.7 §5.6 and §8.3a T246: the renewal `UPDATE` is conditioned on the planned-from
+    attempt, so a renewal planned against *k* cannot land after another process moved *k*.
+
+    The window: the held process has read the record `FAILED` at 1 and planned a renewal to 2;
+    the proxy holds it before its `UPDATE` reaches the server (`held_at` says at which of two
+    statements). Meanwhile a second process renews to 2, runs and fails, leaving the record
+    `FAILED` again. 0.6.1's `WHERE effect_key AND state = 'failed'` then matches, and attempt 2 is
+    written a second time: two dispatches, one number.
+    """
+    key = f"refund:stale-{method}-{window}"
+    failed_once(schema, key)
+    approval = granted_for(schema, method, key)
+
+    held = Child(
+        home,
+        "held",
+        url=proxy.url(URL),
+        schema=schema,
+        key=key,
+        action_id="act_held",
+        now=T0 + timedelta(seconds=1),
+        gated=True,
+        approval=approval,
+    )
+    try:
+        held.wait_ready()
+        proxy.reset_counters()
+        proxy.hold_when = held_at(window, schema)
+        held.go()
+
+        assert proxy.holding.wait(BOUND), (
+            f"the renewal never reached the {window} statement through the proxy, so the window "
+            "this test is about was never opened"
+        )
+        planned_from = stored(schema, key)
+        assert planned_from is not None
+        assert (planned_from.state, planned_from.attempt) == (EffectState.FAILED, 1), (
+            f"the held process planned against {planned_from.state} at {planned_from.attempt}; "
+            "the window needs it to have read FAILED at 1"
+        )
+
+        rival = Child(
+            home,
+            "rival",
+            url=URL,
+            schema=schema,
+            key=key,
+            action_id="act_rival",
+            now=T0 + timedelta(seconds=2),
+            gated=False,
+            then_fail=True,
+        ).result()
+        assert rival["error"] is None, f"the rival did not renew, run and fail: {rival}"
+        assert rival["attempt"] == 2
+        assert held.running(), "the held process finished while its UPDATE was being held"
+
+        proxy.release()
+        outcome = held.result()
+    finally:
+        proxy.release()
+        held.kill()
+
+    assert proxy.holds == 1
+    handed = [r["attempt"] for r in (rival, outcome) if r["attempt"] is not None]
+    assert handed == [2], (
+        f"reservations were handed attempts {handed}: the stale renewal landed, so attempt 2 was "
+        f"written twice and two dispatches share one number. Held process: {outcome}"
+    )
+    assert outcome["error"] == "DuplicateEffect", outcome
+    assert outcome["state"] == "in_progress", (
+        "the stale renewal is refused exactly as a lost renewal race is refused (§5.6)"
+    )
+
+    record = stored(schema, key)
+    assert record is not None
+    found = (record.state, record.attempt, record.action_id)
+    assert found == (EffectState.FAILED, 2, "act_rival"), (
+        f"the record is {record.state} at {record.attempt} under {record.action_id}; the rival's "
+        "failed attempt 2 must be what the store says"
+    )
+    if approval is not None:
+        assert approval_status(schema, approval) == "granted", (
+            "the refused reservation spent its approval; v0.1 §4.2 A4 rolls both back together"
+        )
+
+
+# --- T246b: a lost COMMIT returns the attempt it wrote --------------------------------------
+
+
+@postgres
+@pytest.mark.parametrize("method", METHODS)
+def test_T246b_renewal_a_lost_commit_returns_the_attempt_the_re_issue_wrote(
+    proxy, schema, home, method
+):
+    """§8.3a T246b, the renewal variant: Table A2 row 2 re-issues, and returns what it wrote.
+
+    The window: the held process's renewal to 2 loses its `COMMIT` (the proxy swallows it, so the
+    server rolls it back). Before the store re-reads, another process renews to 2 and fails. The
+    re-read finds `FAILED` at 2 and re-issues, and the re-issue writes 3. 0.6.1 then returned the
+    original plan's reservation, attempt 2, which the rival had already been handed.
+    """
+    key = f"refund:lost-renewal-{method}"
+    failed_once(schema, key)
+    approval = granted_for(schema, method, key)
+    rivals: list[dict[str, Any]] = []
+
+    def another_process_renews_and_fails() -> None:
+        rivals.append(
+            Child(
+                home,
+                "rival",
+                url=URL,
+                schema=schema,
+                key=key,
+                action_id="act_rival",
+                now=T0 + timedelta(seconds=2),
+                gated=False,
+                then_fail=True,
+            ).result()
+        )
+
+    held = Child(
+        home,
+        "held",
+        url=proxy.url(URL),
+        schema=schema,
+        key=key,
+        action_id="act_held",
+        now=T0 + timedelta(seconds=1),
+        gated=True,
+        approval=approval,
+    )
+    try:
+        held.wait_ready()
+        proxy.reset_counters()
+        proxy.on_drop = another_process_renews_and_fails
+        proxy.drop_before_commit = 1
+        held.go()
+        outcome = held.result()
+    finally:
+        held.kill()
+
+    assert proxy.commits_dropped == 1, "no COMMIT was swallowed; the window never opened"
+    assert len(rivals) == 1, "the rival never ran between the lost COMMIT and the re-read"
+    rival = rivals[0]
+    assert rival["error"] is None and rival["attempt"] == 2, rival
+    assert outcome["branches"] == ["a2.row2.reissue"], (
+        f"the held store reported {outcome['branches']}; the window needs the re-read to find "
+        "FAILED and re-issue"
+    )
+    assert outcome["error"] is None, outcome
+
+    record = stored(schema, key)
+    assert record is not None
+    assert (record.state, record.action_id) == (EffectState.RESERVED, "act_held")
+    assert record.attempt == 3, f"the re-issue renewed from 2, so it wrote 3, not {record.attempt}"
+    assert outcome["attempt"] == record.attempt, (
+        f"the reservation method returned attempt {outcome['attempt']} and the store holds "
+        f"{record.attempt}. The rival was handed {rival['attempt']}: the lost COMMIT's re-issue "
+        "was discarded and the original plan's number returned"
+    )
+    if approval is not None:
+        assert approval_status(schema, approval) == "consumed"
+
+
+@postgres
+@pytest.mark.parametrize("method", METHODS)
+def test_T246b_insert_a_lost_commit_returns_the_attempt_the_re_issue_wrote(
+    proxy, schema, home, method
+):
+    """§8.3a T246b, the insert variant: Table A1 row 2 re-issues, and returns what it wrote.
+
+    The window is later than the renewal's, and has to be. The held process's `INSERT` of attempt 1
+    loses its `COMMIT`. Its re-read finds no record and takes `a1.row2.reinsert`. The proxy then
+    holds the re-issue's **own planning `SELECT`** while another process inserts attempt 1 and
+    fails, and releases it, so the re-issue plans a renewal and writes 2. 0.6.1 returned the
+    original plan's attempt 1, the number the rival had just run under.
+
+    Interleaving before the re-read instead would send the insert down `a1.row3.refuse` and never
+    reach the re-issue, which is a test of a window nobody opened. So the hold is armed only when
+    the `COMMIT` is swallowed, and it fires on the second `SELECT` of the effects table after
+    that: the first is the re-read, on its own fresh connection; the second is the re-issue's plan.
+    """
+    key = f"refund:lost-insert-{method}"
+    direct(schema).close()  # migrated, and no record: attempt 1 is an INSERT
+    approval = granted_for(schema, method, key)
+    select = effects_statement(b"SELECT", schema)
+    seen = [0]
+
+    def the_re_issues_planning_read(kind: bytes, body: bytes) -> bool:
+        if not select(kind, body):
+            return False
+        seen[0] += 1
+        return seen[0] == 2
+
+    def arm_the_hold() -> None:
+        proxy.hold_when = the_re_issues_planning_read
+
+    held = Child(
+        home,
+        "held",
+        url=proxy.url(URL),
+        schema=schema,
+        key=key,
+        action_id="act_held",
+        now=T0 + timedelta(seconds=1),
+        gated=True,
+        approval=approval,
+    )
+    try:
+        held.wait_ready()
+        proxy.reset_counters()
+        proxy.on_drop = arm_the_hold
+        proxy.drop_before_commit = 1
+        held.go()
+
+        assert proxy.holding.wait(BOUND), (
+            "the re-issue's planning SELECT never reached the proxy, so the re-issue was never "
+            "entered or never planned"
+        )
+        assert stored(schema, key) is None, (
+            "a record exists while the re-issue's planning read is held; the re-read cannot have "
+            "found none, and this is not the a1.row2 window"
+        )
+
+        rival = Child(
+            home,
+            "rival",
+            url=URL,
+            schema=schema,
+            key=key,
+            action_id="act_rival",
+            now=T0 + timedelta(seconds=2),
+            gated=False,
+            then_fail=True,
+        ).result()
+        assert rival["error"] is None and rival["attempt"] == 1, rival
+        assert held.running(), "the held process finished while its planning read was held"
+
+        proxy.release()
+        outcome = held.result()
+    finally:
+        proxy.release()
+        held.kill()
+
+    assert proxy.commits_dropped == 1, "no COMMIT was swallowed; the window never opened"
+    assert proxy.holds == 1 and seen[0] == 2
+    assert outcome["branches"] == ["a1.row2.reinsert"], (
+        f"the held store reported {outcome['branches']}; the window is the re-issue of a1.row2"
+    )
+    assert outcome["error"] is None, outcome
+
+    record = stored(schema, key)
+    assert record is not None
+    assert (record.state, record.action_id) == (EffectState.RESERVED, "act_held")
+    assert record.attempt == 2, (
+        f"the re-issue planned over the rival's FAILED attempt 1, so it wrote 2, not "
+        f"{record.attempt}"
+    )
+    assert outcome["attempt"] == record.attempt, (
+        f"the reservation method returned attempt {outcome['attempt']} and the store holds "
+        f"{record.attempt}. The rival ran under {rival['attempt']}: the lost COMMIT's re-issue "
+        "was discarded and the original plan's number returned"
+    )
+    if approval is not None:
+        assert approval_status(schema, approval) == "consumed"
+
+
+@postgres
+@pytest.mark.parametrize("method", METHODS)
+def test_T246b_landed_a_renewal_re_read_that_finds_our_action_id_is_not_proof_it_landed(
+    proxy, schema, home, method
+):
+    """§5.5's MUST on the third branch of `_resolve_lost_renewal`, which §8.3a does not name.
+
+    Found while building item 3a (§12.3a). Table A2 row 1 on a renewal concluded *"the commit
+    landed"* from `action_id` and `RESERVED` alone. v0.6 §4.3.3 says why that is not enough on the
+    insert path, and the renewal path never applied it: `action_id` is caller-supplyable, and a
+    caller that rebuilt the same `Action` after a restart renews under the same one. So the held
+    process's renewal loses its `COMMIT`, a second process renews the key under the **same**
+    `action_id` at a later instant, and the re-read finds a record that carries our id and is not
+    our write. 0.6.1 returned attempt 2 to both: two dispatches holding one attempt, and the
+    number returned was one the method never wrote.
+
+    What separates them is §4.3.3's row identity: the rival's lease and `updated_at` are its own.
+    """
+    key = f"refund:lost-landed-{method}"
+    failed_once(schema, key)
+    approval = granted_for(schema, method, key)
+    rivals: list[dict[str, Any]] = []
+
+    def the_same_action_id_renews_elsewhere() -> None:
+        rivals.append(
+            Child(
+                home,
+                "rival",
+                url=URL,
+                schema=schema,
+                key=key,
+                action_id="act_shared",
+                now=T0 + timedelta(seconds=2),
+                gated=False,
+            ).result()
+        )
+
+    held = Child(
+        home,
+        "held",
+        url=proxy.url(URL),
+        schema=schema,
+        key=key,
+        action_id="act_shared",
+        now=T0 + timedelta(seconds=1),
+        gated=True,
+        approval=approval,
+    )
+    try:
+        held.wait_ready()
+        proxy.reset_counters()
+        proxy.on_drop = the_same_action_id_renews_elsewhere
+        proxy.drop_before_commit = 1
+        held.go()
+        outcome = held.result()
+    finally:
+        held.kill()
+
+    assert proxy.commits_dropped == 1, "no COMMIT was swallowed; the window never opened"
+    assert len(rivals) == 1, "the rival never ran between the lost COMMIT and the re-read"
+    rival = rivals[0]
+    assert rival["error"] is None and rival["attempt"] == 2, rival
+
+    record = stored(schema, key)
+    assert record is not None
+    assert (record.state, record.attempt) == (EffectState.RESERVED, 2)
+    assert record.lease_expires_at == T0 + timedelta(seconds=2) + LEASE, (
+        "the record is not the rival's reservation; the window this test needs did not open"
+    )
+
+    assert outcome["attempt"] is None, (
+        f"the held process was handed attempt {outcome['attempt']} for a renewal whose COMMIT "
+        f"never landed, and the rival holds attempt {rival['attempt']} on the same key: one "
+        f"attempt, two dispatches. It reported {outcome['branches']}"
+    )
+    assert outcome["error"] == "DuplicateEffect" and outcome["state"] == "in_progress", outcome
+    assert outcome["branches"] == ["a2.row3.refuse"], (
+        f"the held store reported {outcome['branches']}; a record that is not our own write is "
+        "Table A2's third row"
+    )
+    if approval is not None:
+        assert approval_status(schema, approval) == "granted", (
+            "the held process was refused, and its own consumption was rolled back with the lost "
+            "COMMIT; the approval must still be there for the attempt that runs"
+        )

--- a/tests/test_attempt_integrity.py
+++ b/tests/test_attempt_integrity.py
@@ -1412,7 +1412,8 @@ def test_the_outcome_re_issue_is_bounded_at_one(schema, caplog):
 
 
 @postgres
-def test_the_two_re_issue_bounds_compose(proxy, schema):
+@pytest.mark.parametrize("moves", [(0, 0, 1, 0), (1, 0, 0, 0)])
+def test_the_two_re_issue_bounds_compose(proxy, schema, moves):
     """Two bounds that reset each other are one unbounded loop, and this drives both at once.
 
     `restaged` bounds the stale re-issue; `retrying` bounds the lost-commit re-issue of `v0.6`
@@ -1427,12 +1428,23 @@ def test_the_two_re_issue_bounds_compose(proxy, schema):
     `drop_before_commit = 1000`, which is T155f's injection; the record that keeps moving is the
     bound test's seam, which is what a same-`action_id` renewal leaves behind. Neither invents a
     store answer: one is a connection dying mid-`COMMIT`, the other is a row a rival advanced.
+
+    **The assertion is the nesting, not the absence of a `RecursionError`, and the reason is what a
+    search of these interleavings shows.** Dropping *both* flags recurses, on some patterns and not
+    others. Dropping *one* does not recurse at all on any pattern of four reads or fewer: it
+    permits exactly one re-issue more than the bound allows, which happens to terminate. So a test
+    that asked only "did this blow the stack" would be green for half the ways this can break, and
+    would have been green for the very mutants that say each flag is load-bearing. Each bound
+    permits one re-issue, so the deepest nesting any interleaving may reach is three; a fourth
+    level means a bound was cleared, whether or not that particular pattern went on forever. The
+    patterns here are the two that separate every case, measured through this proxy rather than
+    guessed: both recurse with both flags gone; `(0, 0, 1, 0)` reaches four with the restage's
+    `retrying` dropped, and `(1, 0, 0, 0)` reaches four with the lost-commit re-issue's `restaged`
+    dropped. Either one alone would leave one of the two flags untested.
     """
     from dataclasses import replace
 
     from ctrlrun.postgres import PostgresStateStore
-
-    moves = (0, 0, 1, 0)
 
     class LosesCommitsAndKeepsMoving(PostgresStateStore):
         breaking = False
@@ -1444,11 +1456,10 @@ def test_the_two_re_issue_bounds_compose(proxy, schema):
             record = super()._read_effect(connection, effect_key)
             if record is None or not self.breaking:
                 return record
-            # The pattern a review's search over read patterns found: the rival moves the row on
-            # the third read of each cycle. Whether two bounds compose is a property of the
-            # interleaving, and this is the interleaving that catches it; the obvious
-            # every-other-read pattern happens to end bounded even when they do not compose,
-            # which is the mutation-pattern-4 trap one layer up from the store.
+            # Where in the cycle the rival moves the row. Whether the bounds compose is a
+            # property of the interleaving: the obvious every-other-read pattern ends bounded
+            # even when they do not compose, which is mutation pattern 4 one layer up from the
+            # store, so the patterns come from a search rather than from intuition.
             moved = moves[self.reads % len(moves)]
             self.reads += 1
             return replace(record, attempt=record.attempt + 1) if moved else record
@@ -1484,11 +1495,11 @@ def test_the_two_re_issue_bounds_compose(proxy, schema):
         proxy.drop_before_commit = 0
         store.close()
 
-    assert proxy.commits_dropped >= 2, (
-        f"only {proxy.commits_dropped} COMMIT was swallowed; the lost-commit half of this "
-        "composition never ran"
-    )
+    assert proxy.commits_dropped >= 1, "no COMMIT was swallowed; the lost-commit half never ran"
     assert store.reads >= 2, "the record never moved; the restage half never ran"
+    assert store.deepest >= 2, (
+        "the transition never nested, so neither re-issue ran and this test is about nothing"
+    )
     assert not isinstance(raised, RecursionError), (
         f"the two bounds reset each other and the re-issues alternated to a RecursionError at "
         f"{store.deepest} deep: outside the closed error set, so no caller can classify it"
@@ -1497,9 +1508,10 @@ def test_the_two_re_issue_bounds_compose(proxy, schema):
         f"the composition ended as {type(raised).__name__ if raised else 'a clean return'}; a "
         "write nobody could land must refuse inside the taxonomy"
     )
-    assert store.deepest <= 4, (
-        f"the transition nested {store.deepest} deep; each bound permits one re-issue, so the "
-        "composition of the two is bounded and small"
+    assert store.deepest <= 3, (
+        f"the transition nested {store.deepest} deep. Each bound permits one re-issue, so three "
+        "is the deepest any interleaving may reach; a fourth level is one of the two bounds "
+        "cleared by the other, whether or not this pattern went on to recurse"
     )
 
     record = stored(schema, key)

--- a/tests/test_attempt_integrity.py
+++ b/tests/test_attempt_integrity.py
@@ -1226,8 +1226,9 @@ def test_a_stale_expire_never_overwrites_a_consumption(proxy, schema, home):
 # --- the outcome itself: never lost, whatever the store answers ------------------------------
 
 
+@pytest.mark.parametrize("did", ["raised TimeoutError", "returned", "raised NotExecuted"])
 @pytest.mark.parametrize("backend", ["sqlite", "postgres"])
-def test_an_unknown_outcome_the_store_refuses_to_record_is_never_lost(backend, tmp_path):
+def test_an_unknown_outcome_the_store_refuses_to_record_is_never_lost(backend, did, tmp_path):
     """`v0.1 §5.5` through `Control`, when the outcome write itself is refused.
 
     The round-2 review drove this through the public API on SQLite, so the store is not the
@@ -1243,9 +1244,17 @@ def test_an_unknown_outcome_the_store_refuses_to_record_is_never_lost(backend, t
     written whatever the store says, they name the refusal, and the caller gets its own exception
     back. What the effect record says afterwards is the human's claim and not this attempt's, which
     is the residual §12.3a states and the reason the receipt has to carry the truth.
+
+    **And the receipt says what the executor did**, which is the fact a human resolving the effect
+    needs most. All three outcomes end here: a timeout, an executor that returned normally (so the
+    remote very likely acted), and one that raised `NotExecuted` (so it very likely did not). A
+    review found the last two producing byte-identical receipts, because the refusal was recorded
+    and the outcome was not. A human reading *"DuplicateEffect: ..."* cannot tell a refund that
+    probably landed from one that certainly did not.
     """
     from ctrlrun.action import Action, Principal
     from ctrlrun.control import Control
+    from ctrlrun.errors import NotExecuted
     from ctrlrun.policy import Policy
     from ctrlrun.receipt import EventType, ReceiptResult
     from ctrlrun.state import SQLiteStateStore
@@ -1288,11 +1297,16 @@ def test_an_unknown_outcome_the_store_refuses_to_record_is_never_lost(backend, t
         finally:
             other.close()
         ran.append("the executor ran, and nobody knows what the remote did")
+        if did == "returned":
+            return {"refund": "re_1"}
+        if did == "raised NotExecuted":
+            raise NotExecuted("the gateway refused the request before dispatching it")
         raise TimeoutError("the refund response never arrived")
 
     try:
         before = len(store.receipts())
-        with pytest.raises(TimeoutError):
+        expected = TimeoutError if did == "raised TimeoutError" else CTRLRunError
+        with pytest.raises(expected):
             control.execute(action, executor, "refund:re_1")
         assert ran, "the executor never ran; this test is about what happens after it does"
 
@@ -1302,10 +1316,20 @@ def test_an_unknown_outcome_the_store_refuses_to_record_is_never_lost(backend, t
             "the outcome write and the evidence went with it"
         )
         assert written[0].result is ReceiptResult.AMBIGUOUS, written[0].result
-        assert "TimeoutError" in (written[0].error or ""), written[0].error
         assert "refused" in (written[0].error or ""), (
             f"the receipt says {written[0].error!r}; it must say the outcome could not be written, "
             "because the effect record does not say it either"
+        )
+        says = {
+            "raised TimeoutError": "TimeoutError",
+            "returned": "returned",
+            "raised NotExecuted": "NotExecuted",
+        }[did]
+        assert says in (written[0].error or ""), (
+            f"the executor {did} and the receipt says {written[0].error!r}, which does not. An "
+            "executor that returned and one that proved it did not act must not leave the same "
+            "receipt: for the first the remote very likely acted, and a human resolving this "
+            "effect has nothing else to go on"
         )
         assert EventType.EXECUTION_AMBIGUOUS in [event.type for event in store.events()], (
             "no EXECUTION_AMBIGUOUS event: the one unknown outcome here is recorded nowhere"
@@ -1321,7 +1345,7 @@ def test_an_unknown_outcome_the_store_refuses_to_record_is_never_lost(backend, t
 
 
 @postgres
-def test_the_outcome_re_issue_is_bounded_at_one(schema):
+def test_the_outcome_re_issue_is_bounded_at_one(schema, caplog):
     """*Every loop in this project is bounded*, and the re-issue above is a loop.
 
     `T155f` is the precedent: the lost-commit re-issue had no bound, and driven with a proxy that
@@ -1352,6 +1376,7 @@ def test_the_outcome_re_issue_is_bounded_at_one(schema):
             self.reads += 1
             return replace(record, attempt=record.attempt + self.reads)
 
+    caplog.set_level("WARNING", logger="ctrlrun.postgres")
     key = "refund:bounded-reissue"
     store = KeepsMoving(URL, schema=schema, clock=lambda: T0)
     try:
@@ -1368,6 +1393,14 @@ def test_the_outcome_re_issue_is_bounded_at_one(schema):
             f"the record was read {store.reads} times: the re-issue never ran, so this test is "
             "not about the bound"
         )
+        # And the restage that then refused is in the log. It used to be written only after the
+        # re-issue returned, so the one case an operator would go looking for left no line.
+        restages = [r for r in caplog.records if getattr(r, "restage", None)]
+        assert len(restages) == 1, (
+            f"{len(restages)} restage lines for a re-issue that ran and then refused; §4.3.4's "
+            "rule is that which branch ran is observable, and this is the branch that wrote "
+            "nothing"
+        )
     finally:
         store.moving = False
         store.close()
@@ -1376,3 +1409,101 @@ def test_the_outcome_re_issue_is_bounded_at_one(schema):
     record = stored(schema, key)
     assert record is not None
     assert (record.state, record.attempt) == (EffectState.EXECUTING, 1), record
+
+
+@postgres
+def test_the_two_re_issue_bounds_compose(proxy, schema):
+    """Two bounds that reset each other are one unbounded loop, and this drives both at once.
+
+    `restaged` bounds the stale re-issue; `retrying` bounds the lost-commit re-issue of `v0.6`
+    §4.3.2 Table A2. Each was tested alone. A review composed them: a `COMMIT` lost *inside* a
+    restage re-entered the lost-commit path, which re-issued without `restaged`, which restaged
+    again without `retrying`, and the two alternated to `RecursionError` at 113 deep. That is
+    T155f's failure mode exactly, and T155f's comment says why it matters: `RecursionError` is
+    outside this library's closed set of errors, so no caller can classify it and the record is
+    left stranded.
+
+    Both halves are driven the way each is driven alone. The lost `COMMIT` is the **real** proxy at
+    `drop_before_commit = 1000`, which is T155f's injection; the record that keeps moving is the
+    bound test's seam, which is what a same-`action_id` renewal leaves behind. Neither invents a
+    store answer: one is a connection dying mid-`COMMIT`, the other is a row a rival advanced.
+    """
+    from dataclasses import replace
+
+    from ctrlrun.postgres import PostgresStateStore
+
+    moves = (0, 0, 1, 0)
+
+    class LosesCommitsAndKeepsMoving(PostgresStateStore):
+        breaking = False
+        reads = 0
+        depth = 0
+        deepest = 0
+
+        def _read_effect(self, connection, effect_key):  # type: ignore[no-untyped-def]
+            record = super()._read_effect(connection, effect_key)
+            if record is None or not self.breaking:
+                return record
+            # The pattern a review's search over read patterns found: the rival moves the row on
+            # the third read of each cycle. Whether two bounds compose is a property of the
+            # interleaving, and this is the interleaving that catches it; the obvious
+            # every-other-read pattern happens to end bounded even when they do not compose,
+            # which is the mutation-pattern-4 trap one layer up from the store.
+            moved = moves[self.reads % len(moves)]
+            self.reads += 1
+            return replace(record, attempt=record.attempt + 1) if moved else record
+
+        def _transition(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            self.depth += 1
+            self.deepest = max(self.deepest, self.depth)
+            try:
+                return super()._transition(*args, **kwargs)
+            finally:
+                self.depth -= 1
+
+    key = "refund:composed-bounds"
+    setup = direct(schema)
+    try:
+        setup.reserve_effect(key, REUSED, LEASE)
+        setup.begin_execution(key, REUSED)
+    finally:
+        setup.close()
+
+    store = LosesCommitsAndKeepsMoving(proxy.url(URL), schema=schema, clock=lambda: T0)
+    raised: BaseException | None = None
+    try:
+        proxy.reset_counters()
+        proxy.drop_before_commit = 1000  # every COMMIT from here on, as T155f does
+        store.breaking = True
+        try:
+            store.mark_ambiguous(key, REUSED, "nobody knows what the remote did")
+        except BaseException as broke:
+            raised = broke
+    finally:
+        store.breaking = False
+        proxy.drop_before_commit = 0
+        store.close()
+
+    assert proxy.commits_dropped >= 2, (
+        f"only {proxy.commits_dropped} COMMIT was swallowed; the lost-commit half of this "
+        "composition never ran"
+    )
+    assert store.reads >= 2, "the record never moved; the restage half never ran"
+    assert not isinstance(raised, RecursionError), (
+        f"the two bounds reset each other and the re-issues alternated to a RecursionError at "
+        f"{store.deepest} deep: outside the closed error set, so no caller can classify it"
+    )
+    assert isinstance(raised, CTRLRunError), (
+        f"the composition ended as {type(raised).__name__ if raised else 'a clean return'}; a "
+        "write nobody could land must refuse inside the taxonomy"
+    )
+    assert store.deepest <= 4, (
+        f"the transition nested {store.deepest} deep; each bound permits one re-issue, so the "
+        "composition of the two is bounded and small"
+    )
+
+    record = stored(schema, key)
+    assert record is not None
+    assert (record.state, record.attempt) == (EffectState.EXECUTING, 1), (
+        f"the record is {record.state} at {record.attempt}; no COMMIT was allowed to land"
+    )

--- a/tests/test_attempt_integrity.py
+++ b/tests/test_attempt_integrity.py
@@ -1318,3 +1318,61 @@ def test_an_unknown_outcome_the_store_refuses_to_record_is_never_lost(backend, t
             from ctrlrun.postgres import PostgresStateStore
 
             PostgresStateStore.drop_schema(URL, name)
+
+
+@postgres
+def test_the_outcome_re_issue_is_bounded_at_one(schema):
+    """*Every loop in this project is bounded*, and the re-issue above is a loop.
+
+    `T155f` is the precedent: the lost-commit re-issue had no bound, and driven with a proxy that
+    swallowed every `COMMIT` the store recursed 96 deep and escaped as `RecursionError`, outside
+    the error taxonomy entirely. The stale re-issue is bounded the same way, by a flag, and this
+    drives it the same way: a record that has moved **again** by the time the re-issue reads it.
+
+    No proxy can open that window deterministically, because it would have to interleave a rival
+    inside each re-issue, and a hold fires once. So the seam is the store's own read, subclassed to
+    report the record one attempt further on each time it is consulted while the flag is set: a
+    rival that never stops moving. It refuses nothing the real store refuses and invents no outcome
+    the real store cannot produce, it only makes every conditional `UPDATE` miss, which is what a
+    rival moving the row does. With the bound the call refuses; without it, it recurses until
+    Python stops it, which is a failure mode no caller can classify.
+    """
+    from dataclasses import replace
+
+    from ctrlrun.postgres import PostgresStateStore
+
+    class KeepsMoving(PostgresStateStore):
+        moving = False
+        reads = 0
+
+        def _read_effect(self, connection, effect_key):  # type: ignore[no-untyped-def]
+            record = super()._read_effect(connection, effect_key)
+            if record is None or not self.moving:
+                return record
+            self.reads += 1
+            return replace(record, attempt=record.attempt + self.reads)
+
+    key = "refund:bounded-reissue"
+    store = KeepsMoving(URL, schema=schema, clock=lambda: T0)
+    try:
+        store.reserve_effect(key, "act_moving", LEASE)
+        store.begin_execution(key, "act_moving")
+        store.moving = True
+        with pytest.raises(CTRLRunError) as refused:
+            store.mark_ambiguous(key, "act_moving", "the outcome was lost")
+        assert not isinstance(refused.value, RecursionError), (
+            "the re-issue chased a record that kept moving until Python stopped it"
+        )
+        assert "moved from attempt" in str(refused.value), refused.value
+        assert store.reads >= 3, (
+            f"the record was read {store.reads} times: the re-issue never ran, so this test is "
+            "not about the bound"
+        )
+    finally:
+        store.moving = False
+        store.close()
+
+    # The record is exactly as attempt 1 left it: a refused re-issue writes nothing.
+    record = stored(schema, key)
+    assert record is not None
+    assert (record.state, record.attempt) == (EffectState.EXECUTING, 1), record


### PR DESCRIPTION
v0.7 item 3a (SPEC-v0.7 §4.4, §5.5, §5.6, §8.3a). **Attempt numbers never repeat, and an outcome is never lost.** Item 3's idempotency token and item 4's ceiling both rest on this, so it lands before either.

Every defect here is in shipped 0.6.1 code, found by reading it against the v0.7 spec and then reproduced deterministically before being fixed. Four review rounds.

## What was wrong

- **A stale renewal wrote an attempt number twice.** The renewal `UPDATE` matched on `effect_key` and `state` only, so a caller that read `FAILED` at *k*, stalled while another renewed to *k+1*, ran and failed, then wrote *k+1* a second time. Two dispatches, one number.
- **A lost `COMMIT` returned a number it did not write.** Both resolve paths re-issued the reservation and then returned the *original* plan, so the caller held *k+1* while the store held *k+2*.
- **The "did my COMMIT land?" check trusted any reserved row under our `action_id`**, so a second process renewing under the same id left two dispatches holding one attempt. It now uses v0.6 §4.3.3's whole-row identity check.
- **The attempt number could go backwards**, which is what made the first fix's premise false: `_write_effect` and `_transition` set `attempt` from their own earlier read while matching on `(effect_key, action_id, state)`. A human's stale `resolve_effect(failed)` could overwrite attempt 2's record with attempt 1, and attempt 2 was then handed out again.
- **An unknown outcome could vanish.** On both backends, a late outcome write could reach `_checked`, raise `InvalidArgument` into `Control`, and produce **no receipt and no `EXECUTION_AMBIGUOUS` event** while the record read `FAILED` and a retry was permitted. An executor's timeout disappeared from the evidence.
- **`_expire` overwrote a concurrent consumption**, so an approval that authorised a real effect could read `expired`.

## What it does now

Every `UPDATE` on an effect record carries the attempt it read (on Postgres; SQLite's writes sit inside `BEGIN IMMEDIATE`). A moved row matches nothing, is re-read, and is refused with the exception the found record earns, naming the move. `commit_effect` and `mark_ambiguous` are re-issued once against the re-read so a terminal outcome is never dropped; `begin_execution` and `fail_effect` are refused there, because a stale `FAILED` must never land on a running attempt. `Control` records the event and the receipt whatever the store answers, names the refusal in the recorded error, and re-raises the caller's own exception.

## The bound, proved and tested

The re-issue and the lost-commit re-issue each set a flag that is never cleared and that the other now passes through, so every recursive call strictly increases the flags set: **at most three frames, and three is reachable.** An earlier version let the two bounds clear each other, which recursed to `RecursionError` at 381 deep. That is T155f's failure mode, and a `RecursionError` is outside the closed error set, so no caller could classify it. The test asserts depth 3 over two interleavings found by search, because a test asserting only "this did not blow the stack" was green for each flag dropped alone (measured, not assumed).

## Evidence

- Gate: 2981 passed with Postgres, 2905 passed / 70 skipped without. 24 new tests, 21 of them Postgres, in `tests/test_attempt_integrity.py`.
- Every new test was **red first against the unfixed code**, each for its own defect, with the failure text quoted in the PR discussion.
- Mutation table: 31 rows across four rounds, all killed. Three lines are declared equivalent or unreachable rather than counted: SQLite's `AND attempt = ?`, the `carries_outcome` guard, and `_resolve_lost_renewal`'s final raise.
- The test proxy gained one mode, `arm(predicate)`, which holds a single statement on a single connection and refuses to arm over a pending hold. No second proxy.
- Reviewed independently in four rounds. Rounds 1 to 3 each found a blocking defect, including one introduced by the previous round's fix. Round 4 is clean.

## Residual, stated rather than fixed

With a reused `action_id`, a late transition can still attribute an outcome to the newer attempt, and a late `fail_effect` can permit a dispatch beside a running one. Closing it needs the attempt on every transition, which the frozen `StateStore` signatures do not carry; the store-side memo that would do it is written down in §12.3a and declined here. `resolve_effect` also carries no attempt, so the window a human actually has, inspect then decide then resolve, is wider than the one this closes. Both are in §12.3a and the CHANGELOG.

`main` has moved; `git merge-tree` reports zero conflicts. The `api` drift is two "defined at line" numbers; item 6 regenerates.
