### PR TITLE
Date the 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project are documented here. The format follows
 Public API names are frozen in `docs/SPEC-v0.1.md` §8. Before 1.0 they may still change, and
 any change to one appears here.
 
-## [0.7.0] — unreleased — Execution boundary
+## [0.7.0] - 2026-09-11 - Execution boundary
 
 Every milestone before this one asked what holds *inside* CTRLRun. v0.7 asks whether it holds at
 the edges the kernel does not control. The kernel does not decide whether the remote acted, an


### PR DESCRIPTION
The tag is pushed and PyPI has `ctrlrun 0.7.0` (wheel and sdist, uploaded 2026-09-11T23:46Z), so the changelog heading carries its date.

This is the half of the release that belongs to the tag rather than to the release PR: `render_readiness` deliberately reads the newest *dated* heading, so that the site can never claim a release PyPI does not have. Until now it correctly said "0.7.0 is in development; PyPI has 0.6.1". With the date it reads 0.7.0, confirmed against the generator.

A matching docs PR regenerates the readiness block.