### PR TITLE
A document PyYAML cannot convert is refused in words, not raised as OverflowError

### DIFF
--- a/src/ctrlrun/policy.py
+++ b/src/ctrlrun/policy.py
@@ -564,12 +564,36 @@ class _StrictLoader(yaml.SafeLoader):  # type: ignore[misc]  # PyYAML ships no s
 
 
 def strict_load(text: str, source: str) -> Any:  # noqa: ANN401 - any YAML scalar or node
-    """`yaml.safe_load`, refusing a repeated key. The one loader for every CTRLRun document."""
+    """`yaml.safe_load`, refusing a repeated key. The one loader for every CTRLRun document.
+
+    **`yaml.YAMLError` is not the whole contract.** PyYAML converts a scalar before it has
+    decided the document is well formed, and three conversions raise the interpreter's own
+    exception rather than a `YAMLError`:
+
+    - `"\\U0001f600"` with too many digits overflows converting the codepoint to a C int,
+      which is `OverflowError`. The fuzzer found this one after 174,380 executions;
+    - `"\\U00110000"` is a legal-looking escape above the Unicode maximum, and `chr()` says
+      `ValueError`;
+    - `2026-99-99` is a `ValueError` from `datetime`, and is the one that matters: a mistyped
+      date is a thing a person writes in a real policy, not a thing a fuzzer invents.
+
+    Each was a crash where the caller was promised a refusal, and `Policy.from_yaml` says
+    "anything malformed raises `PolicyError`" without qualification. The document is refused
+    either way, so nothing unsafe was ever admitted; what leaked was the exception type, and a
+    caller that catches `PolicyError` around a policy load would not have caught these.
+
+    `ValueError` and `OverflowError` are therefore refusals too. The catch is deliberately not
+    `Exception`: this function calls one thing, so a `MemoryError` or a `KeyboardInterrupt`
+    here is not the document's fault and must not be reported as one. `RecursionError` is left
+    uncaught for the same reason, and `fuzz/properties.py` says so where it excludes it.
+    """
     try:
         # `_StrictLoader` derives from `SafeLoader`, so this constructs no arbitrary object.
         return yaml.load(text, Loader=_StrictLoader)
     except yaml.YAMLError as exc:
         raise PolicyError(f"{source}: not valid YAML: {exc}") from exc
+    except (ValueError, OverflowError) as exc:
+        raise PolicyError(f"{source}: not valid YAML: {type(exc).__name__}: {exc}") from exc
 
 
 @dataclass(frozen=True)

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -648,6 +648,36 @@ def test_malformed_policy_document_is_a_policy_error(text: str) -> None:
         Policy.from_yaml(text)
 
 
+@pytest.mark.parametrize(
+    ("case", "text"),
+    [
+        # The fuzzer's own crash unit, decoded exactly as `fuzz/properties.py` decodes it
+        # (`utf-8`, `replace`), so this test fails if the decode path or the loader changes.
+        ("overflowing \\U escape", b'"\\Ueeeeeeeeeeeeeeeee\xd4a'.decode("utf-8", "replace")),
+        ("\\U above the Unicode maximum", '"\\U00110000"'),
+        # The one a person writes. The two above need a fuzzer or a bad day; a mistyped month
+        # in a date is an ordinary typo, and it crashed with `ValueError` from `datetime`.
+        ("a month that does not exist", "schema: ctrlrun.policy/v1\nactions: {}\nx: 2026-99-99\n"),
+    ],
+)
+def test_a_document_pyyaml_cannot_convert_is_refused_in_words(case: str, text: str) -> None:
+    """`Policy.from_yaml` promises `PolicyError` for anything malformed, without qualification.
+
+    PyYAML converts a scalar before it has decided the document is well formed, and these three
+    conversions raise the interpreter's exception rather than a `YAMLError`: the codepoint of an
+    over-long `\\U` escape overflows a C int, `chr()` refuses one above `0x10FFFF`, and
+    `datetime` refuses month 99. Each reached the caller as `OverflowError` or `ValueError`
+    through a loader whose whole job is to turn a bad document into one named error.
+
+    Nothing unsafe was admitted -- the document is refused either way -- so what this fixes is
+    the type, and the type is the contract: a caller catching `PolicyError` around a policy load
+    caught none of these. Found by `fuzz/properties.py` after 174,380 executions, which is the
+    argument for the fuzzer running on every push rather than on a schedule somebody mutes.
+    """
+    with pytest.raises(PolicyError, match="not valid YAML"):
+        Policy.from_yaml(text)
+
+
 def test_yaml_is_loaded_safely() -> None:
     # A policy file is untrusted input; it must not be able to construct Python objects.
     with pytest.raises(PolicyError):


### PR DESCRIPTION
Found by `fuzz` on #140, which is how a non-required check earns its place: the failure had nothing to do with that PR and everything to do with `main`.

## What escapes `strict_load`

`Policy.from_yaml` promises `PolicyError` for anything malformed, without qualification, and `strict_load` is the one loader every CTRLRun document goes through. PyYAML converts a scalar **before** it has decided the document is well formed, so these come back as the interpreter's own exception and go straight past `except yaml.YAMLError`:

| document | raised | how you reach it |
|---|---|---|
| `"\Ueeeeeeeeeeeeeeeee…` | `OverflowError: Python int too large to convert to C int` | the fuzzer, after 174,380 executions |
| `"\U00110000"` | `ValueError: chr() arg not in range(0x110000)` | an escape just above the Unicode maximum |
| `x: 2026-99-99` | `ValueError: month must be in 1..12` | **a mistyped date in a real policy** |

The third is the one that matters. The first two need a fuzzer or a bad day; a wrong month is an ordinary typo somebody writes by hand.

## What this does and does not fix

Nothing unsafe was ever admitted: the document is refused either way. What leaked is the **exception type**, and the type is the contract. A caller wrapping a policy load in `except PolicyError` caught none of these.

`ValueError` and `OverflowError` are refusals too now. Deliberately **not** `except Exception`: `strict_load` calls one thing, so a `MemoryError` or `KeyboardInterrupt` there is not the document's fault and must not be reported as one. `RecursionError` stays uncaught for the same reason `fuzz/properties.py` already excludes it.

## Tests

All three cases, with the first seeded from the fuzzer's own crash unit decoded exactly as `policy_text_from_bytes` decodes it, so the test fails if either the decode path or the loader changes. Replaying the crash unit through `properties.check_policy` now passes.

Local: 2,948 passed, 65 skipped. `ruff format --check`, `ruff check` and `mypy --strict src` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)