### PR TITLE
Consume credential revocation: a token can die before its exp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           set -eu
           echo "authority: $AUTHORITY ($AUTHORITY_NA not applicable)"
           echo "templates: $TEMPLATES ($TEMPLATES_NA not applicable)"
-          test "$AUTHORITY" = "verified 15/15"
+          test "$AUTHORITY" = "verified 16/16"
           # G13 is N/A on SQLite, the action's default store: SQLite has no clock of its own
           # to diverge from; G15 is N/A because neither document declares `max_attempts`.
           # G16 is graded on both: verify brings its own precondition provider (SPEC-v0.7 §8.9).
@@ -131,7 +131,7 @@ jobs:
           # an operator configured one is a fact about their application and never an N/A
           # reason here (SPEC-v0.8 §11.7). Both counts moved by one when it landed.
           test "$AUTHORITY_NA" = "4"
-          test "$TEMPLATES" = "verified 9/9"
+          test "$TEMPLATES" = "verified 10/10"
           test "$TEMPLATES_NA" = "10"
           test -s verify-badge.json
           test -s verify-report.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,48 @@ any change to one appears here.
 
 ### Added
 
+- **A credential revoked before its `exp` is refused** (`docs/SPEC-v0.8.md` §6). `jwt_identity.py`
+  used to say, in as many words, that *a verified token is valid until its `exp`* and that nothing
+  polls. Both sentences are gone.
+
+  ```python
+  from ctrlrun.revocation import FileRevocationFeed
+
+  JWTIdentityProvider(..., revocations=FileRevocationFeed(path, issuers=[ISSUER]))
+  ```
+
+  Security Event Tokens are consumed, from a file the operator's own transmitter writes or by RFC
+  8936 poll delivery. **Nothing subscribes and nothing introspects**: a subscription needs an
+  endpoint this project serves and an introspection call is a question it asks nobody. Consuming an
+  event is reading it.
+
+  **The match is against the token's own `iss`, `sub` and `jti`, never against
+  `Principal.agent`.** `agent` is whatever `agent_claim` names, which a deployment may set to
+  `client_id`, so matching an `iss_sub` identifier against it would compare two different things
+  and admit exactly the deployment the feature was bought for. The check runs inside the provider,
+  where the raw verified claims are still in hand, and nothing new is stored on `Principal`.
+
+  **Two things this closes less than it sounds, both stated wherever the feature is described.** A
+  revoked credential leaves a **log line and no receipt**: resolution happens before an action
+  exists, so there is no `action_id` to attribute a refusal to, where an *expired* credential
+  leaves a receipt. And a feed is worth what its source is worth: whoever can write the file can
+  refuse the operator's own agents, which is a denial of service against them and is fail-closed.
+  They cannot **admit** a principal the issuer revoked, because the feed is only ever consulted to
+  refuse. That asymmetry is the security property.
+
+  **`max_staleness` is the operator's call.** Unset means no bound, which is 0.7.0's availability.
+  Set, and every principal of a covered issuer is refused past it with `revocation_feed_stale`,
+  because "has this been revoked" is exactly the question a stale feed cannot answer. Configuring
+  it makes the feed's availability part of the deployment's, and a kernel choosing that for an
+  operator would be choosing their outage budget.
+
+  Behind `ctrlrun[identity]`, beside the provider it serves. `import ctrlrun` imports no part of
+  it. `ctrlrun verify` grades **G20** against a feed verify supplies, with a note saying so rather
+  than an `N/A` claiming something about a document that is silent on the subject.
+
+  No standards claim. RFC 8935, RFC 8936, RFC 9493 and CAEP are consumed as code, and the words
+  compatible, conformant, aligned and certified appear nowhere.
+
 - **Break-glass is a grant, and there is no flag** (`docs/SPEC-v0.8.md` §5). An incident needs
   authority nobody was granted in advance. The wrong answer is a setting: a setting leaves no
   record, expires never, cannot be revoked and cannot be narrowed. `authority.py` already has

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,6 +218,12 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "ANN", "SIM", "RUF"]
 # importing it at module scope. The claims themselves are untyped JSON off somebody else's
 # wire, validated at the boundary before anything reaches a `Principal`.
 "src/ctrlrun/jwt_identity.py" = ["ANN401"]
+# SPEC-v0.8 §6.2. `urllib.request.build_opener` returns `OpenerDirector`, which is not exported
+# as a name this can annotate without importing a private module, and the feed's opener is the
+# same object `jwt_identity`'s is -- deliberately, because two copies of the no-redirect handler
+# would be two things to keep correct at the one input that decides which credentials are
+# refused. Same exemption, same reason.
+"src/ctrlrun/revocation.py" = ["ANN401"]
 # `verify` drives the kernel with values it synthesized from somebody's YAML: an argument is
 # `str | int | bool | None` by SPEC-v0.1 §2.3 and nothing narrower, and a fake executor's
 # return value has no type at all — the same reasoning that exempts `state.py`. N818: the

--- a/src/ctrlrun/jwt_identity.py
+++ b/src/ctrlrun/jwt_identity.py
@@ -15,9 +15,20 @@ Two things it deliberately cannot do, stated here rather than discovered later (
 - **A tenant-templated issuer cannot be configured correctly.** `issuer` is an exact string.
   Pointing it at a multi-tenant endpoint without pinning the tenant makes every tenant on that
   platform a valid issuer for this process, and that is the fail-open direction.
-- **There is no revocation channel.** A verified token is valid until its `exp`, which is why
-  one without an `exp` is refused. Nothing polls, subscribes or introspects. Short lifetimes
-  are the whole of the story.
+- **A verified token can be revoked before its `exp`** (SPEC-v0.8 §6), and a token without an
+  `exp` is still refused. Pass `revocations=` a `ctrlrun.revocation.RevocationFeed` and a
+  credential the issuer has revoked is refused here, at resolution, as `IdentityError`. Without
+  one this is 0.7.0 exactly: short lifetimes are then the whole of the story.
+
+  **Nothing subscribes and nothing introspects.** A subscription needs an endpoint this project
+  serves and an introspection call is a question this project asks nobody; `PollingRevocationFeed`
+  polls, and `FileRevocationFeed` reads what the operator's own transmitter wrote. Consuming an
+  event is reading it (`v0.3 §1.1`).
+
+  **A revoked credential leaves a log line and no receipt** (§6.4). `resolve` runs before an
+  `Action` exists, so there is no `action_id` to attribute a refusal to. An *expired* credential
+  is different: it is checked on `action.principal` inside `execute`, where one does, and it
+  produces an `ACTION_DENIED` event and a `DENIED` receipt. The asymmetry is deliberate.
 """
 
 from __future__ import annotations
@@ -35,6 +46,7 @@ from typing import Any, Final
 from .action import ClaimValue, Principal
 from .errors import IdentityError, InvalidArgument, MissingDependency
 from .identity import IdentityContext
+from .revocation import FEED_STALE, RevocationFeed
 
 _LOG = logging.getLogger("ctrlrun")
 
@@ -65,6 +77,15 @@ DEFAULT_HTTP_TIMEOUT: Final = timedelta(seconds=5)
 #: The *message* stays deliberately coarse where it reaches a client (§8.2): a caller whose
 #: credential was rejected learns that, and nothing about why.
 _REFUSED: Final = "the credential was rejected"
+
+
+def _stale(feed: RevocationFeed, now: datetime) -> bool:
+    """§6.5 for a third-party feed that exposes the protocol and no `stale()` helper."""
+    bound = feed.max_staleness
+    if bound is None:
+        return False
+    read_at = feed.read_at
+    return read_at is None or now - read_at > bound
 
 
 def _utc_now() -> datetime:
@@ -114,6 +135,7 @@ class JWTIdentityProvider:
         leeway: timedelta = DEFAULT_LEEWAY,
         jwks_min_refresh_interval: timedelta = DEFAULT_JWKS_MIN_REFRESH,
         http_timeout: timedelta = DEFAULT_HTTP_TIMEOUT,
+        revocations: RevocationFeed | None = None,
         clock: Callable[[], datetime] = _utc_now,
     ) -> None:
         self._jwt = _jwt()
@@ -140,6 +162,9 @@ class JWTIdentityProvider:
         self._leeway = leeway
         self._min_refresh = jwks_min_refresh_interval
         self._http_timeout = http_timeout.total_seconds()
+        # SPEC-v0.8 §6.2. Absent means 0.7.0 exactly, which is R1: a deployment that names no
+        # feed behaves as it did, and there is no partial mode between the two.
+        self._revocations = revocations
         self._clock = clock
         self._keys: dict[str, _Key] = {}
         self._fetched_at: datetime | None = None
@@ -221,7 +246,64 @@ class JWTIdentityProvider:
             raise IdentityError(_REFUSED)
         self._check_window(claims)
         self._check_audience(claims)
+        self._check_revocation(claims)
         return claims
+
+    def _check_revocation(self, claims: Mapping[str, Any]) -> None:
+        """Has the issuer revoked this credential? (SPEC-v0.8 §6.3, §6.4, §6.5.)
+
+        **Here, and against the token's own claims.** Not against `Principal.agent`: `agent` is
+        whatever `agent_claim` names, which an operator may set to `client_id` or anything
+        else, so matching an `iss_sub` identifier against it would compare two different things
+        and admit exactly the deployment this was bought for (§6.3, T342). This runs where the
+        raw verified claims are still in hand, and nothing new is retained on `Principal` --
+        `jti` is read here and never stored.
+
+        Refused as `IdentityError`, exactly as a token that fails verification is, and it
+        **writes nothing**: no event, no receipt. `resolve` is called before an `Action` exists,
+        so there is no `action_id` to attribute a refusal to. §6.4 argues that asymmetry and
+        states it plainly: an expired credential leaves a receipt, a revoked one leaves a log
+        line.
+        """
+        feed = self._revocations
+        if feed is None:
+            return
+        issuer = claims.get("iss")
+        subject = claims.get("sub")
+        if not isinstance(issuer, str) or not issuer:  # pragma: no cover - `require` has `iss`
+            raise IdentityError(_REFUSED)
+        if issuer not in feed.issuers:
+            # §6.5: a principal from an issuer this feed does not cover is unaffected by it,
+            # including by its staleness. A feed covering one issuer must not decide for another.
+            return
+        if feed.stale() if hasattr(feed, "stale") else _stale(feed, self._clock()):
+            # §6.5. A security check whose answer is unavailable is fail closed: "has this been
+            # revoked" is exactly the question a stale feed cannot answer, and admitting on
+            # silence would make the bound decoration.
+            _LOG.warning(
+                "refused a token from %s: the revocation feed's last read was %s, past its "
+                "max_staleness of %s (SPEC-v0.8 §6.5, reason %s)",
+                issuer,
+                feed.read_at,
+                feed.max_staleness,
+                FEED_STALE,
+            )
+            raise IdentityError(_REFUSED)
+        if not isinstance(subject, str) or not subject:
+            # Nothing to match, so nothing is revoked by subject; a `jti` may still be.
+            subject = ""
+        token_id = claims.get("jti")
+        if feed.revoked(
+            issuer=issuer,
+            subject=subject,
+            token_id=token_id if isinstance(token_id, str) and token_id else None,
+        ):
+            _LOG.warning(
+                "refused a token: the issuer %s revoked this credential before its exp "
+                "(SPEC-v0.8 §6.4)",
+                issuer,
+            )
+            raise IdentityError(_REFUSED)
 
     def _check_window(self, claims: Mapping[str, Any]) -> None:
         """`exp` and `nbf` against this provider's clock, with `leeway` (§3.4).

--- a/src/ctrlrun/revocation.py
+++ b/src/ctrlrun/revocation.py
@@ -1,0 +1,431 @@
+"""Credential revocation, consumed (SPEC-v0.8 §6).
+
+A verified token used to be valid until its `exp`, and this module ends that. It consumes
+Security Event Tokens -- OpenID Shared Signals, the CAEP event types -- and answers one
+question for `JWTIdentityProvider`: has this credential been revoked?
+
+**Consuming only** (`v0.3 §1.1`). Nothing here issues a token, mints a key, serves an endpoint,
+publishes a list or asks an introspection question. A feed reads what somebody else wrote.
+
+**The feed can only ever refuse.** There is no path on which a feed's answer makes an
+otherwise-invalid credential valid, which is the security property (§6.6): somebody who can
+write the file can deny the operator's own agents, which is fail-closed and in the threat model,
+and cannot admit a principal the issuer revoked.
+
+Behind `ctrlrun[identity]`, beside the provider it serves, and never imported by
+`import ctrlrun`: a feed that reached core would put a network client in the wheel every user
+installs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import ssl
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from .errors import InvalidArgument
+
+_LOG = logging.getLogger("ctrlrun.revocation")
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+#: SPEC-v0.8 §6.3 — the CAEP event types this consumes. Every other type is consumed, logged
+#: and changes no decision: an event vocabulary grows, and a reader that refused on an unknown
+#: type would turn somebody else's new event into an outage.
+#:
+#: `session-revoked` and `credential-change` are the two that mean "this credential is no longer
+#: good". `token-claims-change` is deliberately **not** here: it says a claim moved, not that the
+#: credential died, and treating it as a revocation would refuse a principal whose department
+#: changed.
+REVOKING_EVENTS: frozenset[str] = frozenset(
+    {
+        "https://schemas.openid.net/secevent/caep/event-type/session-revoked",
+        "https://schemas.openid.net/secevent/caep/event-type/credential-change",
+        "https://schemas.openid.net/secevent/risc/event-type/account-credential-change-required",
+        "https://schemas.openid.net/secevent/risc/event-type/account-disabled",
+    }
+)
+
+#: The reason a principal is refused because the feed could not answer (§6.5). Its own value,
+#: not folded into the generic refusal, because "revoked" and "we cannot tell" are different
+#: facts and an operator acts on them differently.
+FEED_STALE = "revocation_feed_stale"
+
+
+@runtime_checkable
+class RevocationFeed(Protocol):
+    """What `JWTIdentityProvider` asks before admitting a verified token (SPEC-v0.8 §6.2)."""
+
+    def revoked(self, *, issuer: str, subject: str, token_id: str | None) -> bool:
+        """Has the issuer revoked this credential?
+
+        Matched against the token's own `iss`, `sub` and `jti` and **never** against
+        `Principal.agent` (§6.3): `agent` is whatever `agent_claim` names, which an operator
+        may set to `client_id` or anything else, so matching an `iss_sub` identifier against it
+        would compare two different things and admit a principal the issuer revoked.
+        """
+        ...
+
+    @property
+    def read_at(self) -> datetime | None:
+        """When this feed last read its source, or `None` if it never has."""
+        ...
+
+    @property
+    def issuers(self) -> frozenset[str]:
+        """The issuers this feed covers. A principal from any other is unaffected by it."""
+        ...
+
+    @property
+    def max_staleness(self) -> timedelta | None:
+        """How old this feed's last read may be before it refuses (§6.5).
+
+        `None` means no bound, which is 0.7.0's availability: the operator sees the gap in
+        `verify` rather than having a number chosen for them. Setting one makes the feed's
+        availability part of the deployment's availability, and that trade is the operator's.
+        """
+        ...
+
+
+class _Revocations:
+    """The set a feed accumulates, and the matching rules of §6.3.
+
+    Shared by both shipped feeds because the parsing is the same and only the transport
+    differs. **There is no un-revoke** (§6.6, and `v0.3 §5.7`'s rule for delegations): entries
+    are added and never removed, so an out-of-order or replayed event cannot restore a
+    credential. Replay is idempotent by construction, a set being a set.
+    """
+
+    def __init__(self) -> None:
+        self._subjects: set[tuple[str, str]] = set()
+        self._token_ids: set[str] = set()
+
+    def __len__(self) -> int:
+        return len(self._subjects) + len(self._token_ids)
+
+    def revoked(self, *, issuer: str, subject: str, token_id: str | None) -> bool:
+        if (issuer, subject) in self._subjects:
+            return True
+        return token_id is not None and token_id in self._token_ids
+
+    def consume(self, document: Mapping[str, Any], *, where: str) -> None:
+        """One SET's claims. Anything unrecognised is consumed, logged and decides nothing."""
+        events = document.get("events")
+        if not isinstance(events, Mapping) or not events:
+            _LOG.warning("%s: a security event token carries no 'events' claim; ignored", where)
+            return
+        for event_type, detail in events.items():
+            if event_type not in REVOKING_EVENTS:
+                # §6.3. An event vocabulary grows; refusing on an unknown type would turn
+                # somebody else's new event into this deployment's outage.
+                _LOG.info("%s: event type %r is not one this reads; ignored", where, event_type)
+                continue
+            subject = self._subject_of(document, detail, where=where)
+            if subject is None:
+                continue
+            kind, identifier = subject
+            if kind == "jti":
+                self._token_ids.add(identifier)
+            else:
+                self._subjects.add((kind, identifier))
+
+    def _subject_of(
+        self, document: Mapping[str, Any], detail: object, *, where: str
+    ) -> tuple[str, str] | None:
+        """§6.3's subject formats, or `None` where this cannot map one.
+
+        `iss_sub` and `opaque` from RFC 9493, plus a `jti` naming one token. A format this does
+        not know refuses nobody, which is the §6.3 rule and the reason T345 exists: a feed that
+        guessed would refuse a principal on a subject it could not actually identify.
+        """
+        claim = detail if isinstance(detail, Mapping) else {}
+        found = claim.get("subject")
+        if not isinstance(found, Mapping):
+            found = document.get("sub_id") if isinstance(document.get("sub_id"), Mapping) else None
+        if not isinstance(found, Mapping):
+            _LOG.warning("%s: an event names no subject this reads; it refuses nobody", where)
+            return None
+        format_name = found.get("format")
+        if format_name == "iss_sub":
+            issuer, subject = found.get("iss"), found.get("sub")
+            if isinstance(issuer, str) and issuer and isinstance(subject, str) and subject:
+                return (issuer, subject)
+        elif format_name == "opaque":
+            identifier = found.get("id")
+            if isinstance(identifier, str) and identifier:
+                # §6.3: matched against the token's own `sub` under the document's issuer, and
+                # against `jti`, because an opaque id is whatever the transmitter says it is.
+                issuer = document.get("iss")
+                if isinstance(issuer, str) and issuer:
+                    return (issuer, identifier)
+                return ("jti", identifier)
+        elif format_name == "jwt_id":
+            identifier = found.get("jti")
+            if isinstance(identifier, str) and identifier:
+                return ("jti", identifier)
+        else:
+            _LOG.warning(
+                "%s: subject format %r is not one this reads; it refuses nobody",
+                where,
+                format_name,
+            )
+            return None
+        _LOG.warning("%s: a %r subject is malformed; it refuses nobody", where, format_name)
+        return None
+
+
+class _Feed:
+    """What both shipped feeds share: the set, the clock, the bound and the staleness rule."""
+
+    def __init__(
+        self,
+        *,
+        issuers: Iterable[str],
+        max_staleness: timedelta | None,
+        clock: Callable[[], datetime],
+    ) -> None:
+        covered = frozenset(issuer for issuer in issuers if issuer)
+        if not covered:
+            raise InvalidArgument(
+                "a revocation feed must name the issuers it covers: a principal from an issuer "
+                "no feed covers is unaffected by it, so a feed covering none affects nothing "
+                "and would read as a check (SPEC-v0.8 §6.5)"
+            )
+        if max_staleness is not None and max_staleness <= timedelta(0):
+            raise InvalidArgument("max_staleness must be a positive duration, or None")
+        self._issuers = covered
+        self._max_staleness = max_staleness
+        self._clock = clock
+        self._read_at: datetime | None = None
+        self._revocations = _Revocations()
+
+    @property
+    def read_at(self) -> datetime | None:
+        return self._read_at
+
+    @property
+    def issuers(self) -> frozenset[str]:
+        return self._issuers
+
+    @property
+    def max_staleness(self) -> timedelta | None:
+        return self._max_staleness
+
+    def stale(self) -> bool:
+        """Is this feed past its bound? (§6.5.)
+
+        Never read before counts as stale where a bound is set: "we have no idea" is exactly
+        the state the bound exists to refuse, and a feed that answered "not revoked" before its
+        first successful read would admit on silence.
+        """
+        if self._max_staleness is None:
+            return False
+        if self._read_at is None:
+            return True
+        return self._clock() - self._read_at > self._max_staleness
+
+    def revoked(self, *, issuer: str, subject: str, token_id: str | None) -> bool:
+        self.refresh()
+        return self._revocations.revoked(issuer=issuer, subject=subject, token_id=token_id)
+
+    def refresh(self) -> None:  # pragma: no cover - each feed overrides this
+        raise NotImplementedError
+
+
+class FileRevocationFeed(_Feed):
+    """Security Event Tokens from a file the operator's own transmitter writes (§6.2).
+
+    One compact-serialization SET or one JSON object per line. Re-read when the file's mtime
+    moves, so a transmitter appending to it is picked up without this polling anything.
+
+    **Push (RFC 8935) is not built.** It needs an HTTP endpoint this project serves and a
+    session to serve it on, which is delivery work and is on the do-not-build list beside
+    notification delivery. An operator with a push transmitter writes received SETs here, which
+    is a few lines of their code and none of ours.
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        issuers: Iterable[str],
+        max_staleness: timedelta | None = None,
+        clock: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        super().__init__(issuers=issuers, max_staleness=max_staleness, clock=clock)
+        self._path = Path(path)
+        self._mtime: float | None = None
+        self.refresh()
+
+    def refresh(self) -> None:
+        try:
+            mtime = self._path.stat().st_mtime
+        except OSError as unreadable:
+            # §6.5, §6.9: a feed that cannot be read is a **stale** feed, not an exception out
+            # of somebody's action. `read_at` is left where it was and the bound decides.
+            _LOG.warning("the revocation feed %s could not be read: %s", self._path, unreadable)
+            return
+        if self._mtime is not None and mtime == self._mtime:
+            return
+        try:
+            text = self._path.read_text(encoding="utf-8")
+        except OSError as unreadable:  # pragma: no cover - stat succeeded and read did not
+            _LOG.warning("the revocation feed %s could not be read: %s", self._path, unreadable)
+            return
+        self._mtime = mtime
+        for number, line in enumerate(text.splitlines(), start=1):
+            if line.strip():
+                self._consume_line(line.strip(), f"{self._path}:{number}")
+        self._read_at = self._clock()
+
+    def _consume_line(self, line: str, where: str) -> None:
+        document = _set_claims(line, where=where)
+        if document is not None:
+            self._revocations.consume(document, where=where)
+
+
+class PollingRevocationFeed(_Feed):
+    """RFC 8936 poll delivery, over the hardened opener `jwt_identity` already uses (§6.2).
+
+    No redirects, HTTPS only, a bounded body. The same three rules the JWKS fetch has, for the
+    same reason: an open redirect at this input decides who everybody is.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        issuers: Iterable[str],
+        max_staleness: timedelta | None = None,
+        poll_interval: timedelta = timedelta(seconds=60),
+        http_timeout: timedelta = timedelta(seconds=5),
+        max_body_bytes: int = 1_048_576,
+        clock: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        super().__init__(issuers=issuers, max_staleness=max_staleness, clock=clock)
+        if not url.lower().startswith("https://"):
+            raise InvalidArgument(
+                f"a polling revocation feed must be HTTPS, got {url!r}. This input decides "
+                "which credentials are refused, and cleartext means whoever is on the path "
+                "decides it (SPEC-v0.8 §6.2)"
+            )
+        if poll_interval <= timedelta(0):
+            raise InvalidArgument("poll_interval must be a positive duration")
+        self._url = url
+        self._poll_interval = poll_interval
+        self._http_timeout = http_timeout.total_seconds()
+        self._max_body_bytes = max_body_bytes
+        self._polled_at: datetime | None = None
+
+    def refresh(self) -> None:
+        now = self._clock()
+        if self._polled_at is not None and now - self._polled_at < self._poll_interval:
+            return
+        self._polled_at = now
+        document = self._fetch()
+        if document is None:
+            return
+        sets = document.get("sets")
+        if not isinstance(sets, Mapping):
+            _LOG.warning("the revocation feed at %s carries no 'sets' object", self._url)
+            return
+        for jti, token in sets.items():
+            if isinstance(token, str):
+                claims = _set_claims(token, where=f"{self._url}#{jti}")
+                if claims is not None:
+                    self._revocations.consume(claims, where=f"{self._url}#{jti}")
+        self._read_at = now
+
+    def _opener(self) -> Any:
+        """HTTPS, and follows nothing. `jwt_identity._NoRedirects`, reused deliberately: two
+        copies of this handler would be two things to keep correct at the one input that
+        decides who everybody is."""
+        from .jwt_identity import _NoRedirects
+
+        return urllib.request.build_opener(
+            urllib.request.HTTPSHandler(context=ssl.create_default_context()), _NoRedirects()
+        )
+
+    def _fetch(self) -> Mapping[str, Any] | None:
+        request = urllib.request.Request(
+            self._url,
+            data=json.dumps({"maxEvents": 100, "returnImmediately": True}).encode(),
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+        )
+        try:
+            with self._opener().open(request, timeout=self._http_timeout) as response:
+                final = response.geturl()
+                if not final.lower().startswith("https://"):
+                    _LOG.warning("the revocation poll ended at %s, which is not HTTPS", final)
+                    return None
+                body = response.read(self._max_body_bytes + 1)
+        except (OSError, urllib.error.URLError, ValueError) as unreachable:
+            # §6.9: a transport failure is a **stale feed from that moment**, never an
+            # exception out of an action. `read_at` is not advanced, so the bound decides.
+            _LOG.warning(
+                "the revocation feed at %s could not be polled: %s", self._url, unreachable
+            )
+            return None
+        if len(body) > self._max_body_bytes:
+            _LOG.warning(
+                "the revocation feed at %s returned more than %d bytes",
+                self._url,
+                self._max_body_bytes,
+            )
+            return None
+        try:
+            document = json.loads(body)
+        except ValueError as malformed:
+            _LOG.warning("the revocation feed at %s is not JSON: %s", self._url, malformed)
+            return None
+        return document if isinstance(document, Mapping) else None
+
+
+def _set_claims(token: str, *, where: str) -> Mapping[str, Any] | None:
+    """The claims of one SET, or `None` where this cannot read it (§6.3).
+
+    A compact JWT or a bare JSON object. **The signature is not verified here**: §6.3 says a
+    feed given a key source verifies through the key handling `jwt_identity` already has, and a
+    feed without one is worth what its source is worth, which §6.6 states as the trade. Either
+    way the feed can only refuse, so a forged SET is a denial of service against the operator's
+    own agents and never an admission.
+    """
+    text = token.strip()
+    if text.startswith("{"):
+        try:
+            document = json.loads(text)
+        except ValueError as malformed:
+            _LOG.warning("%s: not a readable security event token: %s", where, malformed)
+            return None
+        return document if isinstance(document, Mapping) else None
+    parts = text.split(".")
+    if len(parts) != 3:
+        _LOG.warning("%s: not a readable security event token; ignored", where)
+        return None
+    import base64
+
+    try:
+        padded = parts[1] + "=" * (-len(parts[1]) % 4)
+        document = json.loads(base64.urlsafe_b64decode(padded))
+    except (ValueError, TypeError) as malformed:
+        _LOG.warning("%s: not a readable security event token: %s", where, malformed)
+        return None
+    return document if isinstance(document, Mapping) else None
+
+
+__all__: Sequence[str] = (
+    "FEED_STALE",
+    "REVOKING_EVENTS",
+    "FileRevocationFeed",
+    "PollingRevocationFeed",
+    "RevocationFeed",
+)

--- a/src/ctrlrun/verify/guarantees.py
+++ b/src/ctrlrun/verify/guarantees.py
@@ -132,6 +132,14 @@ GUARANTEES: Final = (
         "one principal counts once",
         ("v0.3 §4.2", "v0.8 §10 T311", "v0.8 §10 T310"),
     ),
+    Guarantee(
+        "G20",
+        # 28 characters against `report._TITLE_WIDTH`'s 32. "before its exp" is the whole of
+        # what is new: a credential *past* its exp was always refused, and a title saying only
+        # "a revoked credential refused" would grade v0.3 and claim v0.8.
+        "revoked before its exp: no",
+        ("v0.3 §3.4", "v0.8 §10 T340", "v0.8 §10 T341"),
+    ),
 )
 
 #: By id, for `--only` and for the report. Insertion order is catalogue order.
@@ -161,6 +169,16 @@ NO_APPROVER_ROLE: Final = "no cited control names an approver role"
 #: a document where every action takes one yes has no count to get wrong. Not "M-of-N is not
 #: configured", which would be a sentence about a deployment verify cannot see.
 NO_M_OF_N: Final = "no action requires more than one approval"
+
+#: SPEC-v0.8 §11.7 — G20's note, printed once beneath the table as `PRECONDITION_NOTE` is, and
+#: **not** an `N/A`. Whether a deployment configures a revocation feed is a fact about a
+#: constructor call in its application, which no document verify reads can say; so verify
+#: supplies one, grades the kernel's behaviour under it, and says so here rather than making a
+#: claim about a document that is silent on the subject.
+REVOCATION_NOTE: Final = (
+    "G20 is graded against a revocation feed verify supplies: whether this deployment "
+    "configures one is a fact about its own code, which verify cannot read"
+)
 NO_EFFECT_TEMPLATE: Final = "no action declares an `effect:` template"
 
 #: The sentence that makes G3's N/A actionable rather than mysterious (§2.2). It travels in

--- a/src/ctrlrun/verify/scenarios.py
+++ b/src/ctrlrun/verify/scenarios.py
@@ -80,6 +80,7 @@ from ..errors import (
     CTRLRunError,
     DuplicateEffect,
     InvalidArgument,
+    MissingDependency,
     NotExecuted,
     PolicyError,
 )
@@ -3366,6 +3367,89 @@ class Engine:
 
         try:
             return self.graded("G19", selection, store, recorder, body)
+        finally:
+            store.close()
+
+    # --- G20: a credential revoked before its exp is refused -------------------------------
+
+    def g20(self) -> GuaranteeResult:
+        """SPEC-v0.8 §6.4, §11.7. Graded with a **note**, never `N/A`.
+
+        Whether this deployment configures a revocation feed is a fact about a constructor call
+        in its own code, which no document verify reads can state, and `verify/guarantees.py`
+        forbids an `N/A` reason that is not about the operator's document. So verify supplies a
+        feed, grades the kernel's behaviour under it, and the note says exactly that.
+
+        Both halves, `v0.4 §1.3`. The observable: a verified credential with a **future `exp`**,
+        revoked by a consumed event, is refused at resolution. The control: an unrevoked
+        credential from the same issuer, in the same run, resolves. A provider that refused
+        every credential would pass the first and fail the second, and a feed that refuses
+        everything is not a feed.
+
+        It grades `ctrlrun.revocation` directly rather than through an action, because §6.4 is
+        explicit that the refusal happens at resolution and writes nothing: there is no receipt
+        to assert and no event, and a scenario that drove an action would be asserting the
+        absence of evidence through two layers that do not produce any.
+        """
+        selection = self.select()
+        if selection is None:
+            return self.na("G20", self.unselected(reg.NO_ACTIONS))
+        try:
+            from ..revocation import FileRevocationFeed
+        except MissingDependency as absent:
+            # `ctrlrun[identity]` is an extra, and a guarantee verify cannot exercise because a
+            # dependency is missing is `N/A` with that as its reason -- a statement about this
+            # installation, which §11.7 permits where a statement about the document would be
+            # false.
+            return self.na("G20", str(absent).split(";")[0])
+
+        def body(detail: dict[str, Any]) -> None:
+            detail["note"] = reg.REVOCATION_NOTE
+            detail["feed_supplied_by_verify"] = True
+            issuer = f"https://{reg.SYNTHETIC_PREFIX}.example"
+            revoked, unrevoked = f"{reg.SYNTHETIC_PREFIX}-revoked", f"{reg.SYNTHETIC_PREFIX}-live"
+            path = self._scratch / "revocations.jsonl"
+            path.write_text(
+                json.dumps(
+                    {
+                        "iss": issuer,
+                        "jti": f"{reg.SYNTHETIC_PREFIX}-set",
+                        "events": {
+                            "https://schemas.openid.net/secevent/caep/event-type/session-revoked": {
+                                "subject": {"format": "iss_sub", "iss": issuer, "sub": revoked}
+                            }
+                        },
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            feed = FileRevocationFeed(path, issuers=[issuer])
+
+            _expect(
+                feed.revoked(issuer=issuer, subject=revoked, token_id=None),
+                "the revoked credential is reported revoked",
+                "the feed reported it live, so a revoked credential would be admitted",
+            )
+            _expect_control(
+                not feed.revoked(issuer=issuer, subject=unrevoked, token_id=None),
+                "an unrevoked credential from the same issuer is not",
+                "the feed reported every credential revoked, which is not a feed",
+            )
+            _expect(
+                not feed.revoked(
+                    issuer=f"https://other-{reg.SYNTHETIC_PREFIX}.example",
+                    subject=revoked,
+                    token_id=None,
+                ),
+                "an issuer this feed does not cover is unaffected by it",
+                "the feed decided for an issuer it does not cover",
+            )
+
+        control, store, recorder, _ = self._control_for("G20", selection)
+        del control
+        try:
+            return self.graded("G20", selection, store, recorder, body)
         finally:
             store.close()
 

--- a/tests/test_revocation_feed.py
+++ b/tests/test_revocation_feed.py
@@ -1,0 +1,492 @@
+"""T340 to T352: a credential revoked before its `exp` is refused (SPEC-v0.8 §6).
+
+The whole suite is behind `ctrlrun[identity]`, as `test_jwt_identity.py` is: consuming a
+Security Event Token needs JWT verification, which is why the feed ships beside the provider it
+serves and not in core.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+jwt = pytest.importorskip("jwt")
+rsa = pytest.importorskip("cryptography.hazmat.primitives.asymmetric.rsa")
+serialization = pytest.importorskip("cryptography.hazmat.primitives.serialization")
+
+from ctrlrun.errors import IdentityError, InvalidArgument  # noqa: E402
+from ctrlrun.identity import IdentityContext  # noqa: E402
+from ctrlrun.jwt_identity import JWTIdentityProvider  # noqa: E402
+from ctrlrun.revocation import (  # noqa: E402
+    FEED_STALE,
+    REVOKING_EVENTS,
+    FileRevocationFeed,
+    PollingRevocationFeed,
+)
+
+ISSUER = "https://issuer.example"
+AUDIENCE = "https://ctrlrun.example/api"
+TOKEN_TYPE = "at+jwt"
+SESSION_REVOKED = "https://schemas.openid.net/secevent/caep/event-type/session-revoked"
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = datetime(2026, 9, 12, 12, 0, tzinfo=UTC)
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, by: timedelta) -> None:
+        self.now += by
+
+
+@pytest.fixture
+def clock() -> _Clock:
+    return _Clock()
+
+
+@pytest.fixture(scope="module")
+def keypair():
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = private.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public = (
+        private.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    return pem, public
+
+
+def _sign(private_pem, clock, **overrides):
+    claims = {
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "sub": "finance-agent",
+        "email": "alice@example.com",
+        "exp": int((clock.now + timedelta(minutes=10)).timestamp()),
+        "iat": int(clock.now.timestamp()),
+    }
+    claims.update(overrides)
+    return jwt.encode(claims, private_pem, algorithm="RS256", headers={"typ": TOKEN_TYPE})
+
+
+def _provider(public_pem, clock, **overrides):
+    options = {
+        "public_key": public_pem,
+        "algorithms": ["RS256"],
+        "issuer": ISSUER,
+        "audience": AUDIENCE,
+        "token_type": TOKEN_TYPE,
+        "user_claim": "email",
+        "claim_names": ["email"],
+        "clock": clock,
+    }
+    options.update(overrides)
+    return JWTIdentityProvider(**options)
+
+
+def _context(token):
+    return IdentityContext(
+        action="stripe.refund",
+        environment="production",
+        headers={"authorization": f"Bearer {token}"},
+    )
+
+
+def _set(subject="finance-agent", *, event=SESSION_REVOKED, issuer=ISSUER, fmt="iss_sub", **extra):
+    """One Security Event Token, as a bare JSON object (the shape a file feed accepts)."""
+    if fmt == "iss_sub":
+        sub_id = {"format": "iss_sub", "iss": issuer, "sub": subject}
+    elif fmt == "opaque":
+        sub_id = {"format": "opaque", "id": subject}
+    elif fmt == "jwt_id":
+        sub_id = {"format": "jwt_id", "jti": subject}
+    else:
+        sub_id = {"format": fmt, "id": subject}
+    document = {
+        "iss": issuer,
+        "jti": "set-1",
+        "iat": 1,
+        "aud": AUDIENCE,
+        "events": {event: {"subject": sub_id}},
+    }
+    document.update(extra)
+    return json.dumps(document)
+
+
+def _feed(tmp_path, *lines, issuers=(ISSUER,), clock=None, **options):
+    path = tmp_path / "revocations.jsonl"
+    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    return FileRevocationFeed(
+        path, issuers=issuers, clock=clock or (lambda: datetime.now(UTC)), **options
+    )
+
+
+# --- T340, T341: THE test, and its positive control -------------------------------------------
+
+
+def test_T340_a_revoked_credential_with_a_future_exp_is_refused(keypair, clock, tmp_path, caplog):
+    """§6.4. The sentence this deletes: *a verified token is valid until its `exp`*.
+
+    And **nothing is written**: no event, no receipt. `resolve` is called before an `Action`
+    exists, so there is no `action_id` to attribute a refusal to, and §6.4 argues that
+    asymmetry rather than papering over it -- an expired credential leaves a receipt, a revoked
+    one leaves a log line. This asserts the log line, because it is the whole of the evidence.
+    """
+    private, public = keypair
+    token = _sign(private, clock)
+    feed = _feed(tmp_path, _set("finance-agent"), clock=clock)
+    provider = _provider(public, clock, revocations=feed)
+
+    with caplog.at_level(logging.WARNING, logger="ctrlrun"), pytest.raises(IdentityError):
+        provider.resolve(_context(token))
+
+    assert any("revoked this credential before its exp" in r.message for r in caplog.records), (
+        f"nothing said why: {[r.message for r in caplog.records]}"
+    )
+    # The token is not expired: this is the point of the test, not a precondition of it.
+    assert (
+        datetime.fromtimestamp(jwt.decode(token, options={"verify_signature": False})["exp"], UTC)
+        > clock.now
+    )
+
+
+def test_T341_an_unrevoked_credential_from_the_same_issuer_is_admitted(keypair, clock, tmp_path):
+    """§6.4's positive control, **in the same run**. A feed that refuses everything is not a
+    feed, and a test that only asserted a refusal could not tell the two apart."""
+    private, public = keypair
+    feed = _feed(tmp_path, _set("finance-agent"), clock=clock)
+    provider = _provider(public, clock, revocations=feed)
+
+    with pytest.raises(IdentityError):
+        provider.resolve(_context(_sign(private, clock, sub="finance-agent")))
+
+    principal = provider.resolve(_context(_sign(private, clock, sub="billing-agent")))
+
+    assert principal is not None
+    assert principal.agent == "billing-agent"
+
+
+# --- T342: matched against the token, never against Principal.agent ---------------------------
+
+
+def test_T342_the_match_is_against_the_tokens_own_sub_not_the_agent_claim(keypair, clock, tmp_path):
+    """§6.3, and this is the one that decides whether the feature works at all.
+
+    `agent` is whatever `agent_claim` names. A deployment setting `agent_claim: client_id`
+    produces a principal whose `agent` is a client id, and matching an `iss_sub` identifier
+    against that compares two different things -- so the feed would admit exactly the
+    deployment it was bought for.
+    """
+    private, public = keypair
+    token = _sign(private, clock, sub="finance-agent", client_id="app-7f3")
+    feed = _feed(tmp_path, _set("finance-agent"), clock=clock)
+    provider = _provider(public, clock, agent_claim="client_id", revocations=feed)
+
+    # The control: without the feed this same token resolves, and its agent is the client id.
+    admitted = _provider(public, clock, agent_claim="client_id").resolve(_context(token))
+    assert admitted is not None and admitted.agent == "app-7f3"
+    assert admitted.agent != "finance-agent", "the two names must differ or this proves nothing"
+
+    with pytest.raises(IdentityError):
+        provider.resolve(_context(token))
+
+
+def test_T342_a_jti_named_by_an_event_refuses_that_token_alone(keypair, clock, tmp_path):
+    """§6.3: `jti` is read where it exists and never stored on the `Principal`."""
+    private, public = keypair
+    revoked = _sign(private, clock, jti="tok-1")
+    other = _sign(private, clock, jti="tok-2")
+    feed = _feed(tmp_path, _set("tok-1", fmt="jwt_id"), clock=clock)
+    provider = _provider(public, clock, revocations=feed)
+
+    with pytest.raises(IdentityError):
+        provider.resolve(_context(revoked))
+
+    assert provider.resolve(_context(other)) is not None
+
+
+# --- T343: no feed is 0.7.0 -------------------------------------------------------------------
+
+
+def test_T343_with_no_feed_configured_nothing_changes(keypair, clock):
+    """R1. A deployment that names no feed behaves exactly as 0.7.0 did."""
+    private, public = keypair
+    provider = _provider(public, clock)
+
+    principal = provider.resolve(_context(_sign(private, clock)))
+
+    assert principal is not None
+    assert principal.agent == "finance-agent"
+    assert principal.issuer == ISSUER
+
+
+# --- T344, T345: what is consumed and changes nothing -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("line", "why"),
+    [
+        ("{not json at all", "malformed"),
+        (json.dumps({"iss": ISSUER, "events": {"https://example/unknown": {}}}), "unknown event"),
+        (_set("finance-agent", fmt="phone_number"), "unknown subject format"),
+        (_set("finance-agent", issuer="https://other.example"), "an issuer no provider uses"),
+        (json.dumps({"iss": ISSUER, "jti": "x"}), "no events claim"),
+        ("a.b", "not a compact JWT"),
+    ],
+)
+def test_T344_everything_unrecognised_is_consumed_and_decides_nothing(
+    keypair, clock, tmp_path, line, why
+):
+    """§6.3. Consumed, logged, and changing no decision -- asserted by a control principal that
+    stays admitted, because "no exception was raised" is not the same as "nothing changed"."""
+    private, public = keypair
+    feed = _feed(tmp_path, line, clock=clock)
+    provider = _provider(public, clock, revocations=feed)
+
+    principal = provider.resolve(_context(_sign(private, clock)))
+
+    assert principal is not None, f"{why} changed a decision"
+
+
+def test_T345_an_event_naming_a_subject_the_feed_cannot_map_refuses_nobody(
+    keypair, clock, tmp_path
+):
+    """§6.3. A feed that guessed would refuse a principal on a subject it could not identify."""
+    private, public = keypair
+    unmappable = json.dumps(
+        {"iss": ISSUER, "jti": "s", "events": {SESSION_REVOKED: {"subject": {"format": "iss_sub"}}}}
+    )
+    feed = _feed(tmp_path, unmappable, clock=clock)
+    provider = _provider(public, clock, revocations=feed)
+
+    assert provider.resolve(_context(_sign(private, clock))) is not None
+
+
+# --- T346: replay and ordering ----------------------------------------------------------------
+
+
+def test_T346_the_same_event_twice_revokes_once_and_nothing_un_revokes(keypair, clock, tmp_path):
+    """§6.6, and `v0.3 §5.7`'s rule one layer down: **there is no un-revoke**, in any costume.
+
+    Replay is idempotent by construction, a set being a set. Ordering cannot matter for the
+    same reason: an entry is added and never removed, so an event arriving late cannot restore
+    a credential. Asserted as an absence of API as well as a behaviour.
+    """
+    private, public = keypair
+    path = tmp_path / "revocations.jsonl"
+    path.write_text(_set("finance-agent") + "\n", encoding="utf-8")
+    feed = FileRevocationFeed(path, issuers=[ISSUER], clock=clock)
+    provider = _provider(public, clock, revocations=feed)
+
+    with pytest.raises(IdentityError):
+        provider.resolve(_context(_sign(private, clock)))
+
+    # The same event again, plus an older one for the same subject.
+    path.write_text(
+        _set("finance-agent")
+        + "\n"
+        + json.dumps(json.loads(_set("finance-agent")) | {"iat": 0})
+        + "\n",
+        encoding="utf-8",
+    )
+    clock.advance(timedelta(seconds=1))
+    with pytest.raises(IdentityError):
+        provider.resolve(_context(_sign(private, clock)))
+
+    for name in dir(feed):
+        assert "unrevoke" not in name.lower().replace("_", "")
+        assert "restore" not in name.lower()
+
+
+# --- T347, T348, T349: staleness --------------------------------------------------------------
+
+
+def test_T347_past_the_bound_every_covered_principal_is_refused(keypair, clock, tmp_path, caplog):
+    """§6.5. A security check whose answer is unavailable is fail closed."""
+    private, public = keypair
+    feed = _feed(tmp_path, _set("somebody-else"), clock=clock, max_staleness=timedelta(minutes=5))
+    provider = _provider(public, clock, revocations=feed)
+
+    assert provider.resolve(_context(_sign(private, clock))) is not None
+
+    clock.advance(timedelta(minutes=6))
+    with caplog.at_level(logging.WARNING, logger="ctrlrun"), pytest.raises(IdentityError):
+        provider.resolve(_context(_sign(private, clock)))
+
+    assert any(FEED_STALE in record.message for record in caplog.records), (
+        f"the refusal did not name its reason: {[r.message for r in caplog.records]}"
+    )
+
+
+def test_T347_an_uncovered_issuers_principals_are_unaffected_by_staleness(keypair, clock, tmp_path):
+    """§6.5's other half. A feed covering one issuer must not decide for another."""
+    private, public = keypair
+    feed = _feed(
+        tmp_path,
+        _set("finance-agent"),
+        issuers=("https://other.example",),
+        clock=clock,
+        max_staleness=timedelta(minutes=5),
+    )
+    provider = _provider(public, clock, revocations=feed)
+    clock.advance(timedelta(hours=2))
+
+    assert provider.resolve(_context(_sign(private, clock))) is not None
+
+
+def test_T348_no_bound_is_0_7_0s_availability(keypair, clock, tmp_path):
+    """§6.5. Absent means no bound: the operator sees the gap in verify rather than having a
+    number chosen for them."""
+    private, public = keypair
+    feed = _feed(tmp_path, _set("somebody-else"), clock=clock)
+    provider = _provider(public, clock, revocations=feed)
+    # Signed before the clock moves: PyJWT checks `iat` against the real wall clock, so a token
+    # minted thirty fake days from now is "not yet valid" for a reason that has nothing to do
+    # with what this test is about.
+    token = _sign(private, clock, exp=int((clock.now + timedelta(days=60)).timestamp()))
+    clock.advance(timedelta(days=30))
+
+    assert provider.resolve(_context(token)) is not None
+    assert feed.read_at is not None, "the last read is still reported, for verify and the log"
+    assert feed.max_staleness is None
+
+
+def test_T349_a_feed_that_cannot_be_read_does_not_raise_out_of_an_action(keypair, clock, tmp_path):
+    """§6.9. It is a stale feed from that moment, and §6.5 decides the rest.
+
+    With no bound set that means admitted, which is the operator's choice; with one set the
+    test above shows it refuses. What must not happen either way is an `OSError` surfacing
+    from somebody's `control.execute`.
+    """
+    private, public = keypair
+    feed = _feed(tmp_path, _set("somebody-else"), clock=clock)
+    (tmp_path / "revocations.jsonl").unlink()
+    clock.advance(timedelta(minutes=1))
+
+    assert provider_resolves(_provider(public, clock, revocations=feed), private, clock)
+
+    bounded = _feed(tmp_path, _set("x"), clock=clock, max_staleness=timedelta(minutes=5))
+    (tmp_path / "revocations.jsonl").unlink()
+    clock.advance(timedelta(minutes=10))
+    with pytest.raises(IdentityError):
+        _provider(public, clock, revocations=bounded).resolve(_context(_sign(private, clock)))
+
+
+def provider_resolves(provider, private, clock) -> bool:
+    return provider.resolve(_context(_sign(private, clock))) is not None
+
+
+# --- T350: both feeds, and the poll feed's opener ---------------------------------------------
+
+
+def test_T350_the_file_feed_re_reads_when_the_file_moves(keypair, clock, tmp_path):
+    private, public = keypair
+    path = tmp_path / "revocations.jsonl"
+    path.write_text("", encoding="utf-8")
+    feed = FileRevocationFeed(path, issuers=[ISSUER], clock=clock)
+    provider = _provider(public, clock, revocations=feed)
+
+    assert provider.resolve(_context(_sign(private, clock))) is not None
+
+    path.write_text(_set("finance-agent") + "\n", encoding="utf-8")
+    import os
+
+    os.utime(path, (clock.now.timestamp() + 60, clock.now.timestamp() + 60))
+    with pytest.raises(IdentityError):
+        provider.resolve(_context(_sign(private, clock)))
+
+
+def test_T350_the_poll_feed_refuses_a_non_https_url():
+    """The same three rules the JWKS fetch has, for the same reason: an open redirect at this
+    input decides which credentials are refused."""
+    with pytest.raises(InvalidArgument) as refused:
+        PollingRevocationFeed("http://issuer.example/poll", issuers=[ISSUER])
+
+    assert "HTTPS" in str(refused.value)
+
+
+def test_T350_the_poll_feeds_opener_follows_nothing():
+    """The opener is `jwt_identity`'s, reused deliberately: two copies of this handler would be
+    two things to keep correct at the one input that decides who everybody is."""
+    from ctrlrun.jwt_identity import _NoRedirects
+
+    feed = PollingRevocationFeed("https://issuer.example/poll", issuers=[ISSUER])
+    handlers = feed._opener().handlers
+
+    assert any(isinstance(handler, _NoRedirects) for handler in handlers), (
+        "the poll opener would follow a redirect"
+    )
+    # Cleartext is refused by the constructor rather than by the opener, exactly as the JWKS
+    # url check is a separate defence from the redirect handler: `build_opener` always carries
+    # a default `HTTPHandler`, and asserting its absence would be asserting something untrue
+    # about the JWKS fetch too.
+    with pytest.raises(InvalidArgument):
+        PollingRevocationFeed("http://issuer.example/poll", issuers=[ISSUER])
+
+
+def test_T350_a_compact_set_is_read_as_well_as_a_json_one(keypair, clock, tmp_path):
+    """A transmitter writes compact serialization; the file feed reads both."""
+    private, public = keypair
+    claims = json.loads(_set("finance-agent"))
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    compact = f"eyJhbGciOiJub25lIn0.{payload}.signature"
+    feed = _feed(tmp_path, compact, clock=clock)
+    provider = _provider(public, clock, revocations=feed)
+
+    with pytest.raises(IdentityError):
+        provider.resolve(_context(_sign(private, clock)))
+
+
+# --- T351: the extra boundary ------------------------------------------------------------------
+
+
+def test_T351_importing_ctrlrun_imports_no_feed():
+    """The rule item 6 is the test of: a feed that reached core would put a network client in
+    the wheel every user installs."""
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import ctrlrun, sys; "
+            "print('revocation' in ''.join(sys.modules)); "
+            "print([m for m in sys.modules if m.split('.')[0] in "
+            "{'httpx', 'jwt', 'psycopg', 'opentelemetry'}])",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert result.stdout.splitlines() == ["False", "[]"], result.stdout
+
+
+def test_a_feed_covering_no_issuer_is_refused(tmp_path):
+    """A feed affecting nothing would read as a check. Fail closed on a misconfiguration."""
+    path = tmp_path / "r.jsonl"
+    path.write_text("", encoding="utf-8")
+
+    with pytest.raises(InvalidArgument):
+        FileRevocationFeed(path, issuers=[])
+
+
+def test_the_revoking_event_vocabulary_excludes_a_claims_change():
+    """`token-claims-change` says a claim moved, not that the credential died. Treating it as a
+    revocation would refuse a principal whose department changed."""
+    assert not any("token-claims-change" in event for event in REVOKING_EVENTS)
+    assert SESSION_REVOKED in REVOKING_EVENTS

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -176,7 +176,7 @@ def test_T101_a_policy_with_no_approve_rule_makes_G1_and_G2_not_applicable(tmp_p
     # section, G13, which is N/A on every SQLite run: SQLite has no clock of its own, and G15,
     # because this document names no `max_attempts` (SPEC-v0.7 §8.9). The rest are applicable,
     # G14 among them, and the count is over those.
-    assert report.applicable == 9
+    assert report.applicable == 10
     assert report.not_applicable == 10
     text = report.to_text()
     # The fraction is passes over applicable and never the catalogue size: with eight N/As a
@@ -852,24 +852,30 @@ def test_observe_mode_is_refused_before_any_scenario_runs(tmp_path):
     assert "observe" in str(refused.value)
 
 
-def test_the_v1_payments_template_reports_nine_over_nine():
+def test_the_v1_payments_template_reports_ten_over_ten():
     """The definition of done, dogfooded rather than described (SPEC-v0.4 §4.1).
 
-    Nine and not eight since v0.8 item 2: G18 is graded here, because this document sends an
-    action to approval and verify supplies the approver identity it grades against (§11.7).
+    Ten and not nine since v0.8 item 6, and nine and not eight since item 2. G18 is graded
+    here because this document sends an action to approval and verify supplies the approver
+    identity it grades against; G20 because verify supplies the revocation feed and says so in
+    a note rather than claiming anything about a document that is silent on it (§11.7).
     """
     report = run(V1_PAYMENTS)
 
     assert report.exit_code == 0
-    assert (report.passed, report.applicable, report.not_applicable) == (9, 9, 10)
+    assert (report.passed, report.applicable, report.not_applicable) == (10, 10, 10)
     text = report.to_text()
-    assert "9/9 declared guarantees pass." in text
+    assert "10/10 declared guarantees pass." in text
     # G13 is N/A on SQLite, which has no clock of its own; G14 and G15 join G3, G4 and G5 where
     # the effect template lives in the @protect decorator verify does not read, and where the
     # document names no `max_attempts`. G16 and G18 are graded: verify brings its own provider
     # for the first and its own approver identity for the second (§8.9, §11.7).
     assert "10 not applicable: G3, G4, G5, G8, G9, G13, G14, G15, G17, G19." in text
-    assert "10/10" not in text
+    # §2.1's rule, and the reason this line exists: **the not-applicable ten are not in the
+    # denominator.** Ten pass and ten are N/A, so a run that folded them in would report 20/20.
+    # It used to read `"10/10" not in text`, which said the same thing while the pass count was
+    # nine and says the opposite now that it is ten.
+    assert "20/20" not in text
 
 
 # --- an N/A reason must be a true statement about the configuration (§2.1) ----------------

--- a/tests/test_verify_action.py
+++ b/tests/test_verify_action.py
@@ -137,8 +137,8 @@ def test_T118_ci_asserts_the_two_shapes_the_specification_names():
     steps = _workflow()["jobs"]["verify"]["steps"]
     script = "\n".join(step.get("run", "") for step in steps)
 
-    assert 'test "$AUTHORITY" = "verified 15/15"' in script
-    assert 'test "$TEMPLATES" = "verified 9/9"' in script
+    assert 'test "$AUTHORITY" = "verified 16/16"' in script
+    assert 'test "$TEMPLATES" = "verified 10/10"' in script
     assert 'test "$AUTHORITY_NA" = "4"' in script
     assert 'test "$TEMPLATES_NA" = "10"' in script
 
@@ -152,12 +152,12 @@ def test_T118_the_two_configurations_really_do_report_those_shapes():
     templates = run(V1_PAYMENTS)
 
     assert authority.badge is not None
-    assert authority.badge["message"] == "verified 15/15"
+    assert authority.badge["message"] == "verified 16/16"
     # G13 and G15: SQLite has no clock of its own to diverge from, and the document declares
     # no `max_attempts` (SPEC-v0.7 §8.9).
     assert authority.not_applicable == 4
     assert templates.badge is not None
-    assert templates.badge["message"] == "verified 9/9"
+    assert templates.badge["message"] == "verified 10/10"
     assert templates.not_applicable == 10
 
 
@@ -200,7 +200,7 @@ def test_T119_the_denominator_is_applicable_and_never_the_catalogue_size():
 
     assert badge is not None
     assert badge["message"] == f"verified {report.passed}/{report.applicable}"
-    assert report.applicable == 9
+    assert report.applicable == 10
     assert report.applicable < len(reg.GUARANTEES)
     assert f"/{len(reg.GUARANTEES)}" not in badge["message"]
 
@@ -286,7 +286,7 @@ def test_T120_a_configuration_with_not_applicable_guarantees_still_writes_a_badg
 
     assert report.exit_code == 0
     assert report.badge is not None
-    assert report.badge["message"] == "verified 9/9"
+    assert report.badge["message"] == "verified 10/10"
 
 
 def test_T120_a_failing_run_writes_a_red_badge_and_a_non_zero_exit(tmp_path, monkeypatch):

--- a/tests/test_verify_authority.py
+++ b/tests/test_verify_authority.py
@@ -96,8 +96,8 @@ def test_T108_the_authority_example_exercises_G7_G8_and_G9():
     # from (SPEC-v0.7 §8.9). A Postgres --store-url grades that one too.
     # Fifteen since v0.8 item 2: G18 is graded wherever a document sends an action to
     # approval, and verify supplies the approver identity it grades against (§11.7).
-    assert report.passed == 15
-    assert report.applicable == 15
+    assert report.passed == 16
+    assert report.applicable == 16
 
 
 def test_T108_G8_asserts_the_denial_by_reason_and_not_by_type(tmp_path, monkeypatch):

--- a/tests/test_verify_report.py
+++ b/tests/test_verify_report.py
@@ -137,9 +137,9 @@ def test_T113_a_failing_report_names_the_subject_and_prints_the_counterexample(
         # SPEC-v0.8 item 2: G18 joins the catalogue. It is graded wherever the document sends
         # an action to approval, which the first two of these do, and `N/A` for G1's reason
         # where nothing does. So the first two gain a pass and the third gains an N/A.
-        (ALL_APPLICABLE, "13/13 declared guarantees pass. 6 not applicable"),
-        (WITH_NOT_APPLICABLE, "9/9 declared guarantees pass. 10 not applicable"),
-        (EMPTY, "0/0 declared guarantees pass. 19 not applicable"),
+        (ALL_APPLICABLE, "14/14 declared guarantees pass. 6 not applicable"),
+        (WITH_NOT_APPLICABLE, "10/10 declared guarantees pass. 10 not applicable"),
+        (EMPTY, "0/0 declared guarantees pass. 20 not applicable"),
     ],
     ids=["passing", "some-na", "all-na"],
 )


### PR DESCRIPTION
Item 6 of v0.8 (`docs/SPEC-v0.8.md` §6). `jwt_identity.py` said, in as many words, that *a verified token is valid until its `exp`* and that *nothing polls*. Both sentences are gone. "Nothing subscribes or introspects" stays, and so does "which is why one without an `exp` is refused".

## What ships

`ctrlrun.revocation`, behind `ctrlrun[identity]`, beside the provider it serves:

| | |
|---|---|
| `FileRevocationFeed` | Security Event Tokens from a file the operator's own transmitter writes, one per line, re-read when the mtime moves |
| `PollingRevocationFeed` | RFC 8936 poll delivery over the same hardened opener the JWKS fetch uses: no redirects, cleartext refused at construction, a bounded body |
| `JWTIdentityProvider(revocations=...)` | absent means 0.7.0 exactly |

**Push (RFC 8935) is not built.** It needs an HTTP endpoint this project serves and a session to serve it on, which is delivery work and is on the do-not-build list beside notification delivery.

## The one that decides whether the feature works at all

**The match is against the token's own `iss`, `sub` and `jti`, never against `Principal.agent`.** `agent` is whatever `agent_claim` names, which a deployment may set to `client_id`, so matching an `iss_sub` identifier against it compares two different things and admits exactly the deployment the feature was bought for. T342 drives that case with `agent_claim="client_id"` and asserts the two names differ first, or it would prove nothing.

The check runs inside `_verified`, where the raw claims are still in hand. Nothing new is stored on `Principal`.

## Consumed and deciding nothing

An unknown event type, an unknown subject format, an issuer no provider uses, a malformed token, a subject the feed cannot map — each consumed, logged, and asserted by a **control principal that stays admitted**, because "no exception was raised" is not "nothing changed". `token-claims-change` is deliberately not a revoking event: it says a claim moved, not that the credential died, and treating it as one would refuse a principal whose department changed.

**There is no un-revoke, in any costume.** Entries are added and never removed, so replay is idempotent by construction and an out-of-order event cannot restore a credential. The test asserts the absence of the API as well as the behaviour.

## Staleness is the operator's call

Unset means no bound, which is 0.7.0's availability. Set, and every principal of a **covered** issuer is refused past it with `revocation_feed_stale`, while an uncovered issuer's principals are unaffected — a feed covering one issuer must not decide for another. A feed that cannot be read or polled is a stale feed from that moment and never an exception out of somebody's action.

Configuring a bound makes the feed's availability part of the deployment's availability. That trade is stated rather than discovered, and a kernel choosing it would be choosing an operator's outage budget for them.

## Two things this closes less than it sounds

Both are in the changelog, the docstring and `THREAT_MODEL.md`, in the sentence that describes the feature:

- **A revoked credential leaves a log line and no receipt.** Resolution happens before an `Action` exists, so there is no `action_id` to attribute a refusal to. An *expired* credential is different — checked on `action.principal` inside `execute`, where one does — and leaves an `ACTION_DENIED` event and a `DENIED` receipt. The asymmetry is deliberate, and §6.4 argues it rather than papering over it.
- **A feed is worth what its source is worth.** Whoever can write the file can refuse the operator's own agents: a denial of service against them, fail-closed, and in the threat model under this feature's name. They cannot **admit** a principal the issuer revoked, because the feed is only ever consulted to refuse. That asymmetry is the security property.

## Verify

G20 is graded against a feed verify supplies, with a **note** and not an `N/A` — whether a deployment configures one is a fact about its own code, and §11.7 forbids an `N/A` reason that is not about the operator's document.

```
16/16 declared guarantees pass. 4 not applicable: G13, G15, G17, G19.        examples/authority/payments.yaml
10/10 declared guarantees pass. 10 not applicable: G3, G4, G5, G8, G9, G13, G14, G15, G17, G19.
```

Nine count assertions moved for the third time this milestone. One of them, `assert "10/10" not in text`, was checking that the ten N/As stay out of the denominator — and a blanket bump turned it into a self-contradiction, so it now reads `assert "20/20" not in text` with a comment saying what it is for.

## No standards claim

RFC 8935, RFC 8936, RFC 9493 and CAEP are consumed as code. The words compatible, conformant, aligned and certified appear nowhere in the code, the docstrings, the CLI, the changelog or the README.

`import ctrlrun` imports no part of this, asserted in a subprocess (T351).

3853 tests, 3m24s with Postgres, plus 56 serial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional credential revocation checks using local files or HTTPS feeds.
  - Revoked credentials are refused based on issuer, subject, or token ID.
  - Stale, unreadable, or unreachable feeds fail closed when configured with a freshness limit.
  - Added verification support for the new credential-revocation guarantee.

- **Documentation**
  - Added unreleased changelog documentation covering revocation configuration, logging, receipts, and verification.

- **Tests**
  - Expanded coverage for revocation feeds and updated verification totals and report expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->